### PR TITLE
Allow terraform apply on manual workflow trigger

### DIFF
--- a/.github/workflows/infra-staging.yml
+++ b/.github/workflows/infra-staging.yml
@@ -91,7 +91,7 @@ jobs:
         run: exit 1
 
   terraform-apply:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

The `terraform-apply` job only ran on `push` events, so `workflow_dispatch` triggers skipped it. Add `workflow_dispatch` to the condition.

## Test Plan

- [ ] After merge, manually trigger workflow and confirm apply runs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the infra-staging GitHub Actions workflow condition so terraform-apply runs for both push and manual workflow_dispatch triggers.