### PR TITLE
Add Production JWT config and health endpoint for Cloud Run startup

### DIFF
--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -58,7 +58,7 @@ module "secrets" {
 
   project_id               = var.project_id
   region                   = var.region
-  secret_names             = ["STAGING_DATABASE_URL"]
+  secret_names             = ["STAGING_DATABASE_URL", "STAGING_JWT_SECRET"]
   accessor_service_account = google_service_account.cloud_run.email
 }
 
@@ -71,7 +71,10 @@ module "cloud_run" {
   region                  = var.region
   service_name            = "mental-metal-staging"
   image                   = var.image
-  secret_ids              = { "DATABASE_URL" = "STAGING_DATABASE_URL" }
+  secret_ids              = {
+    "DATABASE_URL" = "STAGING_DATABASE_URL"
+    "Jwt__Secret"  = "STAGING_JWT_SECRET"
+  }
   runtime_service_account = google_service_account.cloud_run.email
   allow_public_access     = true
 }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -168,6 +168,8 @@ app.MapPut("/api/users/me/preferences", async (
     return Results.NoContent();
 }).RequireAuthorization();
 
+app.MapGet("/api/health", () => Results.Ok(new { status = "healthy" }));
+
 // Return 404 for unmatched /api requests instead of serving the SPA shell.
 app.MapFallback("/api/{**catch-all}", () => Results.NotFound());
 

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Secret": "OVERRIDE-VIA-ENV-VAR-Jwt__Secret-minimum-32-chars",
+    "Issuer": "MentalMetal",
+    "Audience": "MentalMetal",
+    "AccessTokenExpiryMinutes": 15,
+    "RefreshTokenExpiryDays": 7
+  }
 }


### PR DESCRIPTION
## Summary

The app crashes on Cloud Run because `appsettings.json` (Production) lacks a `Jwt` section — `Program.cs` throws on startup. Add placeholder JWT config that gets overridden by the `STAGING_JWT_SECRET` secret via `Jwt__Secret` env var.

## Changes

- Add `Jwt` section to `appsettings.json` with placeholder values
- Add `STAGING_JWT_SECRET` to Secret Manager and Cloud Run env mapping
- Add `/api/health` endpoint for deployment verification

## Post-merge setup

Populate the JWT secret:
```bash
openssl rand -base64 48 | gcloud secrets versions add STAGING_JWT_SECRET --data-file=- --project=mental-metal
```
Then trigger infra workflow to create the secret, then deploy.

## Test Plan

- [x] All tests pass
- [ ] App starts on Cloud Run without crashing

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure JWT settings for production and expose a basic health endpoint to support Cloud Run startup and deployment verification.

New Features:
- Add a /api/health endpoint to report service health status.

Enhancements:
- Provide default JWT configuration in appsettings.json for production environments.

Deployment:
- Wire a new STAGING_JWT_SECRET secret into the staging infrastructure and map it to the Jwt__Secret environment variable for Cloud Run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public health status endpoint for service monitoring and operational readiness verification
  * Enabled JWT-based authentication framework with configurable security parameters including token issuer, audience, and access/refresh token expiration durations for API endpoint protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->