### PR TITLE
Make Google OAuth conditional on config being present

### DIFF
--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -58,7 +58,7 @@ module "secrets" {
 
   project_id               = var.project_id
   region                   = var.region
-  secret_names             = ["STAGING_DATABASE_URL"]
+  secret_names             = ["STAGING_DATABASE_URL", "STAGING_JWT_SECRET"]
   accessor_service_account = google_service_account.cloud_run.email
 }
 
@@ -71,7 +71,10 @@ module "cloud_run" {
   region                  = var.region
   service_name            = "mental-metal-staging"
   image                   = var.image
-  secret_ids              = { "DATABASE_URL" = "STAGING_DATABASE_URL" }
+  secret_ids              = {
+    "DATABASE_URL" = "STAGING_DATABASE_URL"
+    "Jwt__Secret"  = "STAGING_JWT_SECRET"
+  }
   runtime_service_account = google_service_account.cloud_run.email
   allow_public_access     = true
 }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -168,6 +168,8 @@ app.MapPut("/api/users/me/preferences", async (
     return Results.NoContent();
 }).RequireAuthorization();
 
+app.MapGet("/api/health", () => Results.Ok(new { status = "healthy" }));
+
 // Return 404 for unmatched /api requests instead of serving the SPA shell.
 app.MapFallback("/api/{**catch-all}", () => Results.NotFound());
 

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -35,13 +35,19 @@ builder.Services.AddAuthentication(options =>
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Secret))
         };
     })
-    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme)
-    .AddGoogle(GoogleDefaults.AuthenticationScheme, options =>
-    {
-        options.ClientId = builder.Configuration["Authentication:Google:ClientId"] ?? "";
-        options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"] ?? "";
-        options.CallbackPath = "/api/auth/google-callback";
-    });
+    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
+
+var googleClientId = builder.Configuration["Authentication:Google:ClientId"];
+if (!string.IsNullOrEmpty(googleClientId))
+{
+    builder.Services.AddAuthentication()
+        .AddGoogle(GoogleDefaults.AuthenticationScheme, options =>
+        {
+            options.ClientId = googleClientId;
+            options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"] ?? "";
+            options.CallbackPath = "/api/auth/google-callback";
+        });
+}
 
 builder.Services.AddAuthorization();
 

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Secret": "OVERRIDE-VIA-ENV-VAR-Jwt__Secret-minimum-32-chars",
+    "Issuer": "MentalMetal",
+    "Audience": "MentalMetal",
+    "AccessTokenExpiryMinutes": 15,
+    "RefreshTokenExpiryDays": 7
+  }
 }


### PR DESCRIPTION
## Summary

ASP.NET's OAuth validation rejects empty `ClientId`, crashing the app on every request in staging where Google credentials aren't configured. Make Google auth registration conditional.

## Test Plan

- [x] All tests pass
- [ ] App starts and /api/health returns 200

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make Google OAuth registration conditional on configuration and wire JWT configuration and secrets for staging.

New Features:
- Add a /api/health endpoint returning a simple healthy status payload.
- Provide default JWT configuration values in appsettings.json for local and non-secret-based environments.

Bug Fixes:
- Avoid startup failures by registering Google OAuth only when a non-empty client ID is configured.

Deployment:
- Expose a STAGING_JWT_SECRET in staging via Secret Manager and map it to the Jwt__Secret environment variable in Cloud Run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/api/health` endpoint that returns service status information, enabling health monitoring.

* **Improvements**  
  * Made Google authentication registration conditional based on configuration, improving deployment flexibility.
  * Extended JWT authentication configuration with support for custom secrets, issuers, audiences, and token expiry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->