### PR TITLE
feat: AI provider abstraction — domain and application layers

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -105,6 +105,8 @@ jobs:
         run: |
           dotnet tool restore
           dotnet ef database update --project src/MentalMetal.Infrastructure --startup-project src/MentalMetal.Web
+        env:
+          ASPNETCORE_ENVIRONMENT: Production
 
       # --- Deploy to Cloud Run ---
 

--- a/openspec/changes/byo-provider-config/.openspec.yaml
+++ b/openspec/changes/byo-provider-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-05

--- a/openspec/changes/byo-provider-config/design.md
+++ b/openspec/changes/byo-provider-config/design.md
@@ -1,0 +1,202 @@
+## Context
+
+Mental Metal's Tier 2 features (capture extraction, living briefs, AI chat) all depend on calling an LLM. Users bring their own API keys. The User aggregate currently has no AI configuration. We need a provider abstraction that:
+
+1. Stores user's provider config (provider, API key, model) on the User aggregate
+2. Encrypts API keys at rest in the database
+3. Provides a uniform interface (`IAiCompletionService`) that downstream features consume
+4. Supports Anthropic (Claude), OpenAI (GPT), and Google (Gemini)
+5. Gives new users immediate AI access via an app-managed "taste" key before they set up their own
+6. Gracefully handles model deprecation via fallback chains
+
+The `user-auth-tenancy` spec is already implemented — User aggregate, auth, preferences, and multi-tenant scoping are in place.
+
+### Why Not OAuth?
+
+No AI provider offers a sanctioned OAuth flow for third-party API delegation:
+- **Anthropic:** Built OAuth only for first-party tools (Claude Code). Third-party use was explicitly banned (Feb 2026) and blocked via client fingerprinting (Apr 2026).
+- **OpenAI:** OAuth exists only for ChatGPT plugin/action ecosystem (reversed flow — OpenAI calls your API, not the other way).
+- **Google:** Generative Language API OAuth scopes exist only for tuning and retrieval, not general text generation.
+
+API key paste is the industry standard for BYO-key apps (Cursor, Windsurf, Cody all use this pattern).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can configure their AI provider (Anthropic, OpenAI, Google) with an API key and model selection
+- API keys are encrypted at rest using AES-256-GCM with a server-managed encryption key
+- A single `IAiCompletionService` interface that all AI features consume — no provider-specific code leaks into Application/Domain layers
+- Model fallback chain — if a model is deprecated/unavailable, automatically try alternatives before failing
+- Config-driven model catalog with per-provider defaults — updatable without code changes
+- App-managed taste key gives new users 5 free AI operations/day to demonstrate value before key setup
+- Nudge framework guides users through Fresh → Tasting → Limited → Unlimited states
+- Key validation endpoint so users can test their configuration
+- Frontend settings UI with deep links to provider console pages for key creation
+
+**Non-Goals:**
+- Streaming responses — batch completion only for now (streaming added with AI chat specs)
+- Prompt engineering or prompt templates — downstream specs define their own prompts
+- Token usage tracking or cost estimation
+- Multiple provider configurations per user (one active config at a time)
+- Provider-specific advanced features (function calling, vision, etc.) — unified text-in/text-out for now
+- Rate limiting or retry logic beyond basic HTTP resilience and model fallback
+- OAuth-based provider access or third-party intermediaries (OpenRouter, LiteLLM)
+
+## Decisions
+
+### 1. AiProviderConfig as a Value Object embedded in User
+
+The domain model specifies `AiProviderConfig` as an owned value object on User, not a separate entity. This is correct because:
+- Config has no independent lifecycle — it exists only in the context of a User
+- One config per user (not a collection)
+- Changes are atomic with the User aggregate
+
+EF Core maps this via `OwnsOne` with columns on the Users table (`AiProvider_Provider`, `AiProvider_EncryptedApiKey`, `AiProvider_Model`, `AiProvider_MaxTokens`).
+
+**Alternative considered:** Separate `AiProviderConfigs` table — rejected because it adds a join for every AI operation and breaks aggregate encapsulation.
+
+### 2. API Key Encryption via IApiKeyEncryptionService
+
+API keys are encrypted before storage and decrypted only when making API calls. The encryption key is a server-side configuration value (`AiProvider:EncryptionKey` in appsettings / environment variable).
+
+- **Algorithm:** AES-256-GCM (authenticated encryption)
+- **Storage format:** Base64-encoded `nonce:ciphertext:tag`
+- **Domain stores:** The encrypted string (domain doesn't know about encryption)
+- **Infrastructure handles:** Encrypt on write, decrypt on read when building HTTP clients
+
+The `IApiKeyEncryptionService` interface lives in Application; implementation in Infrastructure.
+
+**Alternative considered:** Using ASP.NET Data Protection API — rejected because it ties key rotation to the machine/cluster and makes database portability harder. AES-256-GCM with a configurable key is simpler and more portable.
+
+### 3. IAiCompletionService as the Provider Abstraction
+
+A single interface in Application layer:
+
+```csharp
+public interface IAiCompletionService
+{
+    Task<AiCompletionResult> CompleteAsync(
+        AiCompletionRequest request,
+        CancellationToken cancellationToken);
+}
+```
+
+Where `AiCompletionRequest` contains: system prompt, user prompt, max tokens (optional override), temperature (optional). `AiCompletionResult` contains: content, token usage (input/output), model used, provider used.
+
+The implementation (`AiCompletionService` in Infrastructure) resolves the current user's config (or falls back to the taste key), decrypts the API key, and delegates to the appropriate provider adapter.
+
+**Alternative considered:** One `IAiCompletionService` per provider injected via DI — rejected because it pushes provider selection into every consumer. A single interface with internal dispatch keeps consumers clean.
+
+### 4. Provider Adapters in Infrastructure
+
+Three adapter classes, each implementing a private `IAiProviderAdapter` interface internal to Infrastructure:
+
+- `AnthropicAdapter` — uses Anthropic .NET SDK (`Anthropic` NuGet package)
+- `OpenAiAdapter` — uses OpenAI .NET SDK (`OpenAI` NuGet package)
+- `GoogleAdapter` — uses Google AI .NET SDK or direct REST via `HttpClient`
+
+Adapters are stateless — they receive the decrypted API key and model per-request. No connection pooling or cached clients (keys differ per user).
+
+**Alternative considered:** Using `IHttpClientFactory` with named clients — rejected because each user has a different API key, so we can't pre-configure named clients. Adapters create clients per-request with the user's key.
+
+### 5. Config-Driven Model Catalog with Fallback Chains
+
+Model configuration lives in `appsettings.json`, not hardcoded in source:
+
+```json
+{
+  "AiProvider": {
+    "Providers": {
+      "Anthropic": {
+        "DefaultModel": "claude-sonnet-4-20250514",
+        "FallbackModels": ["claude-sonnet-4-6", "claude-haiku-4-5"]
+      },
+      "OpenAI": {
+        "DefaultModel": "gpt-4o",
+        "FallbackModels": ["gpt-4o-mini", "gpt-4.1-mini"]
+      },
+      "Google": {
+        "DefaultModel": "gemini-2.5-flash",
+        "FallbackModels": ["gemini-2.0-flash", "gemini-1.5-flash"]
+      }
+    }
+  }
+}
+```
+
+When the primary model returns a model-not-found error, the adapter walks the fallback list. Only model-not-found errors trigger fallback — auth errors, rate limits, and server errors bubble up immediately.
+
+**Alternative considered:** Dynamic model listing from provider APIs — rejected for simplicity and reliability. Config-driven is updatable without code changes but doesn't add API call latency or failure modes. Also considered hardcoded in code — rejected because it requires a code deployment to update when models change.
+
+### 6. Taste Key System (App-Managed Default Key)
+
+New users get immediate AI access via an app-managed Google API key. This demonstrates value before asking users to invest effort in API key setup.
+
+- **Provider:** Google (Gemini 2.5 Flash for development, 2.5 Pro for production)
+- **Budget:** 5 AI operations per user per day (configurable)
+- **Tracking:** Simple `AiTasteBudget` table (UserId, Date, OperationsUsed) — infrastructure concern, not a domain entity
+- **Never expires:** A user who signed up months ago still gets taste operations
+- **Same model defaults:** Taste and BYO-key users get the same default model per provider
+
+The `AiCompletionService` resolution order:
+1. User's own `AiProviderConfig` → use their key (no budget)
+2. No config → use taste key → check budget → proceed or throw `TasteLimitExceededException`
+
+```json
+{
+  "AiProvider": {
+    "TasteKey": {
+      "Provider": "Google",
+      "ApiKey": "...",
+      "DailyLimitPerUser": 5
+    }
+  }
+}
+```
+
+**Alternative considered:** Require key setup before any AI features — rejected because users need to experience value before investing effort. The taste system creates a natural conversion funnel.
+
+### 7. AI Setup Nudge Framework
+
+Users move through four states that determine which nudge they see:
+
+- **Fresh** — No AI used yet. Passive indicators only (settings page shows "not configured").
+- **Tasting** — Using taste key, under daily limit. Contextual suggestions ("Add your own key for unlimited AI") after AI operations complete. Non-blocking, dismissible for 7 days.
+- **Limited** — Daily taste budget exhausted. Blocking prompt — cannot proceed without own key or waiting until tomorrow. Clear messaging: "You've used your 5 free AI operations today."
+- **Unlimited** — Own key configured. No nudges.
+
+The nudge state is derived from `user.AiProviderConfig` (null or not) and `AiTasteBudget` (remaining operations). No separate state entity needed.
+
+### 8. Key Validation via Lightweight API Call
+
+The `/api/users/me/ai-provider/validate` endpoint sends a minimal completion request ("respond with OK") to verify the API key and model work. This gives users confidence before saving config.
+
+Validation is a separate endpoint (not part of ConfigureAiProvider) because:
+- Users may want to test before committing
+- Validation involves external API calls which may be slow or fail
+- The domain action (ConfigureAiProvider) should be fast and offline
+
+### 9. Frontend Deep Links for Key Creation
+
+Instead of generic "get an API key" instructions, the settings UI provides deep links to the exact key creation page per provider:
+
+- **Anthropic:** `https://console.anthropic.com/settings/keys`
+- **OpenAI:** `https://platform.openai.com/api-keys`
+- **Google:** `https://aistudio.google.com/apikey`
+
+Auto-validate triggers the moment the user pastes a key, providing instant feedback.
+
+## Risks / Trade-offs
+
+- **[Encryption key management]** — If the server encryption key is lost, all stored API keys become unrecoverable. → Mitigation: Document key backup procedures. Users can always re-enter their API key.
+- **[Provider SDK version drift]** — Anthropic/OpenAI SDKs may have breaking changes. → Mitigation: Pin SDK versions; adapters are isolated so updates are contained.
+- **[Taste key cost]** — App-managed key has real cost as users grow. → Mitigation: 5 ops/day cap limits exposure. Google free tier covers development. Move to paid tier at launch (~$0.003/op). Monitor and adjust limit.
+- **[Taste key rate limits]** — Google free tier has RPM/RPD limits that could be hit with concurrent users. → Mitigation: Gemini 2.5 Flash has 50 RPD free tier. Sufficient for development. Fallback chain degrades gracefully to models with higher free limits (2.0 Flash: 1,500 RPD).
+- **[Google free tier commercial use]** — Free tier is intended for prototyping, not production. → Mitigation: Switch to pay-as-you-go at launch. Free tier is fine during development.
+- **[Per-request client creation]** — Creating HTTP clients per-request is less efficient than pooling. → Mitigation: Acceptable for now; AI calls are infrequent and high-latency anyway. Can add client caching later keyed by user+provider.
+- **[Single provider per user]** — Users who want to use Claude for extraction and GPT for chat can't. → Mitigation: Single config keeps the UX simple for v1. Multi-config is a future enhancement if demand exists.
+- **[Model fallback masking issues]** — Silent fallback might confuse users if quality drops. → Mitigation: Log fallback events. `AiCompletionResult` includes actual model used so callers can surface it if needed.
+
+## Dependencies
+
+- `user-auth-tenancy` (Tier 1, implemented) — User aggregate, auth, multi-tenant scoping

--- a/openspec/changes/byo-provider-config/proposal.md
+++ b/openspec/changes/byo-provider-config/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Every AI-powered feature in the app (capture extraction, living briefs, AI chat) depends on calling an LLM. Users must bring their own API key and choose their preferred provider (Anthropic, OpenAI, Google). Without a provider abstraction layer, each AI feature would need its own provider integration, and there's no way for users to configure or change providers. This is a Tier 1 foundation that blocks all Tier 2 AI capabilities.
+
+Additionally, new users need to experience AI value immediately — before investing effort in API key setup. An app-managed "taste" key gives every user 5 free AI operations per day, demonstrating value and driving conversion to BYO key setup.
+
+## What Changes
+
+- Add `AiProviderConfig` value object to the User aggregate (provider, encrypted API key, model, max tokens)
+- Add `ConfigureAiProvider` and `RemoveAiProvider` actions on User with validation and domain events
+- Create a provider abstraction interface (`IAiCompletionService`) that all AI features consume
+- Implement provider-specific adapters for Anthropic, OpenAI, and Google
+- Add model fallback chain — if a configured model is unavailable (deprecated/renamed), automatically try fallback models before failing
+- Add API key encryption at rest in the database (AES-256-GCM)
+- Add app-managed "taste" key system — default Google API key with per-user daily operation budget (5/day, never expires)
+- Add taste budget tracking (per-user, per-day operation counter)
+- Add AI setup nudge framework — four user states (Fresh, Tasting, Limited, Unlimited) with contextual prompts encouraging users to add their own key
+- Expose user-facing endpoints to configure and manage AI provider settings
+- Add frontend settings UI for provider selection, API key entry with deep links to provider console pages, auto-validation, and model selection
+- Add subtle taste counter UI in AI-powered sections ("3 of 5 free AI operations remaining today")
+- Add provider health-check / key validation endpoint
+- Config-driven model catalog and defaults in `appsettings.json`
+
+## Non-goals
+
+- Streaming responses (batch completion only — streaming comes with AI chat specs)
+- Prompt engineering or templates (downstream specs define their own prompts)
+- Token usage tracking or cost estimation
+- Multiple provider configs per user (one active config at a time)
+- Provider-specific advanced features (function calling, vision) — unified text-in/text-out
+- OAuth-based provider access (no provider offers sanctioned 3rd-party OAuth for API delegation)
+- Third-party intermediaries like OpenRouter
+
+## Capabilities
+
+### New Capabilities
+- `ai-provider-abstraction`: BYO provider configuration (API key paste with deep links and auto-validate), API key encryption at rest, provider interface abstraction with model fallback chain, taste key system (app-managed default key with daily budget), AI setup nudge framework, config-driven model catalog with defaults. Covers domain model (AiProviderConfig VO, ConfigureAiProvider/RemoveAiProvider actions), infrastructure (encryption, HTTP adapters per provider, taste budget tracking), application handlers, API endpoints, and frontend settings UI.
+
+### Modified Capabilities
+- `user-auth-tenancy`: The User aggregate gains the `AiProviderConfig` property and `ConfigureAiProvider`/`RemoveAiProvider` actions. The user profile response gains `hasAiProvider` boolean. This is additive — no existing requirements change, but the User entity is extended.
+
+## Impact
+
+- **Domain:** User aggregate extended with `AiProviderConfig` value object, new business actions, new domain events
+- **Infrastructure:** New EF Core migration for `AiProviderConfig` columns on Users table. New encryption service for API key storage. New HTTP client adapters for Anthropic, OpenAI, and Google APIs. New taste budget tracking table. Model fallback logic in completion service.
+- **Application:** New handlers for configuring provider, getting provider status, validating keys, removing config, getting available models
+- **Web:** New API endpoints under `/api/users/me/ai-provider` and `/api/ai/models`
+- **Frontend:** New AI provider section on the settings page (provider selector, API key input with deep links, model selector, test connection, taste counter). Nudge components for Fresh/Tasting/Limited states.
+- **Configuration:** Model catalog, defaults, fallback chains, taste key config, encryption key — all in `appsettings.json`, documented in README
+- **Dependencies:** New NuGet packages for Anthropic SDK, OpenAI SDK. Google will use REST via HttpClient.

--- a/openspec/changes/byo-provider-config/specs/ai-provider-abstraction/spec.md
+++ b/openspec/changes/byo-provider-config/specs/ai-provider-abstraction/spec.md
@@ -1,0 +1,323 @@
+## ADDED Requirements
+
+### Requirement: AiProviderConfig value object
+
+The system SHALL define an `AiProviderConfig` value object with: `Provider` (enum: Anthropic, OpenAI, Google), `EncryptedApiKey` (string), `Model` (string), and `MaxTokens` (int?, optional). The value object SHALL be embedded on the User aggregate.
+
+#### Scenario: AiProviderConfig creation with valid inputs
+- **WHEN** AiProviderConfig is created with Provider=Anthropic, EncryptedApiKey="enc_xxx", Model="claude-sonnet-4-20250514", MaxTokens=4096
+- **THEN** the value object is created with all properties set
+
+#### Scenario: AiProviderConfig equality
+- **WHEN** two AiProviderConfig instances have identical Provider, EncryptedApiKey, Model, and MaxTokens
+- **THEN** they are considered equal
+
+### Requirement: User can configure AI provider
+
+The User aggregate SHALL expose a `ConfigureAiProvider(provider, encryptedApiKey, model, maxTokens?)` action that sets the `AiProviderConfig` property and raises an `AiProviderConfigured` domain event.
+
+#### Scenario: First-time AI provider configuration
+- **WHEN** a user with no AI provider config calls ConfigureAiProvider with Provider=Anthropic, a valid encrypted key, and Model="claude-sonnet-4-20250514"
+- **THEN** the user's AiProviderConfig is set with the given values
+- **AND** an `AiProviderConfigured` event is raised with UserId and Provider
+
+#### Scenario: Changing AI provider
+- **WHEN** a user with an existing Anthropic config calls ConfigureAiProvider with Provider=OpenAI and a new key
+- **THEN** the user's AiProviderConfig is replaced with the new config
+- **AND** an `AiProviderConfigured` event is raised
+
+#### Scenario: Invalid provider rejected
+- **WHEN** ConfigureAiProvider is called with an empty API key
+- **THEN** an ArgumentException is thrown
+
+#### Scenario: Invalid model rejected
+- **WHEN** ConfigureAiProvider is called with an empty model string
+- **THEN** an ArgumentException is thrown
+
+### Requirement: User can remove AI provider configuration
+
+The User aggregate SHALL expose a `RemoveAiProvider()` action that clears `AiProviderConfig` to null and raises an `AiProviderRemoved` domain event. The action SHALL be idempotent — removing when already null is a no-op (no event raised).
+
+#### Scenario: Successful removal
+- **WHEN** a user with a configured provider calls RemoveAiProvider
+- **THEN** AiProviderConfig is set to null
+- **AND** an `AiProviderRemoved` event is raised
+
+#### Scenario: Remove when not configured
+- **WHEN** a user without a configured provider calls RemoveAiProvider
+- **THEN** AiProviderConfig remains null
+- **AND** no domain event is raised
+
+### Requirement: API key encryption at rest
+
+The system SHALL encrypt API keys using AES-256-GCM before storing them in the database. The encryption key SHALL be configurable via application settings (`AiProvider:EncryptionKey`). The stored format SHALL be Base64-encoded `nonce:ciphertext:tag`.
+
+#### Scenario: API key is encrypted before storage
+- **WHEN** a user configures an AI provider with a plaintext API key
+- **THEN** the key is encrypted via `IApiKeyEncryptionService.Encrypt()` before being passed to the domain
+- **AND** the database column contains only the encrypted value
+
+#### Scenario: API key is decrypted for provider calls
+- **WHEN** the system needs to make an AI completion call
+- **THEN** the encrypted key is decrypted via `IApiKeyEncryptionService.Decrypt()` to obtain the plaintext key
+- **AND** the plaintext key is used for the provider API call and is never persisted
+
+#### Scenario: Missing encryption key at startup
+- **WHEN** the application starts without `AiProvider:EncryptionKey` configured
+- **THEN** the application SHALL fail fast with a clear configuration error
+
+### Requirement: Provider abstraction interface
+
+The system SHALL define an `IAiCompletionService` interface in the Application layer with a single `CompleteAsync(AiCompletionRequest, CancellationToken)` method. The request SHALL include: system prompt (string), user prompt (string), max tokens (int?, optional override), and temperature (float?, optional). The result SHALL include: content (string), input tokens used (int), output tokens used (int), model used (string), and provider used (AiProvider enum).
+
+#### Scenario: Successful completion via user's own key
+- **WHEN** a user has configured their own AI provider
+- **AND** CompleteAsync is called with a system prompt and user prompt
+- **THEN** the system uses the user's decrypted key and configured model
+- **AND** returns an AiCompletionResult with the response content, token usage, and actual model used
+
+#### Scenario: Successful completion via taste key
+- **WHEN** a user has no configured AI provider and has remaining taste budget
+- **AND** CompleteAsync is called
+- **THEN** the system uses the app-managed taste key with the taste provider's default model
+- **AND** decrements the user's daily taste budget
+- **AND** returns an AiCompletionResult
+
+#### Scenario: Taste budget exhausted
+- **WHEN** a user has no configured AI provider and has exhausted their daily taste budget
+- **AND** CompleteAsync is called
+- **THEN** a `TasteLimitExceededException` is thrown
+
+#### Scenario: User has own key — no taste budget consumed
+- **WHEN** a user has their own AI provider configured
+- **AND** CompleteAsync is called
+- **THEN** the taste budget is NOT decremented (own key = unlimited)
+
+### Requirement: Model fallback chain
+
+The system SHALL attempt the configured default model first. If the provider API returns a model-not-found error, the system SHALL try each model in the provider's fallback list in order. Only model-not-found errors SHALL trigger fallback — auth errors, rate limit errors, and server errors SHALL bubble up immediately.
+
+#### Scenario: Default model succeeds
+- **WHEN** a completion request is made with the default model "claude-sonnet-4-20250514"
+- **AND** the provider API accepts the model
+- **THEN** the response is returned with model="claude-sonnet-4-20250514"
+
+#### Scenario: Default model deprecated, fallback succeeds
+- **WHEN** a completion request is made with default model "claude-sonnet-4-20250514"
+- **AND** the provider API returns a model-not-found error
+- **THEN** the system tries the first fallback model "claude-sonnet-4-6"
+- **AND** if that succeeds, returns the response with model="claude-sonnet-4-6"
+
+#### Scenario: All models fail
+- **WHEN** all models in the chain (default + all fallbacks) return model-not-found
+- **THEN** an `AiProviderException` is thrown indicating no available models
+
+#### Scenario: Auth error does not trigger fallback
+- **WHEN** a completion request fails with an authentication error
+- **THEN** the error bubbles up immediately without trying fallback models
+
+### Requirement: Provider adapter implementations
+
+The system SHALL implement provider-specific adapters for Anthropic (using Anthropic .NET SDK), OpenAI (using OpenAI .NET SDK), and Google (using HttpClient with Gemini REST API). Adapters SHALL be stateless and receive the decrypted API key per request.
+
+#### Scenario: Anthropic adapter maps request correctly
+- **WHEN** the Anthropic adapter receives a completion request
+- **THEN** it maps system prompt to the Anthropic `system` parameter
+- **AND** maps user prompt to a user message
+- **AND** sends the request using the Anthropic SDK
+
+#### Scenario: OpenAI adapter maps request correctly
+- **WHEN** the OpenAI adapter receives a completion request
+- **THEN** it maps system prompt to a system message and user prompt to a user message
+- **AND** sends the request using the OpenAI SDK
+
+#### Scenario: Google adapter maps request correctly
+- **WHEN** the Google adapter receives a completion request
+- **THEN** it maps the prompts to the Gemini API format
+- **AND** sends the request via HttpClient to the Gemini REST endpoint
+
+#### Scenario: Provider API returns an error
+- **WHEN** a provider API call fails (auth error, rate limit, server error)
+- **THEN** the adapter throws an `AiProviderException` with the provider name, HTTP status, and error message
+
+### Requirement: Config-driven model catalog
+
+The system SHALL maintain model configuration in `appsettings.json` with a default model and ordered fallback list per provider. The system SHALL expose an endpoint to retrieve the available models. Model configuration SHALL be updatable without code changes.
+
+#### Scenario: Retrieve models for a provider
+- **WHEN** a client requests available models for Anthropic
+- **THEN** the system returns the default model and fallback models from configuration
+
+#### Scenario: Invalid provider
+- **WHEN** a client requests models for an unrecognized provider
+- **THEN** the system returns 400 Bad Request
+
+### Requirement: Taste key system
+
+The system SHALL provide an app-managed AI key (the "taste key") configured in `appsettings.json`. New users without their own AI provider SHALL automatically use the taste key. Each user SHALL have a daily budget of AI operations (default: 5, configurable). The budget resets daily and never expires (a user who signed up months ago still gets taste operations).
+
+#### Scenario: New user uses taste key
+- **WHEN** a user with no AI provider config triggers an AI operation
+- **THEN** the system uses the taste key
+- **AND** the user's daily operation counter is incremented
+
+#### Scenario: Taste budget exhausted
+- **WHEN** a user has used all 5 daily taste operations
+- **AND** they trigger another AI operation
+- **THEN** the system throws `TasteLimitExceededException`
+- **AND** the frontend displays the Limited nudge
+
+#### Scenario: Taste budget resets daily
+- **WHEN** a new UTC day begins
+- **THEN** all users' taste budgets reset to 0 operations used
+
+#### Scenario: User with own key bypasses taste system
+- **WHEN** a user has their own AI provider configured
+- **THEN** the taste key and budget are not involved in any AI operations
+
+#### Scenario: Taste key not configured
+- **WHEN** the application starts without `AiProvider:TasteKey` configured
+- **THEN** the taste system is disabled (users without own key get an error prompting setup)
+- **AND** the application SHALL NOT fail to start
+
+### Requirement: AI setup nudge framework
+
+The system SHALL guide users through four states based on their AI provider configuration and taste budget. The nudge type determines the UI treatment when AI features are encountered.
+
+**States:**
+- **Fresh** — No AI operations used, no provider configured. Passive indicators only.
+- **Tasting** — Using taste key, under daily limit. Contextual suggestions after AI operations.
+- **Limited** — Daily taste budget exhausted, no own key. Blocking — cannot proceed.
+- **Unlimited** — Own key configured. No nudges.
+
+#### Scenario: Fresh user sees passive indicator
+- **WHEN** a user with no AI provider and no taste usage navigates the app
+- **THEN** AI-powered sections show empty states with a subtle link to AI setup
+- **AND** the settings page shows "AI Provider: Not configured"
+
+#### Scenario: Tasting user sees contextual nudge
+- **WHEN** a user without their own key completes an AI operation via the taste key
+- **THEN** a non-blocking contextual message appears: "Add your own AI key for unlimited access"
+- **AND** the message is dismissible for 7 days per nudge type
+
+#### Scenario: Limited user sees blocking prompt
+- **WHEN** a user without their own key triggers an AI operation with 0 remaining taste budget
+- **THEN** a blocking prompt appears explaining the daily limit is reached
+- **AND** offers "Set Up AI Provider" and "Continue tomorrow" actions
+- **AND** the "Continue tomorrow" action dismisses for this action only (next AI trigger shows it again)
+
+#### Scenario: Unlimited user sees no nudges
+- **WHEN** a user with their own AI provider configured uses any AI feature
+- **THEN** no AI setup nudges are shown
+
+### Requirement: Taste counter display
+
+The system SHALL display a subtle counter showing remaining taste operations in AI-powered sections of the app. The counter SHALL only be visible to users without their own AI provider configured.
+
+#### Scenario: Counter visible for taste users
+- **WHEN** a user without their own key is in an AI-powered section
+- **THEN** a subtle indicator shows "3 of 5 free AI operations remaining today"
+
+#### Scenario: Counter hidden for configured users
+- **WHEN** a user with their own AI provider is in an AI-powered section
+- **THEN** no taste counter is displayed
+
+#### Scenario: Counter updates after AI operation
+- **WHEN** a taste user completes an AI operation
+- **THEN** the counter updates to reflect the new remaining count
+
+### Requirement: API key validation endpoint
+
+The system SHALL expose a `POST /api/users/me/ai-provider/validate` endpoint that sends a minimal completion request to verify the API key and model work. The endpoint SHALL accept provider, API key, and model as input (not requiring the config to be saved first).
+
+#### Scenario: Valid API key
+- **WHEN** a user submits a valid provider, API key, and model for validation
+- **THEN** the system sends a lightweight completion request to the provider
+- **AND** returns a success response with the model name confirmed
+
+#### Scenario: Invalid API key
+- **WHEN** a user submits an invalid API key for validation
+- **THEN** the provider returns an authentication error
+- **AND** the system returns a failure response indicating the key is invalid
+
+#### Scenario: Invalid model
+- **WHEN** a user submits a valid key but an unsupported model
+- **THEN** the provider returns a model-not-found error
+- **AND** the system returns a failure response indicating the model is not available
+
+### Requirement: Configure AI provider API endpoint
+
+The system SHALL expose `PUT /api/users/me/ai-provider` to configure the user's AI provider. The request body SHALL include provider (string), apiKey (plaintext string), model (string), and maxTokens (int?, optional). The endpoint SHALL encrypt the API key before passing to the domain.
+
+#### Scenario: Successful configuration
+- **WHEN** an authenticated user sends a PUT with provider="Anthropic", apiKey="sk-ant-...", model="claude-sonnet-4-20250514"
+- **THEN** the system encrypts the API key, calls User.ConfigureAiProvider, persists changes, and returns 204 No Content
+
+#### Scenario: Unauthenticated request
+- **WHEN** a request is sent without a valid JWT
+- **THEN** the system returns 401 Unauthorized
+
+### Requirement: Get AI provider status endpoint
+
+The system SHALL expose `GET /api/users/me/ai-provider` to return the user's current AI provider configuration (provider, model, maxTokens, isConfigured) and taste budget status (remaining operations, daily limit). The response SHALL NOT include the API key (encrypted or plaintext).
+
+#### Scenario: User has provider configured
+- **WHEN** an authenticated user with a configured provider sends a GET
+- **THEN** the system returns the provider name, model, maxTokens, isConfigured=true, and taste information
+
+#### Scenario: User has no provider configured
+- **WHEN** an authenticated user without a provider config sends a GET
+- **THEN** the system returns isConfigured=false with null provider/model, and remaining taste budget
+
+### Requirement: Get available models endpoint
+
+The system SHALL expose `GET /api/ai/models?provider={provider}` to return the configured models for a given provider, including which is the default.
+
+#### Scenario: Request models for a valid provider
+- **WHEN** a client requests models with provider=Anthropic
+- **THEN** the system returns the model list from configuration with the default flagged
+
+#### Scenario: Request models for an invalid provider
+- **WHEN** a client requests models with an unrecognized provider
+- **THEN** the system returns 400 Bad Request
+
+### Requirement: Delete AI provider configuration
+
+The system SHALL expose `DELETE /api/users/me/ai-provider` to remove the user's AI provider configuration.
+
+#### Scenario: Successful removal
+- **WHEN** an authenticated user with a configured provider sends a DELETE
+- **THEN** the system calls User.RemoveAiProvider, persists changes, and returns 204 No Content
+
+#### Scenario: Remove when not configured
+- **WHEN** an authenticated user without a configured provider sends a DELETE
+- **THEN** the system returns 204 No Content (idempotent)
+
+### Requirement: Frontend AI provider settings
+
+The settings page SHALL include an AI Provider section with: provider cards (Anthropic, OpenAI, Google), an API key input field (password-masked), a "Don't have one?" deep link to the provider's key creation page, a model dropdown (populated from config with default flagged), an optional max tokens input, a "Test Connection" button (auto-validates on key paste), and a "Save" button.
+
+#### Scenario: User configures provider for the first time
+- **WHEN** a user navigates to settings and selects Anthropic
+- **THEN** a deep link to `https://console.anthropic.com/settings/keys` appears as "Don't have one? → Open Anthropic Console"
+- **AND** the model dropdown shows configured Anthropic models with the default pre-selected
+
+#### Scenario: Auto-validate on key paste
+- **WHEN** a user pastes an API key into the input field
+- **THEN** the system automatically calls the validate endpoint
+- **AND** shows a green check with "Connected to Claude Sonnet 4" on success, or an error message on failure
+
+#### Scenario: User saves configuration
+- **WHEN** a user clicks "Save" with valid provider, API key, and model
+- **THEN** the frontend calls PUT /api/users/me/ai-provider
+- **AND** displays a success confirmation
+
+#### Scenario: Existing configuration is shown
+- **WHEN** a user with an existing config navigates to settings
+- **THEN** the provider and model are pre-selected
+- **AND** the API key field shows a placeholder (not the actual key)
+
+#### Scenario: Deep links per provider
+- **WHEN** user selects Anthropic, the "Don't have one?" link opens `https://console.anthropic.com/settings/keys`
+- **WHEN** user selects OpenAI, the link opens `https://platform.openai.com/api-keys`
+- **WHEN** user selects Google, the link opens `https://aistudio.google.com/apikey`

--- a/openspec/changes/byo-provider-config/specs/user-auth-tenancy/spec.md
+++ b/openspec/changes/byo-provider-config/specs/user-auth-tenancy/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: User aggregate supports AI provider configuration
+
+The User aggregate SHALL include an optional `AiProviderConfig` property (value object). When no AI provider is configured, the property SHALL be null. The User SHALL expose `ConfigureAiProvider` and `RemoveAiProvider` business actions.
+
+#### Scenario: New user has no AI provider configured
+- **WHEN** a new user is registered
+- **THEN** the user's AiProviderConfig is null
+
+#### Scenario: User configures AI provider
+- **WHEN** ConfigureAiProvider is called with valid provider, encrypted key, and model
+- **THEN** the user's AiProviderConfig is set and an `AiProviderConfigured` event is raised
+
+#### Scenario: User removes AI provider
+- **WHEN** RemoveAiProvider is called
+- **THEN** the user's AiProviderConfig is set to null and an `AiProviderRemoved` event is raised
+
+### Requirement: User profile response includes AI provider status
+
+The `GET /api/users/me` response SHALL include a `hasAiProvider` boolean field indicating whether the user has configured an AI provider. The response SHALL NOT include any AI provider details (provider name, model, key).
+
+#### Scenario: User with AI provider configured
+- **WHEN** an authenticated user with a configured AI provider requests their profile
+- **THEN** the response includes hasAiProvider=true
+
+#### Scenario: User without AI provider configured
+- **WHEN** an authenticated user without a configured AI provider requests their profile
+- **THEN** the response includes hasAiProvider=false

--- a/openspec/changes/byo-provider-config/tasks.md
+++ b/openspec/changes/byo-provider-config/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Domain Layer
 
-- [ ] 1.1 Create `AiProvider` enum (Anthropic, OpenAI, Google) in Domain/Users
-- [ ] 1.2 Create `AiProviderConfig` value object (Provider, EncryptedApiKey, Model, MaxTokens?) extending ValueObject
-- [ ] 1.3 Add nullable `AiProviderConfig?` property to User aggregate (null by default on registration)
-- [ ] 1.4 Implement `User.ConfigureAiProvider(provider, encryptedApiKey, model, maxTokens?)` action with validation, raising `AiProviderConfigured` event
-- [ ] 1.5 Implement `User.RemoveAiProvider()` action raising `AiProviderRemoved` event (idempotent — no event if already null)
-- [ ] 1.6 Add `AiProviderConfigured` and `AiProviderRemoved` domain events
+- [x] 1.1 Create `AiProvider` enum (Anthropic, OpenAI, Google) in Domain/Users
+- [x] 1.2 Create `AiProviderConfig` value object (Provider, EncryptedApiKey, Model, MaxTokens?) extending ValueObject
+- [x] 1.3 Add nullable `AiProviderConfig?` property to User aggregate (null by default on registration)
+- [x] 1.4 Implement `User.ConfigureAiProvider(provider, encryptedApiKey, model, maxTokens?)` action with validation, raising `AiProviderConfigured` event
+- [x] 1.5 Implement `User.RemoveAiProvider()` action raising `AiProviderRemoved` event (idempotent — no event if already null)
+- [x] 1.6 Add `AiProviderConfigured` and `AiProviderRemoved` domain events
 
 ## 2. Domain Tests
 
-- [ ] 2.1 Test `AiProviderConfig` value object: creation, equality
-- [ ] 2.2 Test `User.ConfigureAiProvider`: sets config, raises event, validates inputs (empty key/model rejected)
-- [ ] 2.3 Test `User.RemoveAiProvider`: clears config, raises event, idempotent when already null
-- [ ] 2.4 Test `User.Register`: new user has null AiProviderConfig
+- [x] 2.1 Test `AiProviderConfig` value object: creation, equality
+- [x] 2.2 Test `User.ConfigureAiProvider`: sets config, raises event, validates inputs (empty key/model rejected)
+- [x] 2.3 Test `User.RemoveAiProvider`: clears config, raises event, idempotent when already null
+- [x] 2.4 Test `User.Register`: new user has null AiProviderConfig
 
 ## 3. Application Layer — Interfaces and Models
 
-- [ ] 3.1 Create `IApiKeyEncryptionService` interface in Application/Common (Encrypt, Decrypt methods)
-- [ ] 3.2 Create `IAiCompletionService` interface in Application/Common with `CompleteAsync(AiCompletionRequest, CancellationToken)` returning `AiCompletionResult`
-- [ ] 3.3 Create `AiCompletionRequest` record (SystemPrompt, UserPrompt, MaxTokens?, Temperature?)
-- [ ] 3.4 Create `AiCompletionResult` record (Content, InputTokens, OutputTokens, Model, Provider)
-- [ ] 3.5 Create `AiProviderException` and `TasteLimitExceededException` exception classes
+- [x] 3.1 Create `IApiKeyEncryptionService` interface in Application/Common (Encrypt, Decrypt methods)
+- [x] 3.2 Create `IAiCompletionService` interface in Application/Common with `CompleteAsync(AiCompletionRequest, CancellationToken)` returning `AiCompletionResult`
+- [x] 3.3 Create `AiCompletionRequest` record (SystemPrompt, UserPrompt, MaxTokens?, Temperature?)
+- [x] 3.4 Create `AiCompletionResult` record (Content, InputTokens, OutputTokens, Model, Provider)
+- [x] 3.5 Create `AiProviderException` and `TasteLimitExceededException` exception classes
 
 ## 4. Application Layer — Handlers
 
-- [ ] 4.1 Create `ConfigureAiProvider` handler — encrypts key, calls User.ConfigureAiProvider, persists
-- [ ] 4.2 Create `GetAiProviderStatus` handler — returns provider config (without key), taste budget remaining
-- [ ] 4.3 Create `ValidateAiProvider` handler — accepts provider/key/model, calls IAiCompletionService with test prompt, returns success/failure
-- [ ] 4.4 Create `RemoveAiProvider` handler — calls User.RemoveAiProvider, persists
-- [ ] 4.5 Create `GetAvailableModels` handler — returns models from config for a given provider
-- [ ] 4.6 Create DTOs: `ConfigureAiProviderRequest`, `AiProviderStatusResponse` (incl. taste budget), `ValidateAiProviderRequest`, `ValidateAiProviderResponse`, `AvailableModelsResponse`
+- [x] 4.1 Create `ConfigureAiProvider` handler — encrypts key, calls User.ConfigureAiProvider, persists
+- [x] 4.2 Create `GetAiProviderStatus` handler — returns provider config (without key), taste budget remaining
+- [x] 4.3 Create `ValidateAiProvider` handler — accepts provider/key/model, calls IAiProviderValidator with test prompt, returns success/failure
+- [x] 4.4 Create `RemoveAiProvider` handler — calls User.RemoveAiProvider, persists
+- [x] 4.5 Create `GetAvailableModels` handler — returns models from config for a given provider
+- [x] 4.6 Create DTOs: `ConfigureAiProviderRequest`, `AiProviderStatusResponse` (incl. taste budget), `ValidateAiProviderRequest`, `ValidateAiProviderResponse`, `AvailableModelsResponse`
 
 ## 5. Application Tests
 

--- a/openspec/changes/byo-provider-config/tasks.md
+++ b/openspec/changes/byo-provider-config/tasks.md
@@ -1,0 +1,110 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create `AiProvider` enum (Anthropic, OpenAI, Google) in Domain/Users
+- [ ] 1.2 Create `AiProviderConfig` value object (Provider, EncryptedApiKey, Model, MaxTokens?) extending ValueObject
+- [ ] 1.3 Add nullable `AiProviderConfig?` property to User aggregate (null by default on registration)
+- [ ] 1.4 Implement `User.ConfigureAiProvider(provider, encryptedApiKey, model, maxTokens?)` action with validation, raising `AiProviderConfigured` event
+- [ ] 1.5 Implement `User.RemoveAiProvider()` action raising `AiProviderRemoved` event (idempotent — no event if already null)
+- [ ] 1.6 Add `AiProviderConfigured` and `AiProviderRemoved` domain events
+
+## 2. Domain Tests
+
+- [ ] 2.1 Test `AiProviderConfig` value object: creation, equality
+- [ ] 2.2 Test `User.ConfigureAiProvider`: sets config, raises event, validates inputs (empty key/model rejected)
+- [ ] 2.3 Test `User.RemoveAiProvider`: clears config, raises event, idempotent when already null
+- [ ] 2.4 Test `User.Register`: new user has null AiProviderConfig
+
+## 3. Application Layer — Interfaces and Models
+
+- [ ] 3.1 Create `IApiKeyEncryptionService` interface in Application/Common (Encrypt, Decrypt methods)
+- [ ] 3.2 Create `IAiCompletionService` interface in Application/Common with `CompleteAsync(AiCompletionRequest, CancellationToken)` returning `AiCompletionResult`
+- [ ] 3.3 Create `AiCompletionRequest` record (SystemPrompt, UserPrompt, MaxTokens?, Temperature?)
+- [ ] 3.4 Create `AiCompletionResult` record (Content, InputTokens, OutputTokens, Model, Provider)
+- [ ] 3.5 Create `AiProviderException` and `TasteLimitExceededException` exception classes
+
+## 4. Application Layer — Handlers
+
+- [ ] 4.1 Create `ConfigureAiProvider` handler — encrypts key, calls User.ConfigureAiProvider, persists
+- [ ] 4.2 Create `GetAiProviderStatus` handler — returns provider config (without key), taste budget remaining
+- [ ] 4.3 Create `ValidateAiProvider` handler — accepts provider/key/model, calls IAiCompletionService with test prompt, returns success/failure
+- [ ] 4.4 Create `RemoveAiProvider` handler — calls User.RemoveAiProvider, persists
+- [ ] 4.5 Create `GetAvailableModels` handler — returns models from config for a given provider
+- [ ] 4.6 Create DTOs: `ConfigureAiProviderRequest`, `AiProviderStatusResponse` (incl. taste budget), `ValidateAiProviderRequest`, `ValidateAiProviderResponse`, `AvailableModelsResponse`
+
+## 5. Application Tests
+
+- [ ] 5.1 Test `ConfigureAiProvider` handler: encrypts key, saves config, persists via UoW
+- [ ] 5.2 Test `GetAiProviderStatus`: returns status for configured/unconfigured users, includes taste budget
+- [ ] 5.3 Test `ValidateAiProvider`: success and failure paths
+- [ ] 5.4 Test `RemoveAiProvider`: clears config, persists
+- [ ] 5.5 Test `GetAvailableModels`: returns correct models per provider, rejects invalid provider
+
+## 6. Infrastructure — Encryption
+
+- [ ] 6.1 Create `AesApiKeyEncryptionService` implementing `IApiKeyEncryptionService` (AES-256-GCM, Base64 nonce:ciphertext:tag format)
+- [ ] 6.2 Add `AiProviderSettings` options class with EncryptionKey, TasteKey config, and per-provider model config (DefaultModel, FallbackModels)
+- [ ] 6.3 Add startup validation — fail fast if `AiProvider:EncryptionKey` is missing (taste key is optional — disabled if not set)
+- [ ] 6.4 Register encryption service in DI
+
+## 7. Infrastructure — Provider Adapters and Completion Service
+
+- [ ] 7.1 Add NuGet packages: Anthropic SDK, OpenAI SDK
+- [ ] 7.2 Create internal `IAiProviderAdapter` interface (CompleteAsync with decrypted key, model, request)
+- [ ] 7.3 Implement `AnthropicAdapter` using Anthropic .NET SDK
+- [ ] 7.4 Implement `OpenAiAdapter` using OpenAI .NET SDK
+- [ ] 7.5 Implement `GoogleAdapter` using HttpClient with Gemini REST API
+- [ ] 7.6 Create `AiCompletionService` implementing `IAiCompletionService` — resolves current user's config or taste key, decrypts key, dispatches to correct adapter, implements model fallback chain (retry on model-not-found only)
+- [ ] 7.7 Register AI services in DI
+
+## 8. Infrastructure — Taste Budget Tracking
+
+- [ ] 8.1 Create `AiTasteBudget` entity (UserId, Date, OperationsUsed) — infrastructure concern, not a domain entity
+- [ ] 8.2 Create `AiTasteBudgetConfiguration` EF Core config
+- [ ] 8.3 Create `ITasteBudgetService` interface and implementation — check/decrement budget, per-user per-day
+- [ ] 8.4 Register taste budget service in DI
+
+## 9. Infrastructure — Persistence
+
+- [ ] 9.1 Add `AiProviderConfig` owned entity configuration to `UserConfiguration` (OwnsOne with encrypted key column)
+- [ ] 9.2 Create EF Core migration for AiProviderConfig columns on Users table and AiTasteBudgets table
+- [ ] 9.3 Add `hasAiProvider` to `GetCurrentUser` response DTO
+
+## 10. Web Layer — API Endpoints
+
+- [ ] 10.1 Map `PUT /api/users/me/ai-provider` — configure provider (encrypt key, save)
+- [ ] 10.2 Map `GET /api/users/me/ai-provider` — get provider status and taste budget
+- [ ] 10.3 Map `POST /api/users/me/ai-provider/validate` — validate key/model via test completion
+- [ ] 10.4 Map `DELETE /api/users/me/ai-provider` — remove provider config
+- [ ] 10.5 Map `GET /api/ai/models?provider={provider}` — list available models from config
+- [ ] 10.6 Register new application handlers in DI
+
+## 11. Configuration and Documentation
+
+- [ ] 11.1 Add AI provider configuration section to `appsettings.json` (encryption key, taste key, per-provider model defaults and fallbacks)
+- [ ] 11.2 Add AI provider configuration section to `appsettings.Development.json` with development defaults
+- [ ] 11.3 Document AI provider configuration in README (encryption key, taste key setup, model config, environment variables)
+
+## 12. Frontend — AI Provider Settings
+
+- [ ] 12.1 Create `AiProviderService` for provider API calls (configure, get status, validate, remove, get models)
+- [ ] 12.2 Add AI Provider section to settings page: provider cards (Anthropic/OpenAI/Google), API key input (password-masked), "Don't have one?" deep link per provider
+- [ ] 12.3 Implement model dropdown populated from config endpoint with default pre-selected
+- [ ] 12.4 Implement auto-validate on key paste (instant feedback — green check or error)
+- [ ] 12.5 Implement save flow calling PUT endpoint with success confirmation
+- [ ] 12.6 Implement remove flow with confirmation dialog
+- [ ] 12.7 Pre-populate form when user has existing config (placeholder for API key)
+
+## 13. Frontend — Taste Counter and Nudge Framework
+
+- [ ] 13.1 Create `AiNudgeService` — derives nudge state (Fresh/Tasting/Limited/Unlimited) from provider status and taste budget
+- [ ] 13.2 Create subtle taste counter component ("3 of 5 free AI operations remaining today") — visible only for taste users
+- [ ] 13.3 Create contextual nudge component for Tasting state ("Add your own AI key for unlimited access") — dismissible for 7 days
+- [ ] 13.4 Create blocking nudge component for Limited state ("You've used your 5 free AI operations today") — "Set Up AI Provider" and "Continue tomorrow" actions
+- [ ] 13.5 Create passive indicator for Fresh state (settings page "AI Provider: Not configured", empty states in AI sections)
+- [ ] 13.6 Integrate nudge components into AI-powered sections (capture processing, AI chat, briefing, etc. — placeholder integration points for future features)
+
+## 14. E2E Tests
+
+- [ ] 14.1 E2E test: Unauthenticated requests to AI provider endpoints return 401
+- [ ] 14.2 E2E test: GET /api/ai/models returns model list for valid provider
+- [ ] 14.3 E2E test: GET /api/users/me/ai-provider returns isConfigured=false and taste budget for new user

--- a/openspec/changes/byo-provider-config/tasks.md
+++ b/openspec/changes/byo-provider-config/tasks.md
@@ -33,11 +33,11 @@
 
 ## 5. Application Tests
 
-- [ ] 5.1 Test `ConfigureAiProvider` handler: encrypts key, saves config, persists via UoW
-- [ ] 5.2 Test `GetAiProviderStatus`: returns status for configured/unconfigured users, includes taste budget
-- [ ] 5.3 Test `ValidateAiProvider`: success and failure paths
-- [ ] 5.4 Test `RemoveAiProvider`: clears config, persists
-- [ ] 5.5 Test `GetAvailableModels`: returns correct models per provider, rejects invalid provider
+- [x] 5.1 Test `ConfigureAiProvider` handler: encrypts key, saves config, persists via UoW
+- [x] 5.2 Test `GetAiProviderStatus`: returns status for configured/unconfigured users, includes taste budget
+- [x] 5.3 Test `ValidateAiProvider`: success and failure paths
+- [x] 5.4 Test `RemoveAiProvider`: clears config, persists
+- [x] 5.5 Test `GetAvailableModels`: returns correct models per provider, rejects invalid provider
 
 ## 6. Infrastructure — Encryption
 

--- a/src/MentalMetal.Application/Common/Ai/AiProviderException.cs
+++ b/src/MentalMetal.Application/Common/Ai/AiProviderException.cs
@@ -1,0 +1,15 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Common.Ai;
+
+public class AiProviderException(
+    AiProvider provider,
+    int? statusCode,
+    string message) : Exception(message)
+{
+    public AiProvider Provider { get; } = provider;
+    public int? StatusCode { get; } = statusCode;
+}
+
+public class TasteLimitExceededException()
+    : Exception("Daily free AI operation limit reached. Add your own AI provider key for unlimited access.");

--- a/src/MentalMetal.Application/Common/Ai/IAiCompletionService.cs
+++ b/src/MentalMetal.Application/Common/Ai/IAiCompletionService.cs
@@ -1,0 +1,23 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Common.Ai;
+
+public interface IAiCompletionService
+{
+    Task<AiCompletionResult> CompleteAsync(
+        AiCompletionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed record AiCompletionRequest(
+    string SystemPrompt,
+    string UserPrompt,
+    int? MaxTokens = null,
+    float? Temperature = null);
+
+public sealed record AiCompletionResult(
+    string Content,
+    int InputTokens,
+    int OutputTokens,
+    string Model,
+    AiProvider Provider);

--- a/src/MentalMetal.Application/Common/Ai/IAiModelCatalog.cs
+++ b/src/MentalMetal.Application/Common/Ai/IAiModelCatalog.cs
@@ -1,0 +1,11 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Common.Ai;
+
+public interface IAiModelCatalog
+{
+    IReadOnlyList<AiModelInfo> GetModels(AiProvider provider);
+    string GetDefaultModel(AiProvider provider);
+}
+
+public sealed record AiModelInfo(string Id, string Name, bool IsDefault);

--- a/src/MentalMetal.Application/Common/Ai/IAiProviderValidator.cs
+++ b/src/MentalMetal.Application/Common/Ai/IAiProviderValidator.cs
@@ -1,0 +1,12 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Common.Ai;
+
+public interface IAiProviderValidator
+{
+    Task<string> ValidateAsync(
+        AiProvider provider,
+        string apiKey,
+        string model,
+        CancellationToken cancellationToken);
+}

--- a/src/MentalMetal.Application/Common/Ai/IApiKeyEncryptionService.cs
+++ b/src/MentalMetal.Application/Common/Ai/IApiKeyEncryptionService.cs
@@ -1,0 +1,7 @@
+namespace MentalMetal.Application.Common.Ai;
+
+public interface IApiKeyEncryptionService
+{
+    string Encrypt(string plaintext);
+    string Decrypt(string ciphertext);
+}

--- a/src/MentalMetal.Application/Common/Ai/ITasteBudgetService.cs
+++ b/src/MentalMetal.Application/Common/Ai/ITasteBudgetService.cs
@@ -1,0 +1,9 @@
+namespace MentalMetal.Application.Common.Ai;
+
+public interface ITasteBudgetService
+{
+    Task<int> GetRemainingAsync(Guid userId, CancellationToken cancellationToken);
+    Task DecrementAsync(Guid userId, CancellationToken cancellationToken);
+    int DailyLimit { get; }
+    bool IsEnabled { get; }
+}

--- a/src/MentalMetal.Application/Users/AiProviderDtos.cs
+++ b/src/MentalMetal.Application/Users/AiProviderDtos.cs
@@ -1,0 +1,38 @@
+namespace MentalMetal.Application.Users;
+
+public sealed record ConfigureAiProviderRequest(
+    string Provider,
+    string ApiKey,
+    string Model,
+    int? MaxTokens = null);
+
+public sealed record AiProviderStatusResponse(
+    bool IsConfigured,
+    string? Provider,
+    string? Model,
+    int? MaxTokens,
+    TasteBudgetDto TasteBudget);
+
+public sealed record TasteBudgetDto(
+    int Remaining,
+    int DailyLimit,
+    bool IsEnabled);
+
+public sealed record ValidateAiProviderRequest(
+    string Provider,
+    string ApiKey,
+    string Model);
+
+public sealed record ValidateAiProviderResponse(
+    bool Success,
+    string? ModelName,
+    string? Error);
+
+public sealed record ModelInfo(
+    string Id,
+    string Name,
+    bool IsDefault);
+
+public sealed record AvailableModelsResponse(
+    string Provider,
+    List<ModelInfo> Models);

--- a/src/MentalMetal.Application/Users/ConfigureAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ConfigureAiProvider.cs
@@ -1,0 +1,28 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Users;
+
+public sealed class ConfigureAiProviderHandler(
+    IUserRepository userRepository,
+    ICurrentUserService currentUserService,
+    IApiKeyEncryptionService encryptionService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task HandleAsync(ConfigureAiProviderRequest request, CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(
+            currentUserService.UserId, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticated user not found.");
+
+        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider))
+            throw new ArgumentException($"Unsupported AI provider: {request.Provider}");
+
+        var encryptedKey = encryptionService.Encrypt(request.ApiKey);
+
+        user.ConfigureAiProvider(provider, encryptedKey, request.Model, request.MaxTokens);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/MentalMetal.Application/Users/ConfigureAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ConfigureAiProvider.cs
@@ -16,8 +16,11 @@ public sealed class ConfigureAiProviderHandler(
             currentUserService.UserId, cancellationToken)
             ?? throw new InvalidOperationException("Authenticated user not found.");
 
-        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider))
+        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider)
+            || !Enum.IsDefined(provider))
             throw new ArgumentException($"Unsupported AI provider: {request.Provider}");
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ApiKey, nameof(request.ApiKey));
 
         var encryptedKey = encryptionService.Encrypt(request.ApiKey);
 

--- a/src/MentalMetal.Application/Users/GetAiProviderStatus.cs
+++ b/src/MentalMetal.Application/Users/GetAiProviderStatus.cs
@@ -15,7 +15,11 @@ public sealed class GetAiProviderStatusHandler(
             ?? throw new InvalidOperationException("Authenticated user not found.");
 
         var config = user.AiProviderConfig;
-        var remaining = await tasteBudgetService.GetRemainingAsync(user.Id, cancellationToken);
+
+        // Only query taste budget if user doesn't have their own key and taste is enabled
+        var remaining = config is null && tasteBudgetService.IsEnabled
+            ? await tasteBudgetService.GetRemainingAsync(user.Id, cancellationToken)
+            : tasteBudgetService.DailyLimit;
 
         return new AiProviderStatusResponse(
             IsConfigured: config is not null,

--- a/src/MentalMetal.Application/Users/GetAiProviderStatus.cs
+++ b/src/MentalMetal.Application/Users/GetAiProviderStatus.cs
@@ -1,0 +1,30 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Users;
+
+public sealed class GetAiProviderStatusHandler(
+    IUserRepository userRepository,
+    ICurrentUserService currentUserService,
+    ITasteBudgetService tasteBudgetService)
+{
+    public async Task<AiProviderStatusResponse> HandleAsync(CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(
+            currentUserService.UserId, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticated user not found.");
+
+        var config = user.AiProviderConfig;
+        var remaining = await tasteBudgetService.GetRemainingAsync(user.Id, cancellationToken);
+
+        return new AiProviderStatusResponse(
+            IsConfigured: config is not null,
+            Provider: config?.Provider.ToString(),
+            Model: config?.Model,
+            MaxTokens: config?.MaxTokens,
+            TasteBudget: new TasteBudgetDto(
+                Remaining: remaining,
+                DailyLimit: tasteBudgetService.DailyLimit,
+                IsEnabled: tasteBudgetService.IsEnabled));
+    }
+}

--- a/src/MentalMetal.Application/Users/GetAvailableModels.cs
+++ b/src/MentalMetal.Application/Users/GetAvailableModels.cs
@@ -7,7 +7,8 @@ public sealed class GetAvailableModelsHandler(IAiModelCatalog modelCatalog)
 {
     public AvailableModelsResponse Handle(string providerName)
     {
-        if (!Enum.TryParse<AiProvider>(providerName, ignoreCase: true, out var provider))
+        if (!Enum.TryParse<AiProvider>(providerName, ignoreCase: true, out var provider)
+            || !Enum.IsDefined(provider))
             throw new ArgumentException($"Unsupported AI provider: {providerName}");
 
         var models = modelCatalog.GetModels(provider);

--- a/src/MentalMetal.Application/Users/GetAvailableModels.cs
+++ b/src/MentalMetal.Application/Users/GetAvailableModels.cs
@@ -1,0 +1,19 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Users;
+
+public sealed class GetAvailableModelsHandler(IAiModelCatalog modelCatalog)
+{
+    public AvailableModelsResponse Handle(string providerName)
+    {
+        if (!Enum.TryParse<AiProvider>(providerName, ignoreCase: true, out var provider))
+            throw new ArgumentException($"Unsupported AI provider: {providerName}");
+
+        var models = modelCatalog.GetModels(provider);
+
+        return new AvailableModelsResponse(
+            Provider: provider.ToString(),
+            Models: models.Select(m => new ModelInfo(m.Id, m.Name, m.IsDefault)).ToList());
+    }
+}

--- a/src/MentalMetal.Application/Users/RemoveAiProvider.cs
+++ b/src/MentalMetal.Application/Users/RemoveAiProvider.cs
@@ -1,0 +1,21 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Users;
+
+public sealed class RemoveAiProviderHandler(
+    IUserRepository userRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task HandleAsync(CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(
+            currentUserService.UserId, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticated user not found.");
+
+        user.RemoveAiProvider();
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/MentalMetal.Application/Users/ValidateAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ValidateAiProvider.cs
@@ -8,7 +8,8 @@ public sealed class ValidateAiProviderHandler(IAiProviderValidator providerValid
     public async Task<ValidateAiProviderResponse> HandleAsync(
         ValidateAiProviderRequest request, CancellationToken cancellationToken)
     {
-        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider))
+        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider)
+            || !Enum.IsDefined(provider))
             return new ValidateAiProviderResponse(false, null, $"Unsupported provider: {request.Provider}");
 
         try

--- a/src/MentalMetal.Application/Users/ValidateAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ValidateAiProvider.cs
@@ -1,0 +1,26 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Users;
+
+public sealed class ValidateAiProviderHandler(IAiProviderValidator providerValidator)
+{
+    public async Task<ValidateAiProviderResponse> HandleAsync(
+        ValidateAiProviderRequest request, CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<AiProvider>(request.Provider, ignoreCase: true, out var provider))
+            return new ValidateAiProviderResponse(false, null, $"Unsupported provider: {request.Provider}");
+
+        try
+        {
+            var model = await providerValidator.ValidateAsync(
+                provider, request.ApiKey, request.Model, cancellationToken);
+
+            return new ValidateAiProviderResponse(true, model, null);
+        }
+        catch (AiProviderException ex)
+        {
+            return new ValidateAiProviderResponse(false, null, ex.Message);
+        }
+    }
+}

--- a/src/MentalMetal.Application/Users/ValidateAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ValidateAiProvider.cs
@@ -20,7 +20,15 @@ public sealed class ValidateAiProviderHandler(IAiProviderValidator providerValid
         }
         catch (AiProviderException ex)
         {
-            return new ValidateAiProviderResponse(false, null, ex.Message);
+            var safeMessage = ex.StatusCode switch
+            {
+                401 => "Invalid API key. Please check your key and try again.",
+                403 => "Access denied. Your API key may not have the required permissions.",
+                404 => "Model not found. Please select a different model.",
+                429 => "Rate limit exceeded. Please try again later.",
+                _ => "Unable to connect to the AI provider. Please check your configuration."
+            };
+            return new ValidateAiProviderResponse(false, null, safeMessage);
         }
     }
 }

--- a/src/MentalMetal.Domain/Users/AiProvider.cs
+++ b/src/MentalMetal.Domain/Users/AiProvider.cs
@@ -1,0 +1,8 @@
+namespace MentalMetal.Domain.Users;
+
+public enum AiProvider
+{
+    Anthropic,
+    OpenAI,
+    Google
+}

--- a/src/MentalMetal.Domain/Users/AiProviderConfig.cs
+++ b/src/MentalMetal.Domain/Users/AiProviderConfig.cs
@@ -1,0 +1,36 @@
+using MentalMetal.Domain.Common;
+
+namespace MentalMetal.Domain.Users;
+
+public sealed class AiProviderConfig : ValueObject
+{
+    public AiProvider Provider { get; }
+    public string EncryptedApiKey { get; }
+    public string Model { get; }
+    public int? MaxTokens { get; }
+
+    private AiProviderConfig()  // EF Core
+    {
+        EncryptedApiKey = null!;
+        Model = null!;
+    }
+
+    public AiProviderConfig(AiProvider provider, string encryptedApiKey, string model, int? maxTokens)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(encryptedApiKey, nameof(encryptedApiKey));
+        ArgumentException.ThrowIfNullOrWhiteSpace(model, nameof(model));
+
+        Provider = provider;
+        EncryptedApiKey = encryptedApiKey;
+        Model = model;
+        MaxTokens = maxTokens;
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Provider;
+        yield return EncryptedApiKey;
+        yield return Model;
+        yield return MaxTokens;
+    }
+}

--- a/src/MentalMetal.Domain/Users/User.cs
+++ b/src/MentalMetal.Domain/Users/User.cs
@@ -9,6 +9,7 @@ public sealed class User : AggregateRoot
     public string Name { get; private set; } = null!;
     public string? AvatarUrl { get; private set; }
     public UserPreferences Preferences { get; private set; } = null!;
+    public AiProviderConfig? AiProviderConfig { get; private set; }
     public string Timezone { get; private set; } = null!;
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset LastLoginAt { get; private set; }
@@ -62,6 +63,21 @@ public sealed class User : AggregateRoot
         Preferences = preferences;
 
         RaiseDomainEvent(new PreferencesUpdated(Id));
+    }
+
+    public void ConfigureAiProvider(AiProvider provider, string encryptedApiKey, string model, int? maxTokens = null)
+    {
+        AiProviderConfig = new AiProviderConfig(provider, encryptedApiKey, model, maxTokens);
+        RaiseDomainEvent(new AiProviderConfigured(Id, provider));
+    }
+
+    public void RemoveAiProvider()
+    {
+        if (AiProviderConfig is null)
+            return;
+
+        AiProviderConfig = null;
+        RaiseDomainEvent(new AiProviderRemoved(Id));
     }
 
     public void RecordLogin()

--- a/src/MentalMetal.Domain/Users/UserEvents.cs
+++ b/src/MentalMetal.Domain/Users/UserEvents.cs
@@ -16,3 +16,13 @@ public sealed record PreferencesUpdated(Guid UserId) : IDomainEvent
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record AiProviderConfigured(Guid UserId, AiProvider Provider) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record AiProviderRemoved(Guid UserId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/tests/MentalMetal.Application.Tests/Users/ConfigureAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/ConfigureAiProviderTests.cs
@@ -1,0 +1,67 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class ConfigureAiProviderTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly IApiKeyEncryptionService _encryptionService = Substitute.For<IApiKeyEncryptionService>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly ConfigureAiProviderHandler _handler;
+
+    public ConfigureAiProviderTests()
+    {
+        _handler = new ConfigureAiProviderHandler(
+            _userRepository, _currentUserService, _encryptionService, _unitOfWork);
+    }
+
+    [Fact]
+    public async Task ValidRequest_EncryptsKeyAndConfigures()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _encryptionService.Encrypt("sk-ant-plainkey").Returns("encrypted_value");
+
+        var request = new ConfigureAiProviderRequest("Anthropic", "sk-ant-plainkey", "claude-sonnet-4-20250514", null);
+
+        await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.NotNull(user.AiProviderConfig);
+        Assert.Equal(AiProvider.Anthropic, user.AiProviderConfig.Provider);
+        Assert.Equal("encrypted_value", user.AiProviderConfig.EncryptedApiKey);
+        Assert.Equal("claude-sonnet-4-20250514", user.AiProviderConfig.Model);
+        _encryptionService.Received(1).Encrypt("sk-ant-plainkey");
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvalidProvider_ThrowsArgumentException()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var request = new ConfigureAiProviderRequest("InvalidProvider", "key", "model", null);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _handler.HandleAsync(request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UserNotFound_ThrowsInvalidOperationException()
+    {
+        _currentUserService.UserId.Returns(Guid.NewGuid());
+        _userRepository.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var request = new ConfigureAiProviderRequest("Anthropic", "key", "model", null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.HandleAsync(request, CancellationToken.None));
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/ConfigureAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/ConfigureAiProviderTests.cs
@@ -41,6 +41,21 @@ public class ConfigureAiProviderTests
     }
 
     [Fact]
+    public async Task CaseInsensitiveProvider_Works()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _encryptionService.Encrypt(Arg.Any<string>()).Returns("encrypted");
+
+        var request = new ConfigureAiProviderRequest("anthropic", "key", "model", null);
+
+        await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.Equal(AiProvider.Anthropic, user.AiProviderConfig!.Provider);
+    }
+
+    [Fact]
     public async Task InvalidProvider_ThrowsArgumentException()
     {
         var user = User.Register("auth-123", "test@example.com", "Name", null);

--- a/tests/MentalMetal.Application.Tests/Users/GetAiProviderStatusTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/GetAiProviderStatusTests.cs
@@ -1,0 +1,56 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class GetAiProviderStatusTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly ITasteBudgetService _tasteBudgetService = Substitute.For<ITasteBudgetService>();
+    private readonly GetAiProviderStatusHandler _handler;
+
+    public GetAiProviderStatusTests()
+    {
+        _handler = new GetAiProviderStatusHandler(_userRepository, _currentUserService, _tasteBudgetService);
+        _tasteBudgetService.DailyLimit.Returns(5);
+        _tasteBudgetService.IsEnabled.Returns(true);
+    }
+
+    [Fact]
+    public async Task ConfiguredUser_ReturnsProviderDetails()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key", "claude-sonnet-4-20250514", 4096);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _tasteBudgetService.GetRemainingAsync(user.Id, Arg.Any<CancellationToken>()).Returns(5);
+
+        var result = await _handler.HandleAsync(CancellationToken.None);
+
+        Assert.True(result.IsConfigured);
+        Assert.Equal("Anthropic", result.Provider);
+        Assert.Equal("claude-sonnet-4-20250514", result.Model);
+        Assert.Equal(4096, result.MaxTokens);
+    }
+
+    [Fact]
+    public async Task UnconfiguredUser_ReturnsNotConfiguredWithTasteBudget()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _tasteBudgetService.GetRemainingAsync(user.Id, Arg.Any<CancellationToken>()).Returns(3);
+
+        var result = await _handler.HandleAsync(CancellationToken.None);
+
+        Assert.False(result.IsConfigured);
+        Assert.Null(result.Provider);
+        Assert.Null(result.Model);
+        Assert.Equal(3, result.TasteBudget.Remaining);
+        Assert.Equal(5, result.TasteBudget.DailyLimit);
+        Assert.True(result.TasteBudget.IsEnabled);
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/GetAvailableModelsTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/GetAvailableModelsTests.cs
@@ -1,0 +1,50 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class GetAvailableModelsTests
+{
+    private readonly IAiModelCatalog _modelCatalog = Substitute.For<IAiModelCatalog>();
+    private readonly GetAvailableModelsHandler _handler;
+
+    public GetAvailableModelsTests()
+    {
+        _handler = new GetAvailableModelsHandler(_modelCatalog);
+    }
+
+    [Fact]
+    public void ValidProvider_ReturnsModels()
+    {
+        var models = new List<AiModelInfo>
+        {
+            new("claude-sonnet-4-20250514", "Claude Sonnet 4", true),
+            new("claude-haiku-4-5", "Claude Haiku 4.5", false)
+        };
+        _modelCatalog.GetModels(AiProvider.Anthropic).Returns(models);
+
+        var result = _handler.Handle("Anthropic");
+
+        Assert.Equal("Anthropic", result.Provider);
+        Assert.Equal(2, result.Models.Count);
+        Assert.True(result.Models[0].IsDefault);
+    }
+
+    [Fact]
+    public void InvalidProvider_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _handler.Handle("InvalidProvider"));
+    }
+
+    [Fact]
+    public void CaseInsensitiveProvider_Works()
+    {
+        _modelCatalog.GetModels(AiProvider.OpenAI).Returns(new List<AiModelInfo>());
+
+        var result = _handler.Handle("openai");
+
+        Assert.Equal("OpenAI", result.Provider);
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/RemoveAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/RemoveAiProviderTests.cs
@@ -1,0 +1,46 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class RemoveAiProviderTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly RemoveAiProviderHandler _handler;
+
+    public RemoveAiProviderTests()
+    {
+        _handler = new RemoveAiProviderHandler(_userRepository, _currentUserService, _unitOfWork);
+    }
+
+    [Fact]
+    public async Task ConfiguredUser_RemovesAndPersists()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key", "model", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        await _handler.HandleAsync(CancellationToken.None);
+
+        Assert.Null(user.AiProviderConfig);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnconfiguredUser_StillPersists()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        _currentUserService.UserId.Returns(user.Id);
+        _userRepository.GetByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        await _handler.HandleAsync(CancellationToken.None);
+
+        Assert.Null(user.AiProviderConfig);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
@@ -31,16 +31,16 @@ public class ValidateAiProviderTests
     }
 
     [Fact]
-    public async Task InvalidKey_ReturnsFailure()
+    public async Task InvalidKey_ReturnsSanitizedError()
     {
         _validator.ValidateAsync(AiProvider.Anthropic, "bad-key", "model", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new AiProviderException(AiProvider.Anthropic, 401, "Invalid API key"));
+            .ThrowsAsync(new AiProviderException(AiProvider.Anthropic, 401, "raw internal error details"));
 
         var request = new ValidateAiProviderRequest("Anthropic", "bad-key", "model");
         var result = await _handler.HandleAsync(request, CancellationToken.None);
 
         Assert.False(result.Success);
-        Assert.Equal("Invalid API key", result.Error);
+        Assert.Equal("Invalid API key. Please check your key and try again.", result.Error);
     }
 
     [Fact]

--- a/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
@@ -1,0 +1,55 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class ValidateAiProviderTests
+{
+    private readonly IAiProviderValidator _validator = Substitute.For<IAiProviderValidator>();
+    private readonly ValidateAiProviderHandler _handler;
+
+    public ValidateAiProviderTests()
+    {
+        _handler = new ValidateAiProviderHandler(_validator);
+    }
+
+    [Fact]
+    public async Task ValidKey_ReturnsSuccess()
+    {
+        _validator.ValidateAsync(AiProvider.Anthropic, "sk-key", "claude-sonnet-4-20250514", Arg.Any<CancellationToken>())
+            .Returns("claude-sonnet-4-20250514");
+
+        var request = new ValidateAiProviderRequest("Anthropic", "sk-key", "claude-sonnet-4-20250514");
+        var result = await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("claude-sonnet-4-20250514", result.ModelName);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task InvalidKey_ReturnsFailure()
+    {
+        _validator.ValidateAsync(AiProvider.Anthropic, "bad-key", "model", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new AiProviderException(AiProvider.Anthropic, 401, "Invalid API key"));
+
+        var request = new ValidateAiProviderRequest("Anthropic", "bad-key", "model");
+        var result = await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal("Invalid API key", result.Error);
+    }
+
+    [Fact]
+    public async Task InvalidProvider_ReturnsFailure()
+    {
+        var request = new ValidateAiProviderRequest("InvalidProvider", "key", "model");
+        var result = await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Unsupported provider", result.Error);
+    }
+}

--- a/tests/MentalMetal.Domain.Tests/Users/AiProviderConfigTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/AiProviderConfigTests.cs
@@ -43,6 +43,16 @@ public class AiProviderConfigTests
             new AiProviderConfig(AiProvider.Anthropic, "enc_key", model!, null));
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_ZeroOrNegativeMaxTokens_Allowed(int maxTokens)
+    {
+        // Domain doesn't enforce MaxTokens range — provider APIs will reject invalid values
+        var config = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model", maxTokens);
+        Assert.Equal(maxTokens, config.MaxTokens);
+    }
+
     [Fact]
     public void Equality_SameValues_AreEqual()
     {

--- a/tests/MentalMetal.Domain.Tests/Users/AiProviderConfigTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/AiProviderConfigTests.cs
@@ -1,0 +1,72 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Domain.Tests.Users;
+
+public class AiProviderConfigTests
+{
+    [Fact]
+    public void Create_ValidInput_SetsProperties()
+    {
+        var config = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "claude-sonnet-4-20250514", 4096);
+
+        Assert.Equal(AiProvider.Anthropic, config.Provider);
+        Assert.Equal("enc_key", config.EncryptedApiKey);
+        Assert.Equal("claude-sonnet-4-20250514", config.Model);
+        Assert.Equal(4096, config.MaxTokens);
+    }
+
+    [Fact]
+    public void Create_NullMaxTokens_Allowed()
+    {
+        var config = new AiProviderConfig(AiProvider.OpenAI, "enc_key", "gpt-4o", null);
+
+        Assert.Null(config.MaxTokens);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Create_EmptyApiKey_Throws(string? key)
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            new AiProviderConfig(AiProvider.Anthropic, key!, "model", null));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Create_EmptyModel_Throws(string? model)
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            new AiProviderConfig(AiProvider.Anthropic, "enc_key", model!, null));
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var a = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model", 4096);
+        var b = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model", 4096);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Equality_DifferentProvider_AreNotEqual()
+    {
+        var a = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model", null);
+        var b = new AiProviderConfig(AiProvider.OpenAI, "enc_key", "model", null);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Equality_DifferentModel_AreNotEqual()
+    {
+        var a = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model-a", null);
+        var b = new AiProviderConfig(AiProvider.Anthropic, "enc_key", "model-b", null);
+
+        Assert.NotEqual(a, b);
+    }
+}

--- a/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
@@ -159,6 +159,10 @@ public class UserTests
 
         Assert.Equal(AiProvider.OpenAI, user.AiProviderConfig!.Provider);
         Assert.Equal("gpt-4o", user.AiProviderConfig.Model);
+
+        var domainEvent = Assert.Single(user.DomainEvents);
+        var configured = Assert.IsType<AiProviderConfigured>(domainEvent);
+        Assert.Equal(AiProvider.OpenAI, configured.Provider);
     }
 
     [Theory]

--- a/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
@@ -123,6 +123,95 @@ public class UserTests
     }
 
     [Fact]
+    public void Register_HasNullAiProviderConfig()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        Assert.Null(user.AiProviderConfig);
+    }
+
+    [Fact]
+    public void ConfigureAiProvider_SetsConfigAndRaisesEvent()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ClearDomainEvents();
+
+        user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key", "claude-sonnet-4-20250514", 4096);
+
+        Assert.NotNull(user.AiProviderConfig);
+        Assert.Equal(AiProvider.Anthropic, user.AiProviderConfig.Provider);
+        Assert.Equal("claude-sonnet-4-20250514", user.AiProviderConfig.Model);
+
+        var domainEvent = Assert.Single(user.DomainEvents);
+        var configured = Assert.IsType<AiProviderConfigured>(domainEvent);
+        Assert.Equal(user.Id, configured.UserId);
+        Assert.Equal(AiProvider.Anthropic, configured.Provider);
+    }
+
+    [Fact]
+    public void ConfigureAiProvider_ReplacesExistingConfig()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key_1", "claude-sonnet-4-20250514", null);
+        user.ClearDomainEvents();
+
+        user.ConfigureAiProvider(AiProvider.OpenAI, "enc_key_2", "gpt-4o", null);
+
+        Assert.Equal(AiProvider.OpenAI, user.AiProviderConfig!.Provider);
+        Assert.Equal("gpt-4o", user.AiProviderConfig.Model);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void ConfigureAiProvider_EmptyKey_Throws(string? key)
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        Assert.ThrowsAny<ArgumentException>(() =>
+            user.ConfigureAiProvider(AiProvider.Anthropic, key!, "model", null));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void ConfigureAiProvider_EmptyModel_Throws(string? model)
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        Assert.ThrowsAny<ArgumentException>(() =>
+            user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key", model!, null));
+    }
+
+    [Fact]
+    public void RemoveAiProvider_ClearsConfigAndRaisesEvent()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ConfigureAiProvider(AiProvider.Anthropic, "enc_key", "model", null);
+        user.ClearDomainEvents();
+
+        user.RemoveAiProvider();
+
+        Assert.Null(user.AiProviderConfig);
+        var domainEvent = Assert.Single(user.DomainEvents);
+        Assert.IsType<AiProviderRemoved>(domainEvent);
+    }
+
+    [Fact]
+    public void RemoveAiProvider_WhenNull_IsIdempotent()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+        user.ClearDomainEvents();
+
+        user.RemoveAiProvider();
+
+        Assert.Null(user.AiProviderConfig);
+        Assert.Empty(user.DomainEvents);
+    }
+
+    [Fact]
     public void RecordLogin_UpdatesLastLoginAt()
     {
         var user = User.Register("auth-123", "test@example.com", "Name", null);


### PR DESCRIPTION
## Summary

Implements the domain and application layers for BYO AI provider configuration (Tier 1 foundation). Users can configure their preferred AI provider (Anthropic, OpenAI, Google) with encrypted API key storage. Includes a "taste" system design where new users get 5 free AI operations/day via an app-managed key before setting up their own.

This is the first PR in the `ai-provider-abstraction` spec — domain model, application handlers/interfaces, and all tests. Infrastructure (encryption, provider adapters, EF migrations) and frontend will follow.

## Changes

**Domain:**
- `AiProvider` enum (Anthropic, OpenAI, Google)
- `AiProviderConfig` value object (Provider, EncryptedApiKey, Model, MaxTokens)
- `User.ConfigureAiProvider()` and `User.RemoveAiProvider()` actions with domain events
- 22 new domain tests

**Application:**
- `IAiCompletionService`, `IApiKeyEncryptionService`, `ITasteBudgetService`, `IAiModelCatalog`, `IAiProviderValidator` interfaces
- `AiCompletionRequest/Result`, `AiProviderException`, `TasteLimitExceededException`
- Handlers: ConfigureAiProvider, GetAiProviderStatus, ValidateAiProvider, RemoveAiProvider, GetAvailableModels
- DTOs for all endpoints
- 13 new application tests

**OpenSpec artifacts:**
- Proposal, design, specs, and tasks for the full AI provider abstraction change
- Covers taste key system, nudge framework, model fallback chains, config-driven catalog

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (78 tests)
- [x] `ng test --watch=false` passes (1 test)
- [ ] Infrastructure layer implementation (next PR)
- [ ] Frontend settings UI (next PR)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce domain and application support for per-user AI provider configuration, including core interfaces, handlers, and specifications for a future BYO-key and taste-key AI system.

New Features:
- Add AiProvider enum and AiProviderConfig value object to represent a user's selected AI provider, encrypted API key, and model settings on the User aggregate.
- Expose User actions to configure or remove an AI provider and emit corresponding domain events for audit and integration purposes.
- Introduce application-layer DTOs, interfaces, and handlers for configuring AI providers, querying status and taste budget, validating keys, and listing available models.
- Define application-level abstractions for AI completion, API key encryption, provider validation, model catalog lookup, and per-user taste-budget tracking.

Enhancements:
- Extend existing user tests and add new domain and application tests to cover AI provider configuration workflows, validation, and model catalog querying.
- Document the AI provider abstraction via OpenSpec proposal, design, specs, and task breakdown to guide subsequent infrastructure and frontend work.

Build:
- Set ASPNETCORE_ENVIRONMENT to Production for EF database migrations in the staging deployment workflow.

Documentation:
- Add OpenSpec documentation detailing requirements, design decisions, and tasks for the AI provider abstraction, taste-key system, and related UX nudges.

Tests:
- Add dedicated tests for AiProviderConfig behavior and equality, and for new application handlers managing AI provider configuration, status retrieval, validation, model listing, and removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can configure and manage their own AI provider (Anthropic, OpenAI, Google) in settings.
  * Added credential validation/test-connection and available-model selection.
  * Introduced a daily free "taste" budget with remaining-count display and an option to add a personal provider key for unlimited use.
  * Added provider status view and the ability to remove configured provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->