### PR TITLE
Scaffolding 1: Repository foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# .NET
+bin/
+obj/
+*.user
+*.suo
+*.userprefs
+*.ncrunchproject
+*.ncrunchsolution
+packages/
+*.DotSettings.user
+
+# Node / npm
+node_modules/
+npm-debug.log*
+yarn-error.log*
+.npm
+
+# Angular
+.angular/
+dist/
+
+# IDE / Editor files
+.vs/
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+Desktop.ini
+ehthumbs.db
+
+# Docker / Environment
+.env
+.env.local
+.env.*.local
+docker-compose.override.yml
+
+# Build / Misc
+*.log
+coverage/
+TestResults/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gareth Baumgart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds comprehensive `.gitignore` covering .NET, Node/Angular, IDE, OS, and Docker/environment files
- Adds MIT `LICENSE`
- Design documents from `initial-ideation` already on `main` via initial commit

Closes #1

## Test plan

- [ ] Verify `.gitignore` covers all listed technologies (.NET, Node, Angular, IDE, OS, Docker)
- [ ] Verify `LICENSE` is MIT with correct copyright
- [ ] Verify all design documents are present: `product-brief.md`, `domain-model.md`, `domain-relationships.md`, `spec-plan.md`, `openspec-config-example.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Initialize repository scaffolding with core project metadata files.

Chores:
- Add a comprehensive .gitignore covering .NET, Node/Angular, common IDEs, OS artifacts, and Docker/environment files.
- Add MIT license file defining the project’s open-source licensing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License to establish project licensing and usage terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->