### PR TITLE
Fix Cloud Run deletion_protection blocking deploy

### DIFF
--- a/infra/modules/cloud-run/main.tf
+++ b/infra/modules/cloud-run/main.tf
@@ -10,9 +10,10 @@ terraform {
 }
 
 resource "google_cloud_run_v2_service" "this" {
-  project  = var.project_id
-  name     = var.service_name
-  location = var.region
+  project             = var.project_id
+  name                = var.service_name
+  location            = var.region
+  deletion_protection = false
 
   template {
     service_account = var.runtime_service_account


### PR DESCRIPTION
## Summary

The previous partial deploy created a Cloud Run service that Terraform now needs to replace (image change). Cloud Run v2 defaults `deletion_protection = true`, blocking the replacement. Set to `false` to allow Terraform to manage the service lifecycle.

## Test Plan

- [ ] `terraform plan` passes
- [ ] After merge, `terraform apply` succeeds

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Configure the Cloud Run v2 service resource with deletion_protection set to false so Terraform can manage lifecycle replacements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloud infrastructure configuration for improved service management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->