### PR TITLE
Add workflow_dispatch to staging infra workflow

### DIFF
--- a/.github/workflows/infra-staging.yml
+++ b/.github/workflows/infra-staging.yml
@@ -1,6 +1,7 @@
 name: Infrastructure — Staging
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger so the staging infrastructure workflow can be manually re-triggered when needed (e.g. after fixing external state issues).

## Test Plan

- [ ] Workflow can be triggered manually from Actions tab after merge

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add a workflow_dispatch trigger to the staging infrastructure workflow so it can be run manually from the Actions tab.