### PR TITLE
Fix staging deploy: SA roles and Neon org_id

### DIFF
--- a/.github/workflows/infra-staging.yml
+++ b/.github/workflows/infra-staging.yml
@@ -24,6 +24,7 @@ concurrency:
 env:
   TF_WORKING_DIR: infra/environments/staging
   TF_VAR_project_id: mental-metal
+  TF_VAR_neon_org_id: ${{ secrets.NEON_ORG_ID }}
   TF_VAR_image: australia-southeast1-docker.pkg.dev/mental-metal/mental-metal/app:latest
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -43,6 +43,7 @@ module "artifact_registry" {
 module "neondb" {
   source = "../../modules/neondb"
 
+  neon_org_id     = var.neon_org_id
   neon_project_id = var.neon_project_id
   neon_branch_id  = var.neon_branch_id
   database_name   = "mentalmetalstaging"

--- a/infra/environments/staging/variables.tf
+++ b/infra/environments/staging/variables.tf
@@ -9,6 +9,12 @@ variable "region" {
   default     = "australia-southeast1"
 }
 
+variable "neon_org_id" {
+  description = "Neon organization ID"
+  type        = string
+  sensitive   = true
+}
+
 variable "neon_project_id" {
   description = "Existing Neon project ID (optional, creates new if null)"
   type        = string

--- a/infra/modules/neondb/main.tf
+++ b/infra/modules/neondb/main.tf
@@ -15,6 +15,7 @@ resource "neon_project" "this" {
 
   name      = "mental-metal"
   region_id = "aws-ap-southeast-2"
+  org_id    = var.neon_org_id
 }
 
 locals {

--- a/infra/modules/neondb/variables.tf
+++ b/infra/modules/neondb/variables.tf
@@ -1,3 +1,9 @@
+variable "neon_org_id" {
+  description = "Neon organization ID"
+  type        = string
+  sensitive   = true
+}
+
 variable "neon_project_id" {
   description = "Existing Neon project ID. If null, a new project is created."
   type        = string


### PR DESCRIPTION
## Summary

Fixes the staging `terraform apply` failure caused by two issues:

1. **Insufficient IAM roles** -- the GitHub Actions service account still had `writer`/`accessor` roles from the initial bootstrap. Re-applied bootstrap to upgrade to `admin` roles (already in code, just not applied).
2. **Neon org_id required** -- the Neon API now requires an `org_id` when creating projects. Added as a variable passed via `NEON_ORG_ID` GitHub secret.

## Changes

- `infra/modules/neondb/` -- add `neon_org_id` variable and pass to `neon_project`
- `infra/environments/staging/` -- wire `neon_org_id` variable through
- `.github/workflows/infra-staging.yml` -- add `TF_VAR_neon_org_id` from secrets

## Test Plan

- [ ] `terraform plan` passes in CI
- [ ] After merge, `terraform apply` successfully provisions staging resources
- [ ] No sensitive values in committed files

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire Neon organization ID through Terraform and CI for the staging environment so Neon project creation succeeds.

New Features:
- Add a sensitive neon_org_id variable to the staging environment configuration for Neon.
- Expose a neon_org_id input variable on the neondb Terraform module used by staging.

Enhancements:
- Pass neon_org_id from the staging environment into the neondb module and on to the Neon project resource.
- Configure the staging infrastructure GitHub Actions workflow to provide TF_VAR_neon_org_id from the NEON_ORG_ID secret.