### PR TITLE
feat: AI provider frontend — settings, nudge framework, taste counter

### DIFF
--- a/openspec/changes/ai-provider-frontend/.openspec.yaml
+++ b/openspec/changes/ai-provider-frontend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/ai-provider-frontend/design.md
+++ b/openspec/changes/ai-provider-frontend/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The backend AI provider abstraction is fully implemented: REST endpoints for CRUD on provider config, API key validation, model catalog, taste budget tracking, and encryption at rest. The existing settings page has Profile and Preferences sections. This change adds the AI Provider configuration section and app-wide nudge framework, all frontend-only.
+
+Existing backend endpoints consumed:
+- `GET /api/users/me/ai-provider` — provider status + taste budget
+- `PUT /api/users/me/ai-provider` — configure provider (apiKey optional for updates)
+- `POST /api/users/me/ai-provider/validate` — test key+model
+- `DELETE /api/users/me/ai-provider` — remove provider
+- `GET /api/ai/models?provider={provider}` — available models per provider
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can configure, validate, and remove their AI provider from the settings page
+- Taste users see their remaining daily budget and contextual nudges to set up their own key
+- Nudge framework provides integration points for future AI-powered features
+
+**Non-Goals:**
+- Backend changes (all endpoints exist)
+- Building the AI-powered features themselves (capture, briefings, chat)
+- Provider usage analytics or billing
+
+## Dependencies
+
+- `user-auth-tenancy` — authentication, settings page, auth guard (complete)
+- `ai-provider-abstraction` — backend endpoints (complete)
+
+## Decisions
+
+### 1. AI Provider section on existing settings page (not a separate page)
+
+Add the AI Provider section as a third section on the existing settings page, below Profile and Preferences. This keeps all user configuration in one place and avoids route proliferation for a single form.
+
+*Alternative: Dedicated `/settings/ai` route* — rejected because the provider config is a single form, not complex enough to warrant its own page.
+
+### 2. AiProviderService as a standalone injectable service
+
+Create `AiProviderService` in `shared/services/` to encapsulate all provider API calls. The settings component consumes it. Future AI features will also inject this service for status checks.
+
+### 3. AiNudgeService derives state from provider status signal
+
+`AiNudgeService` exposes a `nudgeState` signal (Fresh/Tasting/Limited/Unlimited) computed from `AiProviderService.status()`. Components subscribe to the signal — no polling, updates reactively when status changes.
+
+*State derivation:*
+- `Unlimited` — `status.isConfigured === true`
+- `Limited` — `!isConfigured && tasteRemaining === 0`
+- `Tasting` — `!isConfigured && tasteRemaining > 0 && tasteRemaining < dailyLimit`
+- `Fresh` — `!isConfigured && tasteRemaining === dailyLimit` (never used taste)
+
+### 4. Provider cards use PrimeNG Card + RadioButton
+
+Each provider (Anthropic, OpenAI, Google) rendered as a PrimeNG Card with a radio button for selection. Selecting a card reveals the key input, model dropdown, and deep link. Uses `@switch` control flow (per CLAUDE.md).
+
+### 5. Auto-validate on key paste with debounce
+
+Use `input` event on the API key field with a 500ms debounce. When the user pastes or types a key, auto-call the validate endpoint with the selected provider and model. Show inline status (loading spinner → green check with model name, or red error).
+
+### 6. Nudge dismissal via localStorage with TTL
+
+Contextual (Tasting) nudges dismissed for 7 days per nudge type, stored in localStorage with a timestamp. Blocking (Limited) nudges are not permanently dismissible — only dismissed for the current action.
+
+### 7. Taste counter as a lightweight standalone component
+
+`TasteCounterComponent` is a standalone component showing "N of M free AI operations remaining today". Placed in AI-powered sections by future features. Visibility controlled by `AiNudgeService.nudgeState` — hidden for Unlimited users.
+
+## Risks / Trade-offs
+
+- **[Risk] Auto-validate fires on every keystroke** → Mitigated by 500ms debounce and requiring minimum key length before triggering
+- **[Risk] Nudge framework has no consumers yet** → Components are self-contained and inert until future features place them; no wasted overhead
+- **[Risk] Taste counter shows stale data if budget changes in another tab** → Acceptable for MVP; can add BroadcastChannel sync later
+- **[Trade-off] localStorage for nudge dismissal** → Simple but not synced across devices; acceptable since nudges are low-stakes UI hints
+
+## Open Questions
+
+None — all decisions are straightforward frontend patterns with existing backend support.

--- a/openspec/changes/ai-provider-frontend/proposal.md
+++ b/openspec/changes/ai-provider-frontend/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The backend AI provider abstraction is complete (endpoints, encryption, taste budget, model catalog) but users have no way to configure their own AI provider or see their taste budget status from the UI. Without the frontend, the entire AI capability is inaccessible to end users. This is the final piece needed before any AI-powered feature (capture extraction, briefings, AI chat) can be built.
+
+## What Changes
+
+- **AI Provider settings section** on the existing settings page — provider selection cards (Anthropic, OpenAI, Google), API key input with auto-validate on paste, model dropdown from config endpoint, save/remove flows, deep links to provider key creation pages
+- **AiProviderService** — Angular service for all AI provider API calls (configure, get status, validate, remove, get models)
+- **AiNudgeService** — derives nudge state (Fresh/Tasting/Limited/Unlimited) from provider status and taste budget
+- **Taste counter component** — subtle remaining-operations indicator for taste users
+- **Nudge components** — contextual (Tasting), blocking (Limited), and passive (Fresh) nudges for AI-powered sections
+- **E2E tests** — authenticated tests for AI provider configuration and model listing
+
+## Non-goals
+
+- **Backend changes** — all API endpoints already exist and are tested
+- **AI-powered features** — capture extraction, briefings, AI chat are separate specs; this provides the configuration layer they depend on
+- **Additional OAuth providers** — not in scope
+- **Admin/billing** — no provider usage billing or admin dashboards
+
+## Capabilities
+
+### New Capabilities
+<!-- None — all frontend requirements already exist in ai-provider-abstraction spec -->
+
+### Modified Capabilities
+- `ai-provider-abstraction`: No requirement changes — implementing existing frontend requirements (Frontend AI provider settings, AI setup nudge framework, Taste counter display)
+
+## Impact
+
+- **Frontend**: New `AiProviderService`, `AiNudgeService`, AI provider settings section on settings page, taste counter component, nudge components
+- **Settings page**: Extended with AI Provider configuration section below existing profile/preferences
+- **App-wide**: Nudge components will be placed in AI-powered sections (placeholder integration points for future features)
+- **No backend changes** — consuming existing endpoints only
+- **Affected aggregates**: None (frontend only)
+- **Tier**: Tier 1 (Foundation) — unblocks all Tier 2 AI features

--- a/openspec/changes/ai-provider-frontend/specs/ai-provider-abstraction/spec.md
+++ b/openspec/changes/ai-provider-frontend/specs/ai-provider-abstraction/spec.md
@@ -1,0 +1,5 @@
+<!-- No new or modified requirements — this change implements existing frontend requirements from the ai-provider-abstraction spec:
+     - Frontend AI provider settings
+     - AI setup nudge framework
+     - Taste counter display
+     All requirement definitions remain unchanged. -->

--- a/openspec/changes/ai-provider-frontend/tasks.md
+++ b/openspec/changes/ai-provider-frontend/tasks.md
@@ -1,0 +1,43 @@
+## 1. AI Provider Service and Models
+
+- [x] 1.1 Create AI provider TypeScript models: `AiProviderStatus`, `AiModelInfo`, `ConfigureAiProviderRequest`, `ValidateAiProviderRequest`, `ValidateAiProviderResponse`, `AvailableModelsResponse`
+- [x] 1.2 Create `AiProviderService` with methods: `getStatus()`, `configure()`, `validate()`, `remove()`, `getModels(provider)`
+- [x] 1.3 Add `status` signal to `AiProviderService` — loaded on init and refreshed after configure/remove
+
+## 2. AI Provider Settings Section
+
+- [x] 2.1 Create `AiProviderSettingsComponent` (standalone) with provider cards (Anthropic, OpenAI, Google) using PrimeNG Card + RadioButton
+- [x] 2.2 Add API key input (password-masked) with "Don't have one?" deep link per provider
+- [x] 2.3 Add model dropdown populated from `GET /api/ai/models?provider=` with default pre-selected
+- [x] 2.4 Implement auto-validate on key paste — debounce 500ms, show inline status (spinner → green check/red error)
+- [x] 2.5 Implement save flow — call `PUT /api/users/me/ai-provider`, show success toast, refresh status
+- [x] 2.6 Implement remove flow — confirmation dialog, call `DELETE`, refresh status, clear form
+- [x] 2.7 Pre-populate form when user has existing config (provider, model selected, API key placeholder)
+- [x] 2.8 Add `AiProviderSettingsComponent` to settings page below Preferences section
+
+## 3. AI Nudge Service
+
+- [x] 3.1 Create `AiNudgeService` with `nudgeState` signal computed from `AiProviderService.status` — derives Fresh/Tasting/Limited/Unlimited
+- [x] 3.2 Add nudge dismissal helpers using localStorage with 7-day TTL for contextual nudges
+
+## 4. Taste Counter Component
+
+- [x] 4.1 Create `TasteCounterComponent` (standalone) — displays "N of M free AI operations remaining today"
+- [x] 4.2 Visibility controlled by `AiNudgeService.nudgeState` — hidden for Unlimited users
+
+## 5. Nudge Components
+
+- [x] 5.1 Create `AiNudgeContextualComponent` — non-blocking "Add your own AI key for unlimited access" message, dismissible for 7 days
+- [x] 5.2 Create `AiNudgeLimitedComponent` — blocking prompt with "Set Up AI Provider" and "Continue tomorrow" actions
+- [x] 5.3 Create `AiNudgeFreshComponent` — passive "AI Provider: Not configured" indicator with settings link
+
+## 6. Frontend Tests
+
+- [x] 6.1 Unit test `AiNudgeService` — state derivation for all four states (Fresh/Tasting/Limited/Unlimited)
+- [x] 6.2 Unit test `AiProviderSettingsComponent` — provider selection, form population, validation display
+
+## 7. E2E Tests
+
+- [x] 7.1 E2E test: AI provider settings section visible on settings page for authenticated user
+- [x] 7.2 E2E test: GET /api/ai/models returns model list for valid provider
+- [x] 7.3 E2E test: GET /api/users/me/ai-provider returns isConfigured=false and taste budget for new user

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+import { AiProviderSettingsComponent } from './ai-provider-settings.component';
+
+describe('AiProviderSettingsComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AiProviderSettingsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create the component', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    // Flush the status load triggered by ngOnInit
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: false,
+      provider: null,
+      model: null,
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should load models when provider is selected', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: false,
+      provider: null,
+      model: null,
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    fixture.componentInstance.selectProvider('Anthropic');
+
+    const modelReq = httpMock.expectOne('/api/ai/models?provider=Anthropic');
+    modelReq.flush({
+      provider: 'Anthropic',
+      models: [
+        { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', isDefault: true },
+      ],
+    });
+
+    expect(fixture.componentInstance.models().length).toBe(1);
+  });
+
+  it('should pre-populate form when provider is configured', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: true,
+      provider: 'OpenAI',
+      model: 'gpt-4o',
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    // The component reads status synchronously after flush — but loadStatus is async.
+    // The status signal updates after the subscribe callback, so we need to trigger
+    // change detection again and handle the models request from selectProvider.
+    fixture.detectChanges();
+
+    // If the component auto-selects based on status, it will request models
+    const modelReqs = httpMock.match('/api/ai/models?provider=OpenAI');
+    modelReqs.forEach(req => req.flush({
+      provider: 'OpenAI',
+      models: [{ id: 'gpt-4o', name: 'GPT-4o', isDefault: true }],
+    }));
+
+    expect(fixture.componentInstance.selectedProvider()).toBe('OpenAI');
+    expect(fixture.componentInstance.isConfigured()).toBe(true);
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -8,7 +8,7 @@ import {
   DestroyRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Subject, debounceTime, switchMap, takeUntil } from 'rxjs';
+import { Subject, EMPTY, debounceTime, switchMap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -51,15 +51,13 @@ import {
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
         @for (provider of providers; track provider.name) {
           <p-card
-            [class]="selectedProvider() === provider.name ? 'border-2 border-primary' : 'border border-surface-200'"
-            class="cursor-pointer"
+            [class]="'cursor-pointer ' + (selectedProvider() === provider.name ? 'border-2 border-primary' : 'border border-surface-200')"
             (click)="selectProvider(provider.name)"
           >
             <div class="flex items-center gap-3">
               <p-radioButton
                 [value]="provider.name"
                 [(ngModel)]="selectedProviderModel"
-                (ngModelChange)="selectProvider($event)"
                 name="provider"
               />
               <i [class]="provider.icon + ' text-xl'"></i>
@@ -206,16 +204,17 @@ export class AiProviderSettingsComponent implements OnInit {
         switchMap(() => {
           const provider = this.selectedProvider();
           const model = this.selectedModel;
-          if (!provider || !this.apiKey || this.apiKey.length < 10) {
+          if (!provider || !this.apiKey || this.apiKey.length < 10 || !model) {
+            this.validating.set(false);
             this.validationResult.set(null);
             this.validationMessage.set(null);
-            return [];
+            return EMPTY;
           }
           this.validating.set(true);
           return this.aiProviderService.validate({
             provider,
             apiKey: this.apiKey,
-            model: model || 'default',
+            model,
           });
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -245,6 +244,7 @@ export class AiProviderSettingsComponent implements OnInit {
     this.selectedProviderOption.set(
       this.providers.find((p) => p.name === provider) ?? null,
     );
+    this.selectedModel = '';
     this.loadModels(provider);
     // Reset validation when provider changes
     this.validationResult.set(null);
@@ -329,7 +329,7 @@ export class AiProviderSettingsComponent implements OnInit {
     });
   }
 
-  private loadModels(provider: string): void {
+  private loadModels(provider: AiProviderType): void {
     this.loadingModels.set(true);
     this.aiProviderService.getModels(provider).subscribe({
       next: (response) => {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -259,7 +259,7 @@ export class AiProviderSettingsComponent implements OnInit {
     const provider = this.selectedProvider();
     const hasModel = !!this.selectedModel;
     const status = this.aiProviderService.status();
-    const sameProvider = status?.isConfigured && status.provider === provider;
+    const sameProvider = !!(status?.isConfigured && status.provider === provider);
     const hasKey = !!this.apiKey || sameProvider;
     return !!provider && hasModel && hasKey;
   }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -1,0 +1,357 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+  OnInit,
+  DestroyRef,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Subject, debounceTime, switchMap, takeUntil } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { SelectModule } from 'primeng/select';
+import { RadioButtonModule } from 'primeng/radiobutton';
+import { ToastModule } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { MessageService, ConfirmationService } from 'primeng/api';
+import { AiProviderService } from '../../shared/services/ai-provider.service';
+import {
+  AI_PROVIDERS,
+  AiModelInfo,
+  AiProviderType,
+  ProviderOption,
+} from '../../shared/models/ai-provider.model';
+
+@Component({
+  selector: 'app-ai-provider-settings',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FormsModule,
+    ButtonModule,
+    CardModule,
+    InputTextModule,
+    SelectModule,
+    RadioButtonModule,
+    ToastModule,
+    ConfirmDialogModule,
+    ProgressSpinnerModule,
+  ],
+  providers: [ConfirmationService],
+  template: `
+    <section class="flex flex-col gap-4">
+      <h2 class="text-xl font-semibold">AI Provider</h2>
+
+      <!-- Provider Selection Cards -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        @for (provider of providers; track provider.name) {
+          <p-card
+            [class]="selectedProvider() === provider.name ? 'border-2 border-primary' : 'border border-surface-200'"
+            class="cursor-pointer"
+            (click)="selectProvider(provider.name)"
+          >
+            <div class="flex items-center gap-3">
+              <p-radioButton
+                [value]="provider.name"
+                [(ngModel)]="selectedProviderModel"
+                (ngModelChange)="selectProvider($event)"
+                name="provider"
+              />
+              <i [class]="provider.icon + ' text-xl'"></i>
+              <span class="font-medium">{{ provider.label }}</span>
+            </div>
+          </p-card>
+        }
+      </div>
+
+      <!-- Configuration Form (visible when provider selected) -->
+      @if (selectedProvider()) {
+        <div class="flex flex-col gap-4 mt-2">
+          <!-- Deep link -->
+          @if (selectedProviderOption(); as opt) {
+            <a
+              [href]="opt.keyUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm text-primary hover:underline"
+            >
+              Don't have one? &rarr; {{ opt.keyUrlLabel }}
+            </a>
+          }
+
+          <!-- API Key Input -->
+          <div class="flex flex-col gap-2">
+            <label for="apiKey" class="text-sm font-medium text-muted-color">API Key</label>
+            <div class="flex items-center gap-2">
+              <input
+                pInputText
+                id="apiKey"
+                type="password"
+                [(ngModel)]="apiKey"
+                (input)="onApiKeyInput()"
+                [placeholder]="isConfigured() ? '••••••••••••••••' : 'Paste your API key'"
+                class="w-full"
+              />
+              @if (validating()) {
+                <p-progressSpinner
+                  [style]="{ width: '24px', height: '24px' }"
+                  strokeWidth="4"
+                />
+              }
+              @if (validationResult() === 'success') {
+                <i class="pi pi-check-circle text-primary text-xl"></i>
+              }
+              @if (validationResult() === 'error') {
+                <i class="pi pi-times-circle text-danger text-xl"></i>
+              }
+            </div>
+            @if (validationMessage()) {
+              <small [class]="validationResult() === 'success' ? 'text-primary' : 'text-danger'">
+                {{ validationMessage() }}
+              </small>
+            }
+          </div>
+
+          <!-- Model Dropdown -->
+          <div class="flex flex-col gap-2">
+            <label for="model" class="text-sm font-medium text-muted-color">Model</label>
+            <p-select
+              id="model"
+              [options]="models()"
+              optionLabel="name"
+              optionValue="id"
+              [(ngModel)]="selectedModel"
+              placeholder="Select model"
+              class="w-full"
+              [loading]="loadingModels()"
+            />
+          </div>
+
+          <!-- Action Buttons -->
+          <div class="flex gap-2">
+            <p-button
+              label="Save"
+              (onClick)="save()"
+              [loading]="saving()"
+              [disabled]="!canSave()"
+            />
+            @if (isConfigured()) {
+              <p-button
+                label="Remove Provider"
+                severity="danger"
+                [outlined]="true"
+                (onClick)="confirmRemove()"
+              />
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Status when no provider configured -->
+      @if (!selectedProvider() && !isConfigured()) {
+        <p class="text-muted-color text-sm">AI Provider: Not configured</p>
+      }
+    </section>
+    <p-confirmDialog />
+  `,
+})
+export class AiProviderSettingsComponent implements OnInit {
+  private readonly aiProviderService = inject(AiProviderService);
+  private readonly messageService = inject(MessageService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly validateSubject = new Subject<void>();
+  private statusPopulated = false;
+
+  constructor() {
+    // React to status signal changes to pre-populate form
+    effect(() => {
+      const status = this.aiProviderService.status();
+      if (status && !this.statusPopulated) {
+        this.statusPopulated = true;
+        if (status.isConfigured && status.provider) {
+          this.populateFromStatus(status.provider as AiProviderType, status.model);
+        }
+      }
+    });
+  }
+
+  readonly providers = AI_PROVIDERS;
+  readonly selectedProvider = signal<AiProviderType | null>(null);
+  readonly selectedProviderOption = signal<ProviderOption | null>(null);
+  readonly models = signal<AiModelInfo[]>([]);
+  readonly loadingModels = signal(false);
+  readonly validating = signal(false);
+  readonly validationResult = signal<'success' | 'error' | null>(null);
+  readonly validationMessage = signal<string | null>(null);
+  readonly saving = signal(false);
+  readonly isConfigured = signal(false);
+
+  protected selectedProviderModel = '';
+  protected apiKey = '';
+  protected selectedModel = '';
+
+  ngOnInit(): void {
+    this.aiProviderService.loadStatus();
+
+    // Set up debounced auto-validate
+    this.validateSubject
+      .pipe(
+        debounceTime(500),
+        switchMap(() => {
+          const provider = this.selectedProvider();
+          const model = this.selectedModel;
+          if (!provider || !this.apiKey || this.apiKey.length < 10) {
+            this.validationResult.set(null);
+            this.validationMessage.set(null);
+            return [];
+          }
+          this.validating.set(true);
+          return this.aiProviderService.validate({
+            provider,
+            apiKey: this.apiKey,
+            model: model || 'default',
+          });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: (result) => {
+          this.validating.set(false);
+          if (result.success) {
+            this.validationResult.set('success');
+            this.validationMessage.set(`Connected to ${result.modelName}`);
+          } else {
+            this.validationResult.set('error');
+            this.validationMessage.set(result.error ?? 'Validation failed');
+          }
+        },
+        error: () => {
+          this.validating.set(false);
+          this.validationResult.set('error');
+          this.validationMessage.set('Connection failed');
+        },
+      });
+  }
+
+  selectProvider(provider: AiProviderType): void {
+    this.selectedProvider.set(provider);
+    this.selectedProviderModel = provider;
+    this.selectedProviderOption.set(
+      this.providers.find((p) => p.name === provider) ?? null,
+    );
+    this.loadModels(provider);
+    // Reset validation when provider changes
+    this.validationResult.set(null);
+    this.validationMessage.set(null);
+  }
+
+  onApiKeyInput(): void {
+    this.validateSubject.next();
+  }
+
+  canSave(): boolean {
+    const provider = this.selectedProvider();
+    const hasModel = !!this.selectedModel;
+    const hasKey = !!this.apiKey || this.isConfigured();
+    return !!provider && hasModel && hasKey;
+  }
+
+  save(): void {
+    const provider = this.selectedProvider();
+    if (!provider || !this.selectedModel) return;
+
+    this.saving.set(true);
+    this.aiProviderService
+      .configure({
+        provider,
+        apiKey: this.apiKey || undefined,
+        model: this.selectedModel,
+      })
+      .subscribe({
+        next: () => {
+          this.saving.set(false);
+          this.isConfigured.set(true);
+          this.apiKey = '';
+          this.messageService.add({
+            severity: 'success',
+            summary: 'AI provider configured',
+          });
+        },
+        error: () => {
+          this.saving.set(false);
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Failed to configure AI provider',
+          });
+        },
+      });
+  }
+
+  confirmRemove(): void {
+    this.confirmationService.confirm({
+      message: 'Remove your AI provider configuration? You can reconfigure it at any time.',
+      header: 'Remove AI Provider',
+      acceptLabel: 'Remove',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger',
+      accept: () => this.remove(),
+    });
+  }
+
+  private remove(): void {
+    this.aiProviderService.remove().subscribe({
+      next: () => {
+        this.isConfigured.set(false);
+        this.selectedProvider.set(null);
+        this.selectedProviderModel = '';
+        this.apiKey = '';
+        this.selectedModel = '';
+        this.models.set([]);
+        this.validationResult.set(null);
+        this.validationMessage.set(null);
+        this.messageService.add({
+          severity: 'success',
+          summary: 'AI provider removed',
+        });
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Failed to remove AI provider',
+        });
+      },
+    });
+  }
+
+  private loadModels(provider: string): void {
+    this.loadingModels.set(true);
+    this.aiProviderService.getModels(provider).subscribe({
+      next: (response) => {
+        this.models.set(response.models);
+        this.loadingModels.set(false);
+        // Auto-select default model if none selected
+        if (!this.selectedModel) {
+          const defaultModel = response.models.find((m) => m.isDefault);
+          if (defaultModel) {
+            this.selectedModel = defaultModel.id;
+          }
+        }
+      },
+      error: () => this.loadingModels.set(false),
+    });
+  }
+
+  private populateFromStatus(provider: AiProviderType, model: string | null): void {
+    this.isConfigured.set(true);
+    this.selectProvider(provider);
+    if (model) {
+      this.selectedModel = model;
+    }
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -258,7 +258,9 @@ export class AiProviderSettingsComponent implements OnInit {
   canSave(): boolean {
     const provider = this.selectedProvider();
     const hasModel = !!this.selectedModel;
-    const hasKey = !!this.apiKey || this.isConfigured();
+    const status = this.aiProviderService.status();
+    const sameProvider = status?.isConfigured && status.provider === provider;
+    const hasKey = !!this.apiKey || sameProvider;
     return !!provider && hasModel && hasKey;
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
@@ -9,6 +9,7 @@ import { MessageService } from 'primeng/api';
 import { AuthService } from '../../shared/services/auth.service';
 import { UserService } from '../../shared/services/user.service';
 import { ThemeService } from '../../shared/services/theme.service';
+import { AiProviderSettingsComponent } from './ai-provider-settings.component';
 
 @Component({
   selector: 'app-settings',
@@ -21,6 +22,7 @@ import { ThemeService } from '../../shared/services/theme.service';
     SelectModule,
     ToggleSwitchModule,
     ToastModule,
+    AiProviderSettingsComponent,
   ],
   providers: [MessageService],
   template: `
@@ -91,6 +93,9 @@ import { ThemeService } from '../../shared/services/theme.service';
           [loading]="savingPreferences()"
         />
       </section>
+
+      <!-- AI Provider Section -->
+      <app-ai-provider-settings />
     </div>
   `,
 })

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-contextual.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-contextual.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { AiNudgeService } from '../services/ai-nudge.service';
+
+@Component({
+  selector: 'app-ai-nudge-contextual',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, RouterLink],
+  template: `
+    @if (visible()) {
+      <div class="flex items-center justify-between gap-3 p-3 rounded-lg bg-surface-50 border border-surface-200">
+        <span class="text-sm text-muted-color">
+          Add your own AI key for unlimited access
+        </span>
+        <div class="flex items-center gap-2">
+          <a routerLink="/settings" class="text-sm text-primary hover:underline">Set up</a>
+          <p-button
+            icon="pi pi-times"
+            [text]="true"
+            [rounded]="true"
+            size="small"
+            (onClick)="dismiss()"
+          />
+        </div>
+      </div>
+    }
+  `,
+})
+export class AiNudgeContextualComponent {
+  private readonly nudgeService = inject(AiNudgeService);
+
+  readonly visible = computed(
+    () => this.nudgeService.nudgeState() === 'Tasting' && !this.nudgeService.isDismissed('contextual'),
+  );
+
+  dismiss(): void {
+    this.nudgeService.dismiss('contextual', 7);
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-fresh.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-fresh.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AiNudgeService } from '../services/ai-nudge.service';
+
+@Component({
+  selector: 'app-ai-nudge-fresh',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  template: `
+    @if (visible()) {
+      <div class="flex items-center gap-2 text-sm text-muted-color">
+        <i class="pi pi-info-circle"></i>
+        <span>AI Provider: Not configured</span>
+        <a routerLink="/settings" class="text-primary hover:underline">Set up</a>
+      </div>
+    }
+  `,
+})
+export class AiNudgeFreshComponent {
+  private readonly nudgeService = inject(AiNudgeService);
+
+  readonly visible = computed(() => this.nudgeService.nudgeState() === 'Fresh');
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-limited.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-limited.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject, output } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { AiNudgeService } from '../services/ai-nudge.service';
 
@@ -7,7 +7,7 @@ import { AiNudgeService } from '../services/ai-nudge.service';
   selector: 'app-ai-nudge-limited',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonModule, RouterLink],
+  imports: [ButtonModule],
   template: `
     @if (visible()) {
       <div class="flex flex-col items-center gap-4 p-6 rounded-lg bg-surface-50 border border-surface-200 text-center">
@@ -16,9 +16,7 @@ import { AiNudgeService } from '../services/ai-nudge.service';
           You've used your {{ dailyLimit() }} free AI operations today
         </p>
         <div class="flex gap-2">
-          <a routerLink="/settings">
-            <p-button label="Set Up AI Provider" />
-          </a>
+          <p-button label="Set Up AI Provider" (onClick)="goToSettings()" />
           <p-button
             label="Continue tomorrow"
             [outlined]="true"
@@ -31,10 +29,15 @@ import { AiNudgeService } from '../services/ai-nudge.service';
 })
 export class AiNudgeLimitedComponent {
   private readonly nudgeService = inject(AiNudgeService);
+  private readonly router = inject(Router);
   readonly dismissed = output<void>();
 
   readonly visible = computed(() => this.nudgeService.nudgeState() === 'Limited');
   readonly dailyLimit = computed(() => this.nudgeService.tasteDailyLimit());
+
+  goToSettings(): void {
+    this.router.navigate(['/settings']);
+  }
 
   continueTomorrow(): void {
     this.dismissed.emit();

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-limited.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/ai-nudge-limited.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, computed, inject, output } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { AiNudgeService } from '../services/ai-nudge.service';
+
+@Component({
+  selector: 'app-ai-nudge-limited',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, RouterLink],
+  template: `
+    @if (visible()) {
+      <div class="flex flex-col items-center gap-4 p-6 rounded-lg bg-surface-50 border border-surface-200 text-center">
+        <i class="pi pi-exclamation-circle text-3xl text-muted-color"></i>
+        <p class="text-sm font-medium">
+          You've used your {{ dailyLimit() }} free AI operations today
+        </p>
+        <div class="flex gap-2">
+          <a routerLink="/settings">
+            <p-button label="Set Up AI Provider" />
+          </a>
+          <p-button
+            label="Continue tomorrow"
+            [outlined]="true"
+            (onClick)="continueTomorrow()"
+          />
+        </div>
+      </div>
+    }
+  `,
+})
+export class AiNudgeLimitedComponent {
+  private readonly nudgeService = inject(AiNudgeService);
+  readonly dismissed = output<void>();
+
+  readonly visible = computed(() => this.nudgeService.nudgeState() === 'Limited');
+  readonly dailyLimit = computed(() => this.nudgeService.tasteDailyLimit());
+
+  continueTomorrow(): void {
+    this.dismissed.emit();
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/taste-counter.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/taste-counter.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { AiNudgeService } from '../services/ai-nudge.service';
+
+@Component({
+  selector: 'app-taste-counter',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (visible()) {
+      <div class="text-xs text-muted-color flex items-center gap-1">
+        <i class="pi pi-sparkles"></i>
+        <span>{{ remaining() }} of {{ dailyLimit() }} free AI operations remaining today</span>
+      </div>
+    }
+  `,
+})
+export class TasteCounterComponent {
+  private readonly nudgeService = inject(AiNudgeService);
+
+  readonly visible = computed(() => this.nudgeService.isTasteUser());
+  readonly remaining = computed(() => this.nudgeService.tasteRemaining());
+  readonly dailyLimit = computed(() => this.nudgeService.tasteDailyLimit());
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/ai-provider.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/ai-provider.model.ts
@@ -1,0 +1,77 @@
+export interface AiProviderStatus {
+  isConfigured: boolean;
+  provider: string | null;
+  model: string | null;
+  maxTokens: number | null;
+  tasteBudget: TasteBudget;
+}
+
+export interface TasteBudget {
+  remaining: number;
+  dailyLimit: number;
+  isEnabled: boolean;
+}
+
+export interface ConfigureAiProviderRequest {
+  provider: string;
+  apiKey?: string;
+  model: string;
+  maxTokens?: number | null;
+}
+
+export interface ValidateAiProviderRequest {
+  provider: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface ValidateAiProviderResponse {
+  success: boolean;
+  modelName: string | null;
+  error: string | null;
+}
+
+export interface AiModelInfo {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+export interface AvailableModelsResponse {
+  provider: string;
+  models: AiModelInfo[];
+}
+
+export type AiProviderType = 'Anthropic' | 'OpenAI' | 'Google';
+
+export interface ProviderOption {
+  name: AiProviderType;
+  label: string;
+  icon: string;
+  keyUrl: string;
+  keyUrlLabel: string;
+}
+
+export const AI_PROVIDERS: ProviderOption[] = [
+  {
+    name: 'Anthropic',
+    label: 'Anthropic',
+    icon: 'pi pi-bolt',
+    keyUrl: 'https://console.anthropic.com/settings/keys',
+    keyUrlLabel: 'Open Anthropic Console',
+  },
+  {
+    name: 'OpenAI',
+    label: 'OpenAI',
+    icon: 'pi pi-microchip-ai',
+    keyUrl: 'https://platform.openai.com/api-keys',
+    keyUrlLabel: 'Open OpenAI Platform',
+  },
+  {
+    name: 'Google',
+    label: 'Google',
+    icon: 'pi pi-google',
+    keyUrl: 'https://aistudio.google.com/apikey',
+    keyUrlLabel: 'Open AI Studio',
+  },
+];

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { AiNudgeService } from './ai-nudge.service';
+import { AiProviderService } from './ai-provider.service';
+import { AiProviderStatus } from '../models/ai-provider.model';
+
+function makeStatus(overrides: Partial<AiProviderStatus> = {}): AiProviderStatus {
+  return {
+    isConfigured: false,
+    provider: null,
+    model: null,
+    maxTokens: null,
+    tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    ...overrides,
+  };
+}
+
+describe('AiNudgeService', () => {
+  let nudgeService: AiNudgeService;
+  let providerService: AiProviderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()],
+    });
+    nudgeService = TestBed.inject(AiNudgeService);
+    providerService = TestBed.inject(AiProviderService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return Fresh when no status loaded', () => {
+    expect(nudgeService.nudgeState()).toBe('Fresh');
+  });
+
+  it('should return Unlimited when provider is configured', () => {
+    providerService.status.set(makeStatus({ isConfigured: true, provider: 'Anthropic' }));
+    expect(nudgeService.nudgeState()).toBe('Unlimited');
+  });
+
+  it('should return Fresh when taste budget is full', () => {
+    providerService.status.set(makeStatus());
+    expect(nudgeService.nudgeState()).toBe('Fresh');
+  });
+
+  it('should return Tasting when taste budget is partially used', () => {
+    providerService.status.set(makeStatus({
+      tasteBudget: { remaining: 3, dailyLimit: 5, isEnabled: true },
+    }));
+    expect(nudgeService.nudgeState()).toBe('Tasting');
+  });
+
+  it('should return Limited when taste budget is exhausted', () => {
+    providerService.status.set(makeStatus({
+      tasteBudget: { remaining: 0, dailyLimit: 5, isEnabled: true },
+    }));
+    expect(nudgeService.nudgeState()).toBe('Limited');
+  });
+
+  it('should return Fresh when taste is not enabled', () => {
+    providerService.status.set(makeStatus({
+      tasteBudget: { remaining: 0, dailyLimit: 5, isEnabled: false },
+    }));
+    expect(nudgeService.nudgeState()).toBe('Fresh');
+  });
+
+  it('should dismiss and check dismissal with TTL', () => {
+    expect(nudgeService.isDismissed('test')).toBe(false);
+    nudgeService.dismiss('test', 7);
+    expect(nudgeService.isDismissed('test')).toBe(true);
+  });
+
+  it('should report not dismissed when TTL expired', () => {
+    // Set expired timestamp
+    localStorage.setItem('ai-nudge-dismiss-test', (Date.now() - 1000).toString());
+    expect(nudgeService.isDismissed('test')).toBe(false);
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.spec.ts
@@ -66,6 +66,20 @@ describe('AiNudgeService', () => {
     expect(nudgeService.nudgeState()).toBe('Fresh');
   });
 
+  it('should return isTasteUser=false when taste is disabled', () => {
+    providerService.status.set(makeStatus({
+      tasteBudget: { remaining: 0, dailyLimit: 5, isEnabled: false },
+    }));
+    expect(nudgeService.isTasteUser()).toBe(false);
+  });
+
+  it('should return isTasteUser=true when taste is enabled and not configured', () => {
+    providerService.status.set(makeStatus({
+      tasteBudget: { remaining: 3, dailyLimit: 5, isEnabled: true },
+    }));
+    expect(nudgeService.isTasteUser()).toBe(true);
+  });
+
   it('should dismiss and check dismissal with TTL', () => {
     expect(nudgeService.isDismissed('test')).toBe(false);
     nudgeService.dismiss('test', 7);

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.ts
@@ -1,0 +1,58 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { AiProviderService } from './ai-provider.service';
+
+export type NudgeState = 'Fresh' | 'Tasting' | 'Limited' | 'Unlimited';
+
+const DISMISS_PREFIX = 'ai-nudge-dismiss-';
+
+@Injectable({ providedIn: 'root' })
+export class AiNudgeService {
+  private readonly aiProviderService = inject(AiProviderService);
+
+  readonly nudgeState = computed<NudgeState>(() => {
+    const status = this.aiProviderService.status();
+    if (!status) return 'Fresh';
+    if (status.isConfigured) return 'Unlimited';
+    if (!status.tasteBudget.isEnabled) return 'Fresh';
+    if (status.tasteBudget.remaining <= 0) return 'Limited';
+    if (status.tasteBudget.remaining < status.tasteBudget.dailyLimit) return 'Tasting';
+    return 'Fresh';
+  });
+
+  readonly isTasteUser = computed(() => {
+    const state = this.nudgeState();
+    return state === 'Fresh' || state === 'Tasting' || state === 'Limited';
+  });
+
+  readonly tasteRemaining = computed(() => {
+    return this.aiProviderService.status()?.tasteBudget.remaining ?? 0;
+  });
+
+  readonly tasteDailyLimit = computed(() => {
+    return this.aiProviderService.status()?.tasteBudget.dailyLimit ?? 5;
+  });
+
+  isDismissed(nudgeType: string): boolean {
+    try {
+      const raw = localStorage.getItem(DISMISS_PREFIX + nudgeType);
+      if (!raw) return false;
+      const expiry = parseInt(raw, 10);
+      if (Date.now() > expiry) {
+        localStorage.removeItem(DISMISS_PREFIX + nudgeType);
+        return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  dismiss(nudgeType: string, days = 7): void {
+    try {
+      const expiry = Date.now() + days * 24 * 60 * 60 * 1000;
+      localStorage.setItem(DISMISS_PREFIX + nudgeType, expiry.toString());
+    } catch {
+      // localStorage may be unavailable
+    }
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-nudge.service.ts
@@ -20,8 +20,9 @@ export class AiNudgeService {
   });
 
   readonly isTasteUser = computed(() => {
-    const state = this.nudgeState();
-    return state === 'Fresh' || state === 'Tasting' || state === 'Limited';
+    const status = this.aiProviderService.status();
+    if (!status || status.isConfigured) return false;
+    return status.tasteBudget.isEnabled;
   });
 
   readonly tasteRemaining = computed(() => {
@@ -37,7 +38,7 @@ export class AiNudgeService {
       const raw = localStorage.getItem(DISMISS_PREFIX + nudgeType);
       if (!raw) return false;
       const expiry = parseInt(raw, 10);
-      if (Date.now() > expiry) {
+      if (isNaN(expiry) || Date.now() > expiry) {
         localStorage.removeItem(DISMISS_PREFIX + nudgeType);
         return false;
       }

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-provider.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/ai-provider.service.ts
@@ -1,0 +1,51 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, signal } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+import {
+  AiProviderStatus,
+  AvailableModelsResponse,
+  ConfigureAiProviderRequest,
+  ValidateAiProviderRequest,
+  ValidateAiProviderResponse,
+} from '../models/ai-provider.model';
+
+@Injectable({ providedIn: 'root' })
+export class AiProviderService {
+  private readonly http = inject(HttpClient);
+
+  readonly status = signal<AiProviderStatus | null>(null);
+  readonly loading = signal(false);
+
+  loadStatus(): void {
+    this.loading.set(true);
+    this.http.get<AiProviderStatus>('/api/users/me/ai-provider').subscribe({
+      next: (status) => {
+        this.status.set(status);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  configure(request: ConfigureAiProviderRequest): Observable<void> {
+    return this.http.put<void>('/api/users/me/ai-provider', request).pipe(
+      tap(() => this.loadStatus()),
+    );
+  }
+
+  validate(request: ValidateAiProviderRequest): Observable<ValidateAiProviderResponse> {
+    return this.http.post<ValidateAiProviderResponse>('/api/users/me/ai-provider/validate', request);
+  }
+
+  remove(): Observable<void> {
+    return this.http.delete<void>('/api/users/me/ai-provider').pipe(
+      tap(() => this.loadStatus()),
+    );
+  }
+
+  getModels(provider: string): Observable<AvailableModelsResponse> {
+    return this.http.get<AvailableModelsResponse>('/api/ai/models', {
+      params: { provider },
+    });
+  }
+}

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect, API_BASE } from './fixtures/auth.fixture';
+import { test as baseTest } from '@playwright/test';
+
+test.describe('AI Provider Settings', () => {
+  test('AI provider section is visible on settings page', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/settings');
+
+    await expect(authenticatedPage).toHaveURL(/\/settings/);
+    await expect(authenticatedPage.getByText('AI Provider')).toBeVisible();
+  });
+
+  test('Provider status returns isConfigured=false for new user', async ({ authenticatedPage, testUser }) => {
+    await authenticatedPage.goto('/settings');
+
+    const token = testUser.accessToken;
+    const response = await authenticatedPage.request.get(`${API_BASE}/api/users/me/ai-provider`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const status = await response.json();
+    expect(status.isConfigured).toBe(false);
+    expect(status.tasteBudget).toBeDefined();
+  });
+});
+
+baseTest.describe('AI Models Endpoint', () => {
+  baseTest('GET /api/ai/models returns model list for valid provider', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/ai/models`, {
+      params: { provider: 'Anthropic' },
+      headers: { Authorization: 'Bearer test' },
+    });
+
+    // May return 401 (needs real auth) or 200 with models — either confirms the endpoint exists
+    expect([200, 401]).toContain(response.status());
+  });
+});

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, API_BASE } from './fixtures/auth.fixture';
-import { test as baseTest } from '@playwright/test';
 
 test.describe('AI Provider Settings', () => {
   test('AI provider section is visible on settings page', async ({ authenticatedPage }) => {
@@ -24,14 +23,17 @@ test.describe('AI Provider Settings', () => {
   });
 });
 
-baseTest.describe('AI Models Endpoint', () => {
-  baseTest('GET /api/ai/models returns model list for valid provider', async ({ request }) => {
-    const response = await request.get(`${API_BASE}/api/ai/models`, {
+test.describe('AI Models Endpoint', () => {
+  test('GET /api/ai/models returns model list for valid provider', async ({ authenticatedPage, testUser }) => {
+    const response = await authenticatedPage.request.get(`${API_BASE}/api/ai/models`, {
       params: { provider: 'Anthropic' },
-      headers: { Authorization: 'Bearer test' },
+      headers: { Authorization: `Bearer ${testUser.accessToken}` },
     });
 
-    // May return 401 (needs real auth) or 200 with models — either confirms the endpoint exists
-    expect([200, 401]).toContain(response.status());
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.provider).toBe('Anthropic');
+    expect(body.models).toBeDefined();
+    expect(body.models.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Implements the frontend for AI provider configuration, completing the byo-provider feature. Users can now configure their AI provider (Anthropic, OpenAI, Google) from the settings page, with auto-validation on key paste, model selection, and a nudge framework that guides users through taste-to-configured states.

**Spec**: [ai-provider-abstraction](openspec/specs/ai-provider-abstraction/spec.md)

## Changes

- **AiProviderService** — status signal, configure/validate/remove/getModels API calls
- **AiProviderSettingsComponent** — provider cards with radio selection, password-masked API key input with debounced auto-validate, model dropdown from config endpoint, save/remove flows with confirmation, deep links per provider
- **AiNudgeService** — signal-based state derivation (Fresh/Tasting/Limited/Unlimited) with localStorage dismissal (7-day TTL)
- **TasteCounterComponent** — "N of M free AI operations remaining today" indicator
- **Nudge components** — contextual (Tasting), blocking (Limited), passive (Fresh)
- **Unit tests** — AiNudgeService state derivation (8 tests), AiProviderSettingsComponent integration (3 tests)
- **E2E tests** — settings visibility, provider status, models endpoint

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (81 tests)
- [x] `ng test --watch=false` passes (12 tests)
- [ ] E2E tests pass with dev-stack running (Docker required)
- [ ] No banned Tailwind colour utilities (self-review verified)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configurable AI provider section to the settings page, with supporting services, nudge framework, taste counter, and specs/tests for the new AI provider frontend.

New Features:
- Introduce AiProviderSettingsComponent on the settings page for selecting providers, entering API keys, validating configuration, and managing models.
- Add AiProviderService and related TypeScript models to encapsulate AI provider status, configuration, validation, and model catalog APIs.
- Implement AiNudgeService with associated nudge components and a TasteCounterComponent to surface taste budget state and guide users toward configuring an AI provider.

Enhancements:
- Document the AI provider frontend design, proposal, and implementation tasks in OpenSpec, including wiring into existing backend endpoints.

Tests:
- Add unit tests for AiNudgeService nudge state derivation and TTL-based nudge dismissal.
- Add unit and E2E test scaffolding for AI provider settings and AI provider backend integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Provider settings added to Settings with provider selection, API key + model configuration, save/remove flows, and inline debounced validation.
  * Contextual nudges for AI status (Fresh/Tasting/Limited/Unlimited) with dismissal rules and a Taste Counter showing remaining daily free operations.

* **Documentation**
  * Added design, proposal, tasks, and spec docs describing UI flows, nudges, and integration points.

* **Tests**
  * Unit and E2E tests covering settings UI, validation, model listing, and nudge state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->