### PR TITLE
Fix staging deploy: placeholder image and Neon endpoint

### DIFF
--- a/.github/workflows/infra-staging.yml
+++ b/.github/workflows/infra-staging.yml
@@ -25,7 +25,7 @@ env:
   TF_WORKING_DIR: infra/environments/staging
   TF_VAR_project_id: mental-metal
   TF_VAR_neon_org_id: ${{ secrets.NEON_ORG_ID }}
-  TF_VAR_image: australia-southeast1-docker.pkg.dev/mental-metal/mental-metal/app:latest
+  TF_VAR_image: us-docker.pkg.dev/cloudrun/container/hello:latest
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
 jobs:

--- a/infra/environments/staging/terraform.tfvars.example
+++ b/infra/environments/staging/terraform.tfvars.example
@@ -1,5 +1,6 @@
 project_id = "mental-metal"
-image      = "australia-southeast1-docker.pkg.dev/mental-metal/mental-metal/app:latest"
+# Use Google's hello container for initial deploy; replaced by app image once CI/CD builds it
+image      = "us-docker.pkg.dev/cloudrun/container/hello:latest"
 
 # Optional: provide an existing Neon project to reuse
 # neon_project_id = "your-neon-project-id"

--- a/infra/modules/neondb/main.tf
+++ b/infra/modules/neondb/main.tf
@@ -44,8 +44,7 @@ resource "neon_database" "this" {
   owner_name = neon_role.this.name
 }
 
-resource "neon_endpoint" "this" {
-  project_id = local.project_id
-  branch_id  = local.branch_id
-  type       = "read_write"
+locals {
+  # Use the default endpoint host from the project
+  endpoint_host = var.neon_project_id != null ? var.neon_endpoint_host : neon_project.this[0].database_host
 }

--- a/infra/modules/neondb/outputs.tf
+++ b/infra/modules/neondb/outputs.tf
@@ -1,6 +1,6 @@
 output "connection_uri" {
   description = "PostgreSQL connection string"
-  value       = "postgres://${neon_role.this.name}:${neon_role.this.password}@${neon_endpoint.this.host}/${neon_database.this.name}?sslmode=require"
+  value       = "postgres://${neon_role.this.name}:${neon_role.this.password}@${local.endpoint_host}/${neon_database.this.name}?sslmode=require"
   sensitive   = true
 }
 

--- a/infra/modules/neondb/variables.tf
+++ b/infra/modules/neondb/variables.tf
@@ -17,6 +17,12 @@ variable "neon_branch_id" {
 
 }
 
+variable "neon_endpoint_host" {
+  description = "Existing Neon endpoint host. Required when reusing an existing project."
+  type        = string
+  default     = null
+}
+
 variable "database_name" {
   description = "Name of the database to create"
   type        = string


### PR DESCRIPTION
## Summary

Fixes two remaining staging `terraform apply` failures:

1. **Cloud Run image not found** -- the app image doesn't exist yet (no CI/CD build pipeline). Uses Google's `hello` container as a placeholder until the app deployment workflow is built.
2. **Neon endpoint conflict** -- Neon auto-creates a default `read_write` endpoint with the project. Removed the explicit `neon_endpoint` resource and use `neon_project.database_host` instead.

## Changes

- `.github/workflows/infra-staging.yml` -- use placeholder image
- `infra/modules/neondb/main.tf` -- remove `neon_endpoint` resource, use `database_host` from project
- `infra/modules/neondb/variables.tf` -- add `neon_endpoint_host` for reuse scenarios
- `infra/modules/neondb/outputs.tf` -- use `local.endpoint_host` in connection URI
- `infra/environments/staging/terraform.tfvars.example` -- document placeholder image

## Test Plan

- [ ] `terraform plan` passes in CI
- [ ] After merge, `terraform apply` successfully provisions all staging resources
- [ ] No sensitive values in committed files

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update staging infrastructure to use a placeholder Cloud Run image and rely on Neon’s default database endpoint to resolve Terraform apply failures.

Bug Fixes:
- Use Neon project’s default database host instead of managing a separate endpoint resource to avoid endpoint conflicts.
- Point staging Terraform workflow to a public placeholder container image so Cloud Run deployment succeeds before the real app image is available.

Enhancements:
- Introduce a configurable Neon endpoint host variable and wire it into the connection URI for reusing existing Neon projects.

CI:
- Adjust the staging infrastructure workflow environment to reference the placeholder container image.

Deployment:
- Simplify Neon endpoint management by replacing the explicit endpoint resource with a computed endpoint host local used in connection strings.

Documentation:
- Document the use of a placeholder image in the staging Terraform variables example.