### PR TITLE
feat: AI provider infrastructure — adapters, encryption, taste budget, endpoints

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -168,17 +168,29 @@ If CI fails:
    ```
 3. Diagnose and fix the issue
 4. Re-run Step 2 (tests) locally before pushing
-5. Push fixes and restart the monitoring loop
+5. Push fixes — this counts as a new push, so **reset the monitoring loop** (go to Step 5a with a fresh 20-minute budget)
 
 ### 5b. Monitor for Reviews
 
-Poll for reviewer comments every 2 minutes, for up to 5 cycles (10 minutes total). If all comments have been addressed after a cycle, stop polling and proceed:
+Poll for reviewer comments every 2 minutes, for up to 10 cycles (20 minutes total). Check for **both** new comments **and** unresolved review threads:
 
 ```bash
+# Inline review comments
 gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/comments --jq '.[] | "[\(.user.login)] \(.path) L\(.line // "?"): \(.body[0:300])"'
+# Review summaries
 gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews --jq '.[] | "[\(.user.login)] \(.state): \(.body[0:300])"'
+# Issue-level comments
 gh api repos/{owner}/{repo}/issues/$PR_NUMBER/comments --jq '.[] | "[\(.user.login)] \(.body[0:300])"'
+# Unresolved threads (the authoritative signal for "are we done?")
+gh api graphql -f query='{ repository(owner: "{owner}", name: "{repo}") { pullRequest(number: '$PR_NUMBER') { reviewThreads(first: 50) { nodes { isResolved } } } } }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
 ```
+
+**The loop is not done until ALL of these are true:**
+1. CI checks are passing (not pending, not failed)
+2. Zero unresolved review threads
+3. No new reviews have arrived in the last polling cycle
+
+If all three conditions are met for two consecutive cycles, proceed. Otherwise keep polling.
 
 ### 5c. Address Review Comments
 
@@ -188,17 +200,18 @@ For each review comment:
 2. Evaluate whether the feedback is valid and actionable
 3. If valid: make the code change
 4. If by-design or out-of-scope: reply with a clear explanation of why
+5. React with 👀 on the comment and resolve the thread after addressing it
 
 **Batch fixes:** Collect all comments from a review round, fix them all, then commit and push once. Each push triggers new review cycles from bots.
 
-### 5d. Push Fixes and Re-Monitor
+### 5d. Push Fixes and Re-Monitor — **RESET THE LOOP**
 
 After addressing all comments:
 
 1. Re-run Step 2 (tests)
 2. Commit all fixes in a single commit with a message like: "Address review feedback: <summary>"
 3. Push to the remote branch
-4. Restart the review monitoring loop from Step 5a — wait for reviewers to review the latest commit
+4. **IMPORTANT: Every push triggers new bot review cycles.** Reset the monitoring loop timer to zero and restart from Step 5a with a fresh 20-minute budget. Do NOT carry over time from the previous loop — the push invalidates all prior "all clear" signals
 
 ---
 
@@ -226,4 +239,5 @@ The review loop stops when one of these conditions is met:
 | PR already exists for branch | Update the existing PR body instead of creating a duplicate. |
 | No OpenSpec spec found | Omit the Spec line from the PR body. Proceed normally. |
 | CI fails after PR creation | Read logs, fix issues, push fixes, re-monitor. |
-| Review polling timeout (10 min) | If no unaddressed comments remain, proceed. Otherwise ask the user whether to keep waiting. |
+| Review polling timeout (20 min) | If no unaddressed comments and zero unresolved threads remain for 2 consecutive cycles, proceed. Otherwise ask the user whether to keep waiting. |
+| Push after fixing review comments | **Reset the 20-minute monitoring loop to zero.** Every push triggers new bot reviews — prior "all clear" signals are invalid. |

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -239,5 +239,5 @@ The review loop stops when one of these conditions is met:
 | PR already exists for branch | Update the existing PR body instead of creating a duplicate. |
 | No OpenSpec spec found | Omit the Spec line from the PR body. Proceed normally. |
 | CI fails after PR creation | Read logs, fix issues, push fixes, re-monitor. |
-| Review polling timeout (20 min) | If no unaddressed comments and zero unresolved threads remain for 2 consecutive cycles, proceed. Otherwise ask the user whether to keep waiting. |
+| Review polling timeout (20 min) | If CI is passing, zero unresolved threads, and no new reviews arrived in the last cycle — for 2 consecutive cycles — proceed. Otherwise ask the user whether to keep waiting. |
 | Push after fixing review comments | **Reset the 20-minute monitoring loop to zero.** Every push triggers new bot reviews — prior "all clear" signals are invalid. |

--- a/openspec/changes/byo-provider-config/tasks.md
+++ b/openspec/changes/byo-provider-config/tasks.md
@@ -41,47 +41,47 @@
 
 ## 6. Infrastructure — Encryption
 
-- [ ] 6.1 Create `AesApiKeyEncryptionService` implementing `IApiKeyEncryptionService` (AES-256-GCM, Base64 nonce:ciphertext:tag format)
-- [ ] 6.2 Add `AiProviderSettings` options class with EncryptionKey, TasteKey config, and per-provider model config (DefaultModel, FallbackModels)
-- [ ] 6.3 Add startup validation — fail fast if `AiProvider:EncryptionKey` is missing (taste key is optional — disabled if not set)
-- [ ] 6.4 Register encryption service in DI
+- [x] 6.1 Create `AesApiKeyEncryptionService` implementing `IApiKeyEncryptionService` (AES-256-GCM, Base64 nonce:ciphertext:tag format)
+- [x] 6.2 Add `AiProviderSettings` options class with EncryptionKey, TasteKey config, and per-provider model config (DefaultModel, FallbackModels)
+- [x] 6.3 Add startup validation — fail fast if `AiProvider:EncryptionKey` is missing (taste key is optional — disabled if not set)
+- [x] 6.4 Register encryption service in DI
 
 ## 7. Infrastructure — Provider Adapters and Completion Service
 
-- [ ] 7.1 Add NuGet packages: Anthropic SDK, OpenAI SDK
-- [ ] 7.2 Create internal `IAiProviderAdapter` interface (CompleteAsync with decrypted key, model, request)
-- [ ] 7.3 Implement `AnthropicAdapter` using Anthropic .NET SDK
-- [ ] 7.4 Implement `OpenAiAdapter` using OpenAI .NET SDK
-- [ ] 7.5 Implement `GoogleAdapter` using HttpClient with Gemini REST API
-- [ ] 7.6 Create `AiCompletionService` implementing `IAiCompletionService` — resolves current user's config or taste key, decrypts key, dispatches to correct adapter, implements model fallback chain (retry on model-not-found only)
-- [ ] 7.7 Register AI services in DI
+- [x] 7.1 Add NuGet packages: Anthropic SDK, OpenAI SDK
+- [x] 7.2 Create internal `IAiProviderAdapter` interface (CompleteAsync with decrypted key, model, request)
+- [x] 7.3 Implement `AnthropicAdapter` using Anthropic .NET SDK
+- [x] 7.4 Implement `OpenAiAdapter` using OpenAI .NET SDK
+- [x] 7.5 Implement `GoogleAdapter` using HttpClient with Gemini REST API
+- [x] 7.6 Create `AiCompletionService` implementing `IAiCompletionService` — resolves current user's config or taste key, decrypts key, dispatches to correct adapter, implements model fallback chain (retry on model-not-found only)
+- [x] 7.7 Register AI services in DI
 
 ## 8. Infrastructure — Taste Budget Tracking
 
-- [ ] 8.1 Create `AiTasteBudget` entity (UserId, Date, OperationsUsed) — infrastructure concern, not a domain entity
-- [ ] 8.2 Create `AiTasteBudgetConfiguration` EF Core config
-- [ ] 8.3 Create `ITasteBudgetService` interface and implementation — check/decrement budget, per-user per-day
-- [ ] 8.4 Register taste budget service in DI
+- [x] 8.1 Create `AiTasteBudget` entity (UserId, Date, OperationsUsed) — infrastructure concern, not a domain entity
+- [x] 8.2 Create `AiTasteBudgetConfiguration` EF Core config
+- [x] 8.3 Create `ITasteBudgetService` interface and implementation — check/decrement budget, per-user per-day
+- [x] 8.4 Register taste budget service in DI
 
 ## 9. Infrastructure — Persistence
 
-- [ ] 9.1 Add `AiProviderConfig` owned entity configuration to `UserConfiguration` (OwnsOne with encrypted key column)
-- [ ] 9.2 Create EF Core migration for AiProviderConfig columns on Users table and AiTasteBudgets table
-- [ ] 9.3 Add `hasAiProvider` to `GetCurrentUser` response DTO
+- [x] 9.1 Add `AiProviderConfig` owned entity configuration to `UserConfiguration` (OwnsOne with encrypted key column)
+- [x] 9.2 Create EF Core migration for AiProviderConfig columns on Users table and AiTasteBudgets table
+- [x] 9.3 Add `hasAiProvider` to `GetCurrentUser` response DTO
 
 ## 10. Web Layer — API Endpoints
 
-- [ ] 10.1 Map `PUT /api/users/me/ai-provider` — configure provider (encrypt key, save)
-- [ ] 10.2 Map `GET /api/users/me/ai-provider` — get provider status and taste budget
-- [ ] 10.3 Map `POST /api/users/me/ai-provider/validate` — validate key/model via test completion
-- [ ] 10.4 Map `DELETE /api/users/me/ai-provider` — remove provider config
-- [ ] 10.5 Map `GET /api/ai/models?provider={provider}` — list available models from config
-- [ ] 10.6 Register new application handlers in DI
+- [x] 10.1 Map `PUT /api/users/me/ai-provider` — configure provider (encrypt key, save)
+- [x] 10.2 Map `GET /api/users/me/ai-provider` — get provider status and taste budget
+- [x] 10.3 Map `POST /api/users/me/ai-provider/validate` — validate key/model via test completion
+- [x] 10.4 Map `DELETE /api/users/me/ai-provider` — remove provider config
+- [x] 10.5 Map `GET /api/ai/models?provider={provider}` — list available models from config
+- [x] 10.6 Register new application handlers in DI
 
 ## 11. Configuration and Documentation
 
-- [ ] 11.1 Add AI provider configuration section to `appsettings.json` (encryption key, taste key, per-provider model defaults and fallbacks)
-- [ ] 11.2 Add AI provider configuration section to `appsettings.Development.json` with development defaults
+- [x] 11.1 Add AI provider configuration section to `appsettings.json` (encryption key, taste key, per-provider model defaults and fallbacks)
+- [x] 11.2 Add AI provider configuration section to `appsettings.Development.json` with development defaults
 - [ ] 11.3 Document AI provider configuration in README (encryption key, taste key setup, model config, environment variables)
 
 ## 12. Frontend — AI Provider Settings

--- a/src/MentalMetal.Application/Users/GetCurrentUser.cs
+++ b/src/MentalMetal.Application/Users/GetCurrentUser.cs
@@ -22,6 +22,7 @@ public sealed class GetCurrentUserHandler(
                 user.Preferences.Theme.ToString(),
                 user.Preferences.NotificationsEnabled,
                 user.Preferences.BriefingTime),
+            user.AiProviderConfig is not null,
             user.CreatedAt,
             user.LastLoginAt);
     }

--- a/src/MentalMetal.Application/Users/UserDtos.cs
+++ b/src/MentalMetal.Application/Users/UserDtos.cs
@@ -7,6 +7,7 @@ public sealed record UserProfileResponse(
     string? AvatarUrl,
     string Timezone,
     UserPreferencesDto Preferences,
+    bool HasAiProvider,
     DateTimeOffset CreatedAt,
     DateTimeOffset LastLoginAt);
 

--- a/src/MentalMetal.Infrastructure/Ai/AesApiKeyEncryptionService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AesApiKeyEncryptionService.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using MentalMetal.Application.Common.Ai;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AesApiKeyEncryptionService(IOptions<AiProviderSettings> settings) : IApiKeyEncryptionService
+{
+    private readonly byte[] _key = Convert.FromBase64String(settings.Value.EncryptionKey);
+
+    public string Encrypt(string plaintext)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(plaintext, nameof(plaintext));
+
+        var nonce = new byte[AesGcm.NonceByteSizes.MaxSize]; // 12 bytes
+        RandomNumberGenerator.Fill(nonce);
+
+        var plaintextBytes = System.Text.Encoding.UTF8.GetBytes(plaintext);
+        var ciphertext = new byte[plaintextBytes.Length];
+        var tag = new byte[AesGcm.TagByteSizes.MaxSize]; // 16 bytes
+
+        using var aes = new AesGcm(_key, tag.Length);
+        aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
+
+        // Format: base64(nonce):base64(ciphertext):base64(tag)
+        return $"{Convert.ToBase64String(nonce)}:{Convert.ToBase64String(ciphertext)}:{Convert.ToBase64String(tag)}";
+    }
+
+    public string Decrypt(string encrypted)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(encrypted, nameof(encrypted));
+
+        var parts = encrypted.Split(':');
+        if (parts.Length != 3)
+            throw new FormatException("Invalid encrypted key format. Expected nonce:ciphertext:tag.");
+
+        var nonce = Convert.FromBase64String(parts[0]);
+        var ciphertext = Convert.FromBase64String(parts[1]);
+        var tag = Convert.FromBase64String(parts[2]);
+
+        var plaintext = new byte[ciphertext.Length];
+
+        using var aes = new AesGcm(_key, tag.Length);
+        aes.Decrypt(nonce, ciphertext, tag, plaintext);
+
+        return System.Text.Encoding.UTF8.GetString(plaintext);
+    }
+}

--- a/src/MentalMetal.Infrastructure/Ai/AesApiKeyEncryptionService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AesApiKeyEncryptionService.cs
@@ -6,7 +6,27 @@ namespace MentalMetal.Infrastructure.Ai;
 
 public sealed class AesApiKeyEncryptionService(IOptions<AiProviderSettings> settings) : IApiKeyEncryptionService
 {
-    private readonly byte[] _key = Convert.FromBase64String(settings.Value.EncryptionKey);
+    private readonly byte[] _key = ValidateKey(settings.Value.EncryptionKey);
+
+    private static byte[] ValidateKey(string base64Key)
+    {
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(base64Key);
+        }
+        catch (FormatException)
+        {
+            throw new InvalidOperationException(
+                "AiProvider:EncryptionKey is not valid Base64. Generate a 32-byte key: openssl rand -base64 32");
+        }
+
+        if (key.Length != 32)
+            throw new InvalidOperationException(
+                $"AiProvider:EncryptionKey must be exactly 32 bytes (AES-256). Got {key.Length} bytes. Generate with: openssl rand -base64 32");
+
+        return key;
+    }
 
     public string Encrypt(string plaintext)
     {

--- a/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
@@ -1,0 +1,105 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AiCompletionService(
+    ICurrentUserService currentUserService,
+    IUserRepository userRepository,
+    IApiKeyEncryptionService encryptionService,
+    ITasteBudgetService tasteBudgetService,
+    AiModelCatalog modelCatalog,
+    AnthropicAdapter anthropicAdapter,
+    OpenAiAdapter openAiAdapter,
+    GoogleAdapter googleAdapter,
+    IOptions<AiProviderSettings> settings,
+    ILogger<AiCompletionService> logger) : IAiCompletionService
+{
+    private readonly AiProviderSettings _settings = settings.Value;
+
+    public async Task<AiCompletionResult> CompleteAsync(
+        AiCompletionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(
+            currentUserService.UserId, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticated user not found.");
+
+        var (apiKey, provider, model, isTaste) = await ResolveConfigAsync(user, cancellationToken);
+
+        var adapter = GetAdapter(provider);
+        var fallbackModels = modelCatalog.GetFallbackModels(provider);
+
+        // Try primary model, then fallbacks on model-not-found
+        var modelsToTry = new List<string> { model };
+        modelsToTry.AddRange(fallbackModels.Where(m => m != model));
+
+        foreach (var candidateModel in modelsToTry)
+        {
+            try
+            {
+                var result = await adapter.CompleteAsync(apiKey, candidateModel, request, cancellationToken);
+
+                if (candidateModel != model)
+                    logger.LogWarning("Model fallback: {OriginalModel} -> {FallbackModel} for provider {Provider}",
+                        model, candidateModel, provider);
+
+                if (isTaste)
+                    await tasteBudgetService.DecrementAsync(user.Id, cancellationToken);
+
+                return result;
+            }
+            catch (AiProviderException ex) when (ex.StatusCode == 404 && candidateModel != modelsToTry[^1])
+            {
+                logger.LogWarning("Model {Model} not found for {Provider}, trying fallback",
+                    candidateModel, provider);
+                continue;
+            }
+        }
+
+        // Should not reach here — last model throws without catch
+        throw new AiProviderException(provider, null, "All configured models are unavailable.");
+    }
+
+    private async Task<(string ApiKey, AiProvider Provider, string Model, bool IsTaste)> ResolveConfigAsync(
+        User user, CancellationToken cancellationToken)
+    {
+        var config = user.AiProviderConfig;
+
+        if (config is not null)
+        {
+            var apiKey = encryptionService.Decrypt(config.EncryptedApiKey);
+            return (apiKey, config.Provider, config.Model, false);
+        }
+
+        // Fall back to taste key
+        if (_settings.TasteKey is null)
+            throw new InvalidOperationException(
+                "AI provider is not configured. Please set up your AI provider in settings.");
+
+        if (!tasteBudgetService.IsEnabled)
+            throw new InvalidOperationException(
+                "AI provider is not configured. Please set up your AI provider in settings.");
+
+        var remaining = await tasteBudgetService.GetRemainingAsync(user.Id, cancellationToken);
+        if (remaining <= 0)
+            throw new TasteLimitExceededException();
+
+        if (!Enum.TryParse<AiProvider>(_settings.TasteKey.Provider, ignoreCase: true, out var tasteProvider))
+            throw new InvalidOperationException($"Invalid taste key provider: {_settings.TasteKey.Provider}");
+
+        var tasteModel = modelCatalog.GetDefaultModel(tasteProvider);
+
+        return (_settings.TasteKey.ApiKey, tasteProvider, tasteModel, true);
+    }
+
+    private IAiProviderAdapter GetAdapter(AiProvider provider) => provider switch
+    {
+        AiProvider.Anthropic => anthropicAdapter,
+        AiProvider.OpenAI => openAiAdapter,
+        AiProvider.Google => googleAdapter,
+        _ => throw new ArgumentOutOfRangeException(nameof(provider))
+    };
+}

--- a/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
@@ -55,11 +55,11 @@ public sealed class AiCompletionService(
             {
                 logger.LogWarning("Model {Model} not found for {Provider}, trying fallback",
                     candidateModel, provider);
-                continue;
             }
         }
 
-        // Should not reach here — last model throws without catch
+        // Unreachable in practice — the last model attempt throws without the catch filter matching.
+        // Required by the compiler since foreach doesn't guarantee iteration.
         throw new AiProviderException(provider, null, "All configured models are unavailable.");
     }
 

--- a/src/MentalMetal.Infrastructure/Ai/AiModelCatalog.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiModelCatalog.cs
@@ -1,0 +1,53 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AiModelCatalog(IOptions<AiProviderSettings> settings) : IAiModelCatalog
+{
+    private readonly AiProviderSettings _settings = settings.Value;
+
+    public IReadOnlyList<AiModelInfo> GetModels(AiProvider provider)
+    {
+        var providerName = provider.ToString();
+        if (!_settings.Providers.TryGetValue(providerName, out var providerSettings))
+            return [];
+
+        var defaultModel = providerSettings.DefaultModel;
+        var models = new List<AiModelInfo>
+        {
+            new(defaultModel, FormatModelName(defaultModel), true)
+        };
+
+        foreach (var fallback in providerSettings.FallbackModels)
+        {
+            models.Add(new AiModelInfo(fallback, FormatModelName(fallback), false));
+        }
+
+        return models;
+    }
+
+    public string GetDefaultModel(AiProvider provider)
+    {
+        var providerName = provider.ToString();
+        return _settings.Providers.TryGetValue(providerName, out var providerSettings)
+            ? providerSettings.DefaultModel
+            : throw new InvalidOperationException($"No model configuration for provider: {providerName}");
+    }
+
+    internal IReadOnlyList<string> GetFallbackModels(AiProvider provider)
+    {
+        var providerName = provider.ToString();
+        return _settings.Providers.TryGetValue(providerName, out var providerSettings)
+            ? providerSettings.FallbackModels
+            : [];
+    }
+
+    private static string FormatModelName(string modelId)
+    {
+        // Convert "claude-sonnet-4-20250514" to "Claude Sonnet 4 20250514" etc.
+        return string.Join(' ', modelId.Split('-').Select(p =>
+            p.Length > 0 ? char.ToUpper(p[0]) + p[1..] : p));
+    }
+}

--- a/src/MentalMetal.Infrastructure/Ai/AiModelCatalog.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiModelCatalog.cs
@@ -48,6 +48,6 @@ public sealed class AiModelCatalog(IOptions<AiProviderSettings> settings) : IAiM
     {
         // Convert "claude-sonnet-4-20250514" to "Claude Sonnet 4 20250514" etc.
         return string.Join(' ', modelId.Split('-').Select(p =>
-            p.Length > 0 ? char.ToUpper(p[0]) + p[1..] : p));
+            p.Length > 0 ? char.ToUpperInvariant(p[0]) + p[1..] : p));
     }
 }

--- a/src/MentalMetal.Infrastructure/Ai/AiProviderSettings.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiProviderSettings.cs
@@ -1,0 +1,25 @@
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AiProviderSettings
+{
+    public const string SectionName = "AiProvider";
+
+    public string EncryptionKey { get; set; } = null!;
+
+    public TasteKeySettings? TasteKey { get; set; }
+
+    public Dictionary<string, ProviderModelSettings> Providers { get; set; } = new();
+}
+
+public sealed class TasteKeySettings
+{
+    public string Provider { get; set; } = null!;
+    public string ApiKey { get; set; } = null!;
+    public int DailyLimitPerUser { get; set; } = 5;
+}
+
+public sealed class ProviderModelSettings
+{
+    public string DefaultModel { get; set; } = null!;
+    public List<string> FallbackModels { get; set; } = [];
+}

--- a/src/MentalMetal.Infrastructure/Ai/AiProviderValidator.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiProviderValidator.cs
@@ -1,0 +1,35 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AiProviderValidator(
+    AnthropicAdapter anthropicAdapter,
+    OpenAiAdapter openAiAdapter,
+    GoogleAdapter googleAdapter) : IAiProviderValidator
+{
+    public async Task<string> ValidateAsync(
+        AiProvider provider,
+        string apiKey,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        var adapter = GetAdapter(provider);
+
+        var testRequest = new AiCompletionRequest(
+            SystemPrompt: "You are a test. Respond with exactly: OK",
+            UserPrompt: "Test connection.",
+            MaxTokens: 10);
+
+        var result = await adapter.CompleteAsync(apiKey, model, testRequest, cancellationToken);
+        return result.Model;
+    }
+
+    private IAiProviderAdapter GetAdapter(AiProvider provider) => provider switch
+    {
+        AiProvider.Anthropic => anthropicAdapter,
+        AiProvider.OpenAI => openAiAdapter,
+        AiProvider.Google => googleAdapter,
+        _ => throw new ArgumentOutOfRangeException(nameof(provider))
+    };
+}

--- a/src/MentalMetal.Infrastructure/Ai/AiTasteBudget.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiTasteBudget.cs
@@ -1,0 +1,9 @@
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AiTasteBudget
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public DateOnly Date { get; set; }
+    public int OperationsUsed { get; set; }
+}

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -33,8 +33,13 @@ public sealed class AnthropicAdapter : IAiProviderAdapter
                 temperature: request.Temperature.HasValue ? (double)request.Temperature.Value : null,
                 cancellationToken: cancellationToken);
 
-            var firstBlock = response.Content.FirstOrDefault();
-            var text = firstBlock.IsText ? firstBlock.Text.Text : "";
+            var text = "";
+            if (response.Content.Count > 0)
+            {
+                var firstBlock = response.Content[0];
+                if (firstBlock.IsText)
+                    text = firstBlock.Text.Text;
+            }
 
             return new AiCompletionResult(
                 Content: text,

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -45,7 +45,7 @@ public sealed class AnthropicAdapter : IAiProviderAdapter
                 Content: text,
                 InputTokens: response.Usage.InputTokens,
                 OutputTokens: response.Usage.OutputTokens,
-                Model: response.Model.ToString(),
+                Model: response.Model?.ToString() ?? model,
                 Provider: AiProvider.Anthropic);
         }
         catch (ApiException ex)

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -45,7 +45,7 @@ public sealed class AnthropicAdapter : IAiProviderAdapter
                 Content: text,
                 InputTokens: response.Usage.InputTokens,
                 OutputTokens: response.Usage.OutputTokens,
-                Model: response.Model?.ToString() ?? model,
+                Model: response.Model.ToString() ?? model,
                 Provider: AiProvider.Anthropic);
         }
         catch (ApiException ex)

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -1,0 +1,54 @@
+using Anthropic;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class AnthropicAdapter : IAiProviderAdapter
+{
+    public async Task<AiCompletionResult> CompleteAsync(
+        string apiKey,
+        string model,
+        AiCompletionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var client = new AnthropicClient(apiKey: apiKey);
+
+        var messages = new List<InputMessage>
+        {
+            new()
+            {
+                Role = InputMessageRole.User,
+                Content = request.UserPrompt
+            }
+        };
+
+        try
+        {
+            var response = await client.Messages.MessagesPostAsync(
+                model: model,
+                messages: messages,
+                maxTokens: request.MaxTokens ?? 1024,
+                system: request.SystemPrompt,
+                temperature: request.Temperature.HasValue ? (double)request.Temperature.Value : null,
+                cancellationToken: cancellationToken);
+
+            var firstBlock = response.Content.FirstOrDefault();
+            var text = firstBlock.IsText ? firstBlock.Text.Text : "";
+
+            return new AiCompletionResult(
+                Content: text,
+                InputTokens: response.Usage.InputTokens,
+                OutputTokens: response.Usage.OutputTokens,
+                Model: response.Model.ToString(),
+                Provider: AiProvider.Anthropic);
+        }
+        catch (ApiException ex)
+        {
+            throw new AiProviderException(
+                AiProvider.Anthropic,
+                (int)ex.StatusCode,
+                $"Anthropic API error: {ex.Message}");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
@@ -6,7 +6,7 @@ using MentalMetal.Domain.Users;
 
 namespace MentalMetal.Infrastructure.Ai;
 
-public sealed class GoogleAdapter : IAiProviderAdapter
+public sealed class GoogleAdapter(IHttpClientFactory httpClientFactory) : IAiProviderAdapter
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -20,7 +20,7 @@ public sealed class GoogleAdapter : IAiProviderAdapter
         AiCompletionRequest request,
         CancellationToken cancellationToken)
     {
-        using var httpClient = new HttpClient();
+        using var httpClient = httpClientFactory.CreateClient("GoogleAi");
         httpClient.DefaultRequestHeaders.Add("x-goog-api-key", apiKey);
         var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent";
 

--- a/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
@@ -22,7 +22,7 @@ public sealed class GoogleAdapter(IHttpClientFactory httpClientFactory) : IAiPro
     {
         var httpClient = httpClientFactory.CreateClient("GoogleAi");
         httpClient.DefaultRequestHeaders.Add("x-goog-api-key", apiKey);
-        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent";
+        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{Uri.EscapeDataString(model)}:generateContent";
 
         var body = new GeminiRequest
         {

--- a/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
@@ -1,0 +1,114 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class GoogleAdapter : IAiProviderAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public async Task<AiCompletionResult> CompleteAsync(
+        string apiKey,
+        string model,
+        AiCompletionRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var httpClient = new HttpClient();
+        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={apiKey}";
+
+        var body = new GeminiRequest
+        {
+            SystemInstruction = new GeminiContent
+            {
+                Parts = [new GeminiPart { Text = request.SystemPrompt }]
+            },
+            Contents =
+            [
+                new GeminiContent
+                {
+                    Role = "user",
+                    Parts = [new GeminiPart { Text = request.UserPrompt }]
+                }
+            ],
+            GenerationConfig = new GeminiGenerationConfig
+            {
+                MaxOutputTokens = request.MaxTokens,
+                Temperature = request.Temperature
+            }
+        };
+
+        var response = await httpClient.PostAsJsonAsync(url, body, JsonOptions, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new AiProviderException(
+                AiProvider.Google,
+                (int)response.StatusCode,
+                $"Gemini API error ({response.StatusCode}): {errorBody}");
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<GeminiResponse>(JsonOptions, cancellationToken)
+            ?? throw new AiProviderException(AiProvider.Google, null, "Empty response from Gemini API.");
+
+        var text = result.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text ?? "";
+        var inputTokens = result.UsageMetadata?.PromptTokenCount ?? 0;
+        var outputTokens = result.UsageMetadata?.CandidatesTokenCount ?? 0;
+
+        return new AiCompletionResult(
+            Content: text,
+            InputTokens: inputTokens,
+            OutputTokens: outputTokens,
+            Model: model,
+            Provider: AiProvider.Google);
+    }
+
+    // Gemini API request/response models
+    private sealed class GeminiRequest
+    {
+        public GeminiContent? SystemInstruction { get; set; }
+        public List<GeminiContent> Contents { get; set; } = [];
+        public GeminiGenerationConfig? GenerationConfig { get; set; }
+    }
+
+    private sealed class GeminiContent
+    {
+        public string? Role { get; set; }
+        public List<GeminiPart> Parts { get; set; } = [];
+    }
+
+    private sealed class GeminiPart
+    {
+        public string? Text { get; set; }
+    }
+
+    private sealed class GeminiGenerationConfig
+    {
+        public int? MaxOutputTokens { get; set; }
+        public float? Temperature { get; set; }
+    }
+
+    private sealed class GeminiResponse
+    {
+        public List<GeminiCandidate>? Candidates { get; set; }
+        public GeminiUsageMetadata? UsageMetadata { get; set; }
+    }
+
+    private sealed class GeminiCandidate
+    {
+        public GeminiContent? Content { get; set; }
+    }
+
+    private sealed class GeminiUsageMetadata
+    {
+        public int PromptTokenCount { get; set; }
+        public int CandidatesTokenCount { get; set; }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
@@ -21,7 +21,8 @@ public sealed class GoogleAdapter : IAiProviderAdapter
         CancellationToken cancellationToken)
     {
         using var httpClient = new HttpClient();
-        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={apiKey}";
+        httpClient.DefaultRequestHeaders.Add("x-goog-api-key", apiKey);
+        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent";
 
         var body = new GeminiRequest
         {

--- a/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/GoogleAdapter.cs
@@ -20,7 +20,7 @@ public sealed class GoogleAdapter(IHttpClientFactory httpClientFactory) : IAiPro
         AiCompletionRequest request,
         CancellationToken cancellationToken)
     {
-        using var httpClient = httpClientFactory.CreateClient("GoogleAi");
+        var httpClient = httpClientFactory.CreateClient("GoogleAi");
         httpClient.DefaultRequestHeaders.Add("x-goog-api-key", apiKey);
         var url = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent";
 

--- a/src/MentalMetal.Infrastructure/Ai/IAiProviderAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/IAiProviderAdapter.cs
@@ -1,0 +1,12 @@
+using MentalMetal.Application.Common.Ai;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public interface IAiProviderAdapter
+{
+    Task<AiCompletionResult> CompleteAsync(
+        string apiKey,
+        string model,
+        AiCompletionRequest request,
+        CancellationToken cancellationToken);
+}

--- a/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
@@ -1,0 +1,49 @@
+using System.ClientModel;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Users;
+using OpenAI.Chat;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class OpenAiAdapter : IAiProviderAdapter
+{
+    public async Task<AiCompletionResult> CompleteAsync(
+        string apiKey,
+        string model,
+        AiCompletionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var client = new ChatClient(model, apiKey);
+
+        var messages = new List<ChatMessage>
+        {
+            ChatMessage.CreateSystemMessage(request.SystemPrompt),
+            ChatMessage.CreateUserMessage(request.UserPrompt)
+        };
+
+        var options = new ChatCompletionOptions();
+        if (request.MaxTokens.HasValue)
+            options.MaxOutputTokenCount = request.MaxTokens.Value;
+        if (request.Temperature.HasValue)
+            options.Temperature = request.Temperature.Value;
+
+        try
+        {
+            var response = await client.CompleteChatAsync(messages, options, cancellationToken);
+
+            return new AiCompletionResult(
+                Content: response.Value.Content[0].Text,
+                InputTokens: response.Value.Usage.InputTokenCount,
+                OutputTokens: response.Value.Usage.OutputTokenCount,
+                Model: response.Value.Model ?? model,
+                Provider: AiProvider.OpenAI);
+        }
+        catch (ClientResultException ex)
+        {
+            throw new AiProviderException(
+                AiProvider.OpenAI,
+                ex.Status,
+                $"OpenAI API error: {ex.Message}");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
@@ -31,8 +31,12 @@ public sealed class OpenAiAdapter : IAiProviderAdapter
         {
             var response = await client.CompleteChatAsync(messages, options, cancellationToken);
 
+            var content = response.Value.Content.Count > 0
+                ? response.Value.Content[0].Text
+                : "";
+
             return new AiCompletionResult(
-                Content: response.Value.Content[0].Text,
+                Content: content,
                 InputTokens: response.Value.Usage.InputTokenCount,
                 OutputTokens: response.Value.Usage.OutputTokenCount,
                 Model: response.Value.Model ?? model,

--- a/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
@@ -33,22 +33,14 @@ public sealed class TasteBudgetService(
             return;
 
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        var budget = await dbContext.AiTasteBudgets
-            .FirstOrDefaultAsync(b => b.UserId == userId && b.Date == today, cancellationToken);
 
-        if (budget is null)
-        {
-            budget = new AiTasteBudget
-            {
-                Id = Guid.NewGuid(),
-                UserId = userId,
-                Date = today,
-                OperationsUsed = 0
-            };
-            dbContext.AiTasteBudgets.Add(budget);
-        }
-
-        budget.OperationsUsed++;
-        await dbContext.SaveChangesAsync(cancellationToken);
+        // Upsert: insert or increment, conflict-safe against the unique (UserId, Date) index
+        await dbContext.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            INSERT INTO "AiTasteBudgets" ("Id", "UserId", "Date", "OperationsUsed")
+            VALUES ({Guid.NewGuid()}, {userId}, {today}, 1)
+            ON CONFLICT ("UserId", "Date")
+            DO UPDATE SET "OperationsUsed" = "AiTasteBudgets"."OperationsUsed" + 1
+            """, cancellationToken);
     }
 }

--- a/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
@@ -24,7 +24,7 @@ public sealed class TasteBudgetService(
         var budget = await dbContext.AiTasteBudgets
             .FirstOrDefaultAsync(b => b.UserId == userId && b.Date == today, cancellationToken);
 
-        return DailyLimit - (budget?.OperationsUsed ?? 0);
+        return Math.Max(0, DailyLimit - (budget?.OperationsUsed ?? 0));
     }
 
     public async Task DecrementAsync(Guid userId, CancellationToken cancellationToken)
@@ -49,5 +49,6 @@ public sealed class TasteBudgetService(
         }
 
         budget.OperationsUsed++;
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/TasteBudgetService.cs
@@ -1,0 +1,53 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+public sealed class TasteBudgetService(
+    MentalMetalDbContext dbContext,
+    IOptions<AiProviderSettings> settings) : ITasteBudgetService
+{
+    private readonly TasteKeySettings? _tasteSettings = settings.Value.TasteKey;
+
+    public int DailyLimit => _tasteSettings?.DailyLimitPerUser ?? 5;
+
+    public bool IsEnabled => _tasteSettings is not null;
+
+    public async Task<int> GetRemainingAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        if (!IsEnabled)
+            return 0;
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var budget = await dbContext.AiTasteBudgets
+            .FirstOrDefaultAsync(b => b.UserId == userId && b.Date == today, cancellationToken);
+
+        return DailyLimit - (budget?.OperationsUsed ?? 0);
+    }
+
+    public async Task DecrementAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        if (!IsEnabled)
+            return;
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var budget = await dbContext.AiTasteBudgets
+            .FirstOrDefaultAsync(b => b.UserId == userId && b.Date == today, cancellationToken);
+
+        if (budget is null)
+        {
+            budget = new AiTasteBudget
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Date = today,
+                OperationsUsed = 0
+            };
+            dbContext.AiTasteBudgets.Add(budget);
+        }
+
+        budget.OperationsUsed++;
+    }
+}

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -27,7 +27,11 @@ public static class DependencyInjection
             options.UseNpgsql(connectionString));
 
         services.Configure<JwtSettings>(configuration.GetSection(JwtSettings.SectionName));
-        services.Configure<AiProviderSettings>(configuration.GetSection(AiProviderSettings.SectionName));
+        services.AddOptions<AiProviderSettings>()
+            .Bind(configuration.GetSection(AiProviderSettings.SectionName))
+            .Validate(s => !string.IsNullOrWhiteSpace(s.EncryptionKey),
+                "AiProvider:EncryptionKey is required. Generate with: openssl rand -base64 32")
+            .ValidateOnStart();
 
         // Infrastructure services
         services.AddHttpContextAccessor();

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -41,6 +41,7 @@ public static class DependencyInjection
         services.AddScoped<ITokenService, TokenService>();
 
         // AI provider services
+        services.AddHttpClient("GoogleAi");
         services.AddSingleton<IApiKeyEncryptionService, AesApiKeyEncryptionService>();
         services.AddSingleton<AiModelCatalog>();
         services.AddSingleton<IAiModelCatalog>(sp => sp.GetRequiredService<AiModelCatalog>());

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
 using MentalMetal.Application.Common.Auth;
 using MentalMetal.Application.Users;
 using MentalMetal.Domain.Users;
+using MentalMetal.Infrastructure.Ai;
 using MentalMetal.Infrastructure.Auth;
 using MentalMetal.Infrastructure.Persistence;
 using MentalMetal.Infrastructure.Repositories;
@@ -25,6 +27,7 @@ public static class DependencyInjection
             options.UseNpgsql(connectionString));
 
         services.Configure<JwtSettings>(configuration.GetSection(JwtSettings.SectionName));
+        services.Configure<AiProviderSettings>(configuration.GetSection(AiProviderSettings.SectionName));
 
         // Infrastructure services
         services.AddHttpContextAccessor();
@@ -33,6 +36,17 @@ public static class DependencyInjection
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<ITokenService, TokenService>();
 
+        // AI provider services
+        services.AddSingleton<IApiKeyEncryptionService, AesApiKeyEncryptionService>();
+        services.AddSingleton<AiModelCatalog>();
+        services.AddSingleton<IAiModelCatalog>(sp => sp.GetRequiredService<AiModelCatalog>());
+        services.AddSingleton<AnthropicAdapter>();
+        services.AddSingleton<OpenAiAdapter>();
+        services.AddSingleton<GoogleAdapter>();
+        services.AddScoped<IAiCompletionService, AiCompletionService>();
+        services.AddScoped<IAiProviderValidator, AiProviderValidator>();
+        services.AddScoped<ITasteBudgetService, TasteBudgetService>();
+
         // Application handlers
         services.AddScoped<RegisterOrLoginUserHandler>();
         services.AddScoped<GetCurrentUserHandler>();
@@ -40,6 +54,11 @@ public static class DependencyInjection
         services.AddScoped<UpdateUserPreferencesHandler>();
         services.AddScoped<RefreshAccessTokenHandler>();
         services.AddScoped<LogoutUserHandler>();
+        services.AddScoped<ConfigureAiProviderHandler>();
+        services.AddScoped<GetAiProviderStatusHandler>();
+        services.AddScoped<ValidateAiProviderHandler>();
+        services.AddScoped<RemoveAiProviderHandler>();
+        services.AddSingleton<GetAvailableModelsHandler>();
 
         return services;
     }

--- a/src/MentalMetal.Infrastructure/MentalMetal.Infrastructure.csproj
+++ b/src/MentalMetal.Infrastructure/MentalMetal.Infrastructure.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Anthropic" Version="3.5.0" />
+    <PackageReference Include="OpenAI" Version="2.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 

--- a/src/MentalMetal.Infrastructure/Migrations/20260406111851_AddAiProviderConfig.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260406111851_AddAiProviderConfig.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406111851_AddAiProviderConfig")]
+    partial class AddAiProviderConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260406111851_AddAiProviderConfig.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260406111851_AddAiProviderConfig.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAiProviderConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AiProviderEncryptedApiKey",
+                table: "Users",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AiProviderMaxTokens",
+                table: "Users",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AiProviderModel",
+                table: "Users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AiProviderProvider",
+                table: "Users",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "AiTasteBudgets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    OperationsUsed = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AiTasteBudgets", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AiTasteBudgets_UserId_Date",
+                table: "AiTasteBudgets",
+                columns: new[] { "UserId", "Date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AiTasteBudgets");
+
+            migrationBuilder.DropColumn(
+                name: "AiProviderEncryptedApiKey",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "AiProviderMaxTokens",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "AiProviderModel",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "AiProviderProvider",
+                table: "Users");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Migrations/20260406114447_AddAiProviderConfig.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260406114447_AddAiProviderConfig.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    [Migration("20260406111851_AddAiProviderConfig")]
+    [Migration("20260406114447_AddAiProviderConfig")]
     partial class AddAiProviderConfig
     {
         /// <inheritdoc />
@@ -212,6 +212,15 @@ namespace MentalMetal.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("Preferences")
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("MentalMetal.Infrastructure.Ai.AiTasteBudget", b =>
+                {
+                    b.HasOne("MentalMetal.Domain.Users.User", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 #pragma warning restore 612, 618

--- a/src/MentalMetal.Infrastructure/Migrations/20260406114447_AddAiProviderConfig.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260406114447_AddAiProviderConfig.cs
@@ -50,6 +50,12 @@ namespace MentalMetal.Infrastructure.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_AiTasteBudgets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AiTasteBudgets_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(

--- a/src/MentalMetal.Infrastructure/Migrations/MentalMetalDbContextModelSnapshot.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/MentalMetalDbContextModelSnapshot.cs
@@ -211,6 +211,15 @@ namespace MentalMetal.Infrastructure.Migrations
                     b.Navigation("Preferences")
                         .IsRequired();
                 });
+
+            modelBuilder.Entity("MentalMetal.Infrastructure.Ai.AiTasteBudget", b =>
+                {
+                    b.HasOne("MentalMetal.Domain.Users.User", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/AiTasteBudgetConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/AiTasteBudgetConfiguration.cs
@@ -1,0 +1,21 @@
+using MentalMetal.Infrastructure.Ai;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MentalMetal.Infrastructure.Persistence.Configurations;
+
+public sealed class AiTasteBudgetConfiguration : IEntityTypeConfiguration<AiTasteBudget>
+{
+    public void Configure(EntityTypeBuilder<AiTasteBudget> builder)
+    {
+        builder.ToTable("AiTasteBudgets");
+
+        builder.HasKey(b => b.Id);
+
+        builder.HasIndex(b => new { b.UserId, b.Date })
+            .IsUnique();
+
+        builder.Property(b => b.Date);
+        builder.Property(b => b.OperationsUsed);
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/AiTasteBudgetConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/AiTasteBudgetConfiguration.cs
@@ -1,3 +1,4 @@
+using MentalMetal.Domain.Users;
 using MentalMetal.Infrastructure.Ai;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -11,6 +12,11 @@ public sealed class AiTasteBudgetConfiguration : IEntityTypeConfiguration<AiTast
         builder.ToTable("AiTasteBudgets");
 
         builder.HasKey(b => b.Id);
+
+        builder.HasOne<User>()
+            .WithMany()
+            .HasForeignKey(b => b.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(b => new { b.UserId, b.Date })
             .IsUnique();

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -51,6 +51,25 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
                 .HasColumnName("PreferencesBriefingTime");
         });
 
+        builder.OwnsOne(u => u.AiProviderConfig, ai =>
+        {
+            ai.Property(a => a.Provider)
+                .HasColumnName("AiProviderProvider")
+                .HasConversion<string>()
+                .HasMaxLength(20);
+
+            ai.Property(a => a.EncryptedApiKey)
+                .HasColumnName("AiProviderEncryptedApiKey")
+                .HasMaxLength(1024);
+
+            ai.Property(a => a.Model)
+                .HasColumnName("AiProviderModel")
+                .HasMaxLength(100);
+
+            ai.Property(a => a.MaxTokens)
+                .HasColumnName("AiProviderMaxTokens");
+        });
+
         builder.Property(u => u.Timezone)
             .IsRequired()
             .HasMaxLength(100);

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -60,10 +60,12 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
 
             ai.Property(a => a.EncryptedApiKey)
                 .HasColumnName("AiProviderEncryptedApiKey")
+                .IsRequired()
                 .HasMaxLength(1024);
 
             ai.Property(a => a.Model)
                 .HasColumnName("AiProviderModel")
+                .IsRequired()
                 .HasMaxLength(100);
 
             ai.Property(a => a.MaxTokens)

--- a/src/MentalMetal.Infrastructure/Persistence/MentalMetalDbContext.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/MentalMetalDbContext.cs
@@ -1,5 +1,6 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Users;
+using MentalMetal.Infrastructure.Ai;
 using MentalMetal.Infrastructure.Auth;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,7 @@ public sealed class MentalMetalDbContext(
 {
     public DbSet<User> Users => Set<User>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<AiTasteBudget> AiTasteBudgets => Set<AiTasteBudget>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text;
+using MentalMetal.Application.Common.Ai;
 using MentalMetal.Application.Users;
 using MentalMetal.Infrastructure;
 using MentalMetal.Infrastructure.Auth;
@@ -57,6 +58,24 @@ app.UseStaticFiles();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.Use(async (context, next) =>
+{
+    try
+    {
+        await next();
+    }
+    catch (TasteLimitExceededException ex)
+    {
+        context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+    }
+    catch (AiProviderException ex)
+    {
+        context.Response.StatusCode = StatusCodes.Status502BadGateway;
+        await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+    }
+});
 
 // --- Auth Endpoints ---
 

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -72,8 +72,10 @@ app.Use(async (context, next) =>
     }
     catch (AiProviderException ex) when (!context.Response.HasStarted)
     {
+        var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("AiErrorMiddleware");
+        logger.LogWarning(ex, "AI provider error from {Provider}", ex.Provider);
         context.Response.StatusCode = StatusCodes.Status502BadGateway;
-        await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+        await context.Response.WriteAsJsonAsync(new { error = "AI provider request failed. Please try again or check your provider configuration." });
     }
 });
 

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -174,6 +174,57 @@ app.MapPut("/api/users/me/preferences", async (
     return Results.NoContent();
 }).RequireAuthorization();
 
+// --- AI Provider Endpoints ---
+
+app.MapGet("/api/users/me/ai-provider", async (
+    GetAiProviderStatusHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var status = await handler.HandleAsync(cancellationToken);
+    return Results.Ok(status);
+}).RequireAuthorization();
+
+app.MapPut("/api/users/me/ai-provider", async (
+    ConfigureAiProviderRequest request,
+    ConfigureAiProviderHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    await handler.HandleAsync(request, cancellationToken);
+    return Results.NoContent();
+}).RequireAuthorization();
+
+app.MapPost("/api/users/me/ai-provider/validate", async (
+    ValidateAiProviderRequest request,
+    ValidateAiProviderHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var result = await handler.HandleAsync(request, cancellationToken);
+    return Results.Ok(result);
+}).RequireAuthorization();
+
+app.MapDelete("/api/users/me/ai-provider", async (
+    RemoveAiProviderHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    await handler.HandleAsync(cancellationToken);
+    return Results.NoContent();
+}).RequireAuthorization();
+
+app.MapGet("/api/ai/models", (
+    string provider,
+    GetAvailableModelsHandler handler) =>
+{
+    try
+    {
+        var result = handler.Handle(provider);
+        return Results.Ok(result);
+    }
+    catch (ArgumentException)
+    {
+        return Results.BadRequest(new { error = $"Unsupported provider: {provider}" });
+    }
+});
+
 app.MapGet("/api/health", () => Results.Ok(new { status = "healthy" }));
 
 // Return 404 for unmatched /api requests instead of serving the SPA shell.

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -65,12 +65,12 @@ app.Use(async (context, next) =>
     {
         await next();
     }
-    catch (TasteLimitExceededException ex)
+    catch (TasteLimitExceededException ex) when (!context.Response.HasStarted)
     {
         context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
         await context.Response.WriteAsJsonAsync(new { error = ex.Message });
     }
-    catch (AiProviderException ex)
+    catch (AiProviderException ex) when (!context.Response.HasStarted)
     {
         context.Response.StatusCode = StatusCodes.Status502BadGateway;
         await context.Response.WriteAsJsonAsync(new { error = ex.Message });

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -223,7 +223,7 @@ app.MapGet("/api/ai/models", (
     {
         return Results.BadRequest(new { error = $"Unsupported provider: {provider}" });
     }
-});
+}).RequireAuthorization();
 
 app.MapGet("/api/health", () => Results.Ok(new { status = "healthy" }));
 

--- a/src/MentalMetal.Web/appsettings.Development.json
+++ b/src/MentalMetal.Web/appsettings.Development.json
@@ -15,6 +15,14 @@
     "AccessTokenExpiryMinutes": 15,
     "RefreshTokenExpiryDays": 7
   },
+  "AiProvider": {
+    "EncryptionKey": "dGhpcyBpcyBhIGRldiBvbmx5IGtleSBmb3IgdGVzdGluZyE=",
+    "TasteKey": {
+      "Provider": "Google",
+      "ApiKey": "your-google-ai-studio-api-key",
+      "DailyLimitPerUser": 5
+    }
+  },
   "Authentication": {
     "Google": {
       "ClientId": "your-google-client-id",

--- a/src/MentalMetal.Web/appsettings.Development.json
+++ b/src/MentalMetal.Web/appsettings.Development.json
@@ -16,7 +16,7 @@
     "RefreshTokenExpiryDays": 7
   },
   "AiProvider": {
-    "EncryptionKey": "dGhpcyBpcyBhIGRldiBvbmx5IGtleSBmb3IgdGVzdGluZyE=",
+    "EncryptionKey": "GSvlmYUjJvkRbbyE5OWzl/pivxUJBlZ6CdZhEK7pdQU=",
     "TasteKey": {
       "Provider": "Google",
       "ApiKey": "your-google-ai-studio-api-key",

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "AiProvider": {
-    "EncryptionKey": "OVERRIDE-VIA-ENV-VAR-AiProvider__EncryptionKey",
+    "EncryptionKey": "",
     "Providers": {
       "Anthropic": {
         "DefaultModel": "claude-sonnet-4-20250514",

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -6,6 +6,23 @@
     }
   },
   "AllowedHosts": "*",
+  "AiProvider": {
+    "EncryptionKey": "OVERRIDE-VIA-ENV-VAR-AiProvider__EncryptionKey",
+    "Providers": {
+      "Anthropic": {
+        "DefaultModel": "claude-sonnet-4-20250514",
+        "FallbackModels": ["claude-sonnet-4-6", "claude-haiku-4-5"]
+      },
+      "OpenAI": {
+        "DefaultModel": "gpt-4o",
+        "FallbackModels": ["gpt-4o-mini", "gpt-4.1-mini"]
+      },
+      "Google": {
+        "DefaultModel": "gemini-2.5-flash",
+        "FallbackModels": ["gemini-2.0-flash", "gemini-1.5-flash"]
+      }
+    }
+  },
   "Jwt": {
     "Secret": "OVERRIDE-VIA-ENV-VAR-Jwt__Secret-minimum-32-chars",
     "Issuer": "MentalMetal",


### PR DESCRIPTION
## Summary

Implements the infrastructure and web layers for AI provider abstraction. This adds provider adapters (Anthropic, OpenAI, Google), AES-256-GCM API key encryption, taste budget tracking, model fallback chains, and all API endpoints. Builds on the domain/application layers from #48.

## Changes

**Infrastructure — Encryption:**
- `AesApiKeyEncryptionService` — AES-256-GCM with nonce:ciphertext:tag format
- `AiProviderSettings` options class (encryption key, taste key, per-provider model config)

**Infrastructure — Provider Adapters:**
- `AnthropicAdapter` — Anthropic .NET SDK
- `OpenAiAdapter` — OpenAI .NET SDK  
- `GoogleAdapter` — Gemini REST API via IHttpClientFactory
- `AiCompletionService` — resolves user config or taste key, model fallback chain
- `AiModelCatalog` — config-driven model list with defaults
- `AiProviderValidator` — lightweight test completion for key validation

**Infrastructure — Taste Budget:**
- `AiTasteBudget` entity + EF config (UserId, Date, OperationsUsed) with FK to Users
- `TasteBudgetService` — per-user per-day operation tracking with conflict-safe upsert

**Infrastructure — Persistence:**
- `AiProviderConfig` OwnsOne on UserConfiguration
- EF migration for AiProviderConfig columns + AiTasteBudgets table
- `hasAiProvider` added to user profile response

**Web — API Endpoints:**
- `PUT /api/users/me/ai-provider` — configure provider
- `GET /api/users/me/ai-provider` — get status + taste budget
- `POST /api/users/me/ai-provider/validate` — test key/model
- `DELETE /api/users/me/ai-provider` — remove config
- `GET /api/ai/models?provider={provider}` — list models

**Web — Error Handling:**
- Middleware for `TasteLimitExceededException` (429) and `AiProviderException` (502)

**Tooling:**
- Updated PR skill monitoring loop: reset 20-min timer after each push

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (81 tests)
- [x] Solution builds with no errors
- [ ] Frontend settings UI (next PR)
- [ ] E2E tests (next PR)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can configure personal AI providers (Anthropic, OpenAI, Google) with per-user API keys, validate them, remove them, and list available models.
  * Securely stored provider keys with model fallback and retry across provider models.
  * Optional "taste key" grants limited daily AI access with per-user budget and decrementing usage.

* **Behavior**
  * User profile now indicates whether an AI provider is configured.
  * API maps taste-limit to HTTP 429 and upstream provider failures to HTTP 502.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->