### PR TITLE
Add sensitive info checks to /pr skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -9,6 +9,8 @@ Automates the full PR lifecycle: branch verification, PR creation, pre-flight te
 
 > **Note:** This skill is scoped to the Mental Metal repository (.NET backend, Angular frontend when present). Frontend steps are conditional — they are skipped automatically when the Angular project does not yet exist.
 
+> **Sensitive data categories (public repo):** GCP org/project IDs, billing account IDs, API keys (including Neon), connection strings, internal domain names, email addresses, IP addresses, or any other PII/credentials. When any step below references "sensitive information", it means this list. Use placeholders (e.g. `<your-gcp-org-id>`) or environment variables instead of real values.
+
 ---
 
 ## Step 1: Verify Branch and Uncommitted Changes
@@ -71,7 +73,7 @@ EOF
 
    - If no OpenSpec spec is found (or `openspec/specs/` does not exist), omit the **Spec** line entirely.
    - Review `git log main..HEAD` and `git diff main...HEAD` to write an accurate summary and change list.
-   - **CRITICAL: This is a public repository.** Never include sensitive information in the PR title, body, or comments. This includes GCP org/project IDs, billing account IDs, API keys, connection strings, internal domain names, email addresses, or any PII. Use generic descriptions instead.
+   - **CRITICAL: This is a public repository.** Never include sensitive information (see categories above) in the PR title, body, or comments. Use generic descriptions instead.
 
 ---
 
@@ -109,7 +111,7 @@ Check for:
 - **Code duplication** — extract shared logic if the same pattern appears 3+ times
 - **Missing error handling** — at system boundaries (user input, external APIs)
 - **Security issues** — unsanitised input, exposed secrets, SQL injection, XSS
-- **Sensitive information exposure** — this is a public repo. Scan the entire diff for GCP org/project IDs, billing account IDs, Neon API keys, connection strings, internal domain names, email addresses, IP addresses, or any other PII/credentials. Check code, comments, config files, PR body text, and commit messages. **STOP and remove any sensitive values before proceeding.** Use placeholders (e.g. `<your-gcp-org-id>`) or environment variables instead.
+- **Sensitive information exposure** — this is a public repo. Scan the entire diff for any sensitive data categories listed above. Also review commit messages (`git log main..HEAD`) and the PR body (`gh pr view $PR_NUMBER --json body -q '.body'`) since these are not included in the diff. **STOP and remove any sensitive values before proceeding.**
 - **Codebase convention violations** — if `CLAUDE.md` exists, check it for banned patterns and required conventions; otherwise follow the repository conventions documented in this checklist
 - **EF Core pitfalls** — `HashSet.Contains()` and `.ToLowerInvariant()` are not SQL-translatable; use `List<T>.Contains()` and `.ToLower()`
 - **Angular pitfalls** — race conditions in async calls, timezone-safe date handling, plain properties instead of signals

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -71,6 +71,7 @@ EOF
 
    - If no OpenSpec spec is found (or `openspec/specs/` does not exist), omit the **Spec** line entirely.
    - Review `git log main..HEAD` and `git diff main...HEAD` to write an accurate summary and change list.
+   - **CRITICAL: This is a public repository.** Never include sensitive information in the PR title, body, or comments. This includes GCP org/project IDs, billing account IDs, API keys, connection strings, internal domain names, email addresses, or any PII. Use generic descriptions instead.
 
 ---
 
@@ -108,6 +109,7 @@ Check for:
 - **Code duplication** — extract shared logic if the same pattern appears 3+ times
 - **Missing error handling** — at system boundaries (user input, external APIs)
 - **Security issues** — unsanitised input, exposed secrets, SQL injection, XSS
+- **Sensitive information exposure** — this is a public repo. Scan the entire diff for GCP org/project IDs, billing account IDs, Neon API keys, connection strings, internal domain names, email addresses, IP addresses, or any other PII/credentials. Check code, comments, config files, PR body text, and commit messages. **STOP and remove any sensitive values before proceeding.** Use placeholders (e.g. `<your-gcp-org-id>`) or environment variables instead.
 - **Codebase convention violations** — if `CLAUDE.md` exists, check it for banned patterns and required conventions; otherwise follow the repository conventions documented in this checklist
 - **EF Core pitfalls** — `HashSet.Contains()` and `.ToLowerInvariant()` are not SQL-translatable; use `List<T>.Contains()` and `.ToLower()`
 - **Angular pitfalls** — race conditions in async calls, timezone-safe date handling, plain properties instead of signals

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -96,6 +96,24 @@ Run available test suites and **abort if any fail**:
 
 After fixing, commit and push the fixes.
 
+### 3a. Verify Linked Issue Test Plans
+
+Check if the PR is linked to an issue that contains a test plan:
+
+```bash
+gh pr view $PR_NUMBER --json body,closingIssuesReferences --jq '.closingIssuesReferences[].number'
+```
+
+For each linked issue, read its body and look for test plan checkboxes. Execute every test plan item and check it off on the issue:
+
+```bash
+# Read the issue body:
+gh issue view <issue-number> --json body -q '.body'
+# After verifying each item, update the issue body with the checkbox checked off.
+```
+
+If no linked issues exist or they have no test plan, skip this step.
+
 ---
 
 ## Step 4: Self Code Review
@@ -162,10 +180,17 @@ gh api repos/{owner}/{repo}/issues/$PR_NUMBER/comments --jq '.[] | "[\(.user.log
 
 For each review comment:
 
-1. Read the full comment to understand the feedback
-2. Evaluate whether the feedback is valid and actionable
-3. If valid: make the code change
-4. If by-design or out-of-scope: reply with a clear explanation of why
+1. **Acknowledge the comment** — add an 👀 (eyes) emoji reaction so the author has visual confirmation it has been seen:
+   ```bash
+   # For inline review comments:
+   gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions -f content=eyes
+   # For issue-level comments:
+   gh api repos/{owner}/{repo}/issues/comments/{comment_id}/reactions -f content=eyes
+   ```
+2. Read the full comment to understand the feedback
+3. Evaluate whether the feedback is valid and actionable
+4. If valid: make the code change
+5. If by-design or out-of-scope: reply with a clear explanation of why
 
 **Batch fixes:** Collect all comments from a review round, fix them all, then commit and push once. Each push triggers new review cycles from bots.
 


### PR DESCRIPTION
## Summary

Adds two safeguards to the `/pr` skill to prevent sensitive information from leaking into this public repository:

1. **PR creation (Step 2)** -- explicit reminder that PR titles/bodies must never contain org IDs, API keys, connection strings, or PII
2. **Self-review (Step 4)** -- adds a sensitive information scan to the review checklist, requiring the full diff to be checked for credentials, internal domains, and other sensitive values before proceeding

## Changes

- Added sensitive info warning to Step 2 (PR body creation guidance)
- Added sensitive info scan to Step 4 (self code review checklist)

## Test Plan

- [ ] Verify `/pr` skill file is valid markdown
- [ ] Confirm no sensitive values in this diff

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen the `/pr` skill guidance to prevent sensitive information from being included in pull requests to this public repository.

Enhancements:
- Add an explicit warning in the PR creation step to avoid including sensitive information such as IDs, API keys, internal domains, and PII in PR titles, bodies, or comments.
- Expand the self-review checklist to require a thorough scan of the diff and related text for credentials, internal domains, and other sensitive values before proceeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security documentation with explicit guidelines to prevent sensitive information exposure in pull requests. Includes instructions to avoid sharing API keys, credentials, internal identifiers, and personal information, plus a new mandatory security checklist that scans code, comments, configuration files, and commit messages for sensitive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->