### PR TITLE
docs: Propose person-management and initiative-management specs

### DIFF
--- a/openspec/changes/initiative-management/.openspec.yaml
+++ b/openspec/changes/initiative-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/initiative-management/design.md
+++ b/openspec/changes/initiative-management/design.md
@@ -1,0 +1,88 @@
+## Context
+
+Mental Metal has two Tier 1 specs implemented (user-auth-tenancy, ai-provider-abstraction) and person-management is being proposed in parallel. The Initiative aggregate is defined in the domain model with a rich set of properties, but this Tier 1 spec covers only the foundational CRUD and status management. The AI-maintained brief, decisions, risks, requirements, and design snapshots are deferred to the initiative-living-brief Tier 2 spec.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement the Initiative aggregate with core metadata (title, status, milestones, linked people)
+- Enforce the status state machine (Active ↔ OnHold, Active → Completed/Cancelled)
+- Provide CRUD API endpoints and Angular UI for managing initiatives
+- Support milestone tracking and person linking
+
+**Non-Goals:**
+- AI summary, key decisions, risks, requirements/design snapshots (initiative-living-brief, Tier 2)
+- Dependencies tracking (initiative-living-brief, Tier 2)
+- Initiative-scoped AI chat (initiative-ai-chat, Tier 2)
+- Auto-linking from captures (capture-ai-extraction, Tier 2)
+
+## Dependencies
+
+- `user-auth-tenancy` — UserId scoping, ICurrentUserService, authentication
+- `person-management` — LinkedPersonIds reference Person aggregate by ID (soft reference, no FK constraint)
+
+## Decisions
+
+### 1. Scope to core metadata only — defer living brief features
+
+**Decision:** The Initiative aggregate in this spec includes only Title, Status, Milestones, and LinkedPersonIds. Properties like AiSummary, KeyDecisions, OpenRisks, Requirements, DesignDirection, and Dependencies are added by the initiative-living-brief Tier 2 spec.
+
+**Rationale:** Keeps the Tier 1 implementation focused and unblocks dependents quickly. The domain model defines the full aggregate, but we build incrementally — the aggregate grows as specs are implemented.
+
+**Alternatives considered:**
+- Implement the full aggregate now: Rejected — most properties require AI infrastructure and capture processing that don't exist yet
+- Stub all properties as empty: Rejected — unused columns in the database; migrations should reflect actual usage
+
+### 2. Status state machine enforced in the domain
+
+**Decision:** InitiativeStatus is an enum (Active, OnHold, Completed, Cancelled). The ChangeStatus method on the aggregate validates transitions:
+- Active → OnHold, Completed, Cancelled
+- OnHold → Active
+- Completed/Cancelled → no transitions (terminal states)
+
+**Rationale:** Simple and matches the domain model exactly. Terminal states prevent accidental modification. If a grace-period reversal is needed later, it can be added as a separate business action.
+
+### 3. Milestones as owned collection of value objects
+
+**Decision:** Milestones are a `List<Milestone>` owned by the Initiative, mapped via EF Core OwnsMany. Each Milestone has an Id (Guid, for update/remove), Title, TargetDate, Description, and IsCompleted.
+
+**Rationale:** Milestones are value objects scoped to an initiative — they have no independent lifecycle. OwnsMany maps them to a separate table but manages them within the aggregate boundary.
+
+### 4. LinkedPersonIds as a simple Guid list
+
+**Decision:** LinkedPersonIds is stored as a separate table (InitiativeLinkedPeople) with InitiativeId and PersonId columns. No FK constraint to Person table — just ID references.
+
+**Rationale:** Follows the DDD principle of cross-aggregate references by ID only. No FK constraint means person-management and initiative-management can be deployed independently. Validation of PersonId existence is done at the application layer when linking.
+
+### 5. API design: RESTful under /api/initiatives
+
+**Decision:** Endpoints:
+- `GET /api/initiatives` — list (with optional status filter)
+- `GET /api/initiatives/{id}` — get by ID
+- `POST /api/initiatives` — create
+- `PUT /api/initiatives/{id}` — update title
+- `PUT /api/initiatives/{id}/status` — change status
+- `POST /api/initiatives/{id}/milestones` — add milestone
+- `PUT /api/initiatives/{id}/milestones/{milestoneId}` — update milestone
+- `DELETE /api/initiatives/{id}/milestones/{milestoneId}` — remove milestone
+- `POST /api/initiatives/{id}/milestones/{milestoneId}/complete` — mark milestone complete
+- `POST /api/initiatives/{id}/link-person` — link a person
+- `DELETE /api/initiatives/{id}/link-person/{personId}` — unlink a person
+
+**Rationale:** Sub-resources for milestones and linked people reflect the aggregate's internal structure while keeping endpoints focused.
+
+### 6. Frontend: PrimeNG DataTable for list, dedicated detail page
+
+**Decision:** Use PrimeNG Table for the initiative list with status filtering and status badges. Detail page shows title, status with transition buttons, milestones timeline, and linked people chips.
+
+**Rationale:** Initiatives have more sub-content than people (milestones, linked people), so a dedicated detail page rather than a dialog gives more room.
+
+## Risks / Trade-offs
+
+- **[LinkedPersonIds without FK]** → No referential integrity at DB level. Mitigated by application-layer validation on link and graceful handling if a person is archived/deleted. This is by design per DDD aggregate boundaries.
+- **[Incremental aggregate growth]** → The Initiative entity will gain properties in Tier 2. Mitigated by clean domain model — new properties are added via new migrations when their specs are implemented.
+- **[Terminal status is permanent]** → Completed/Cancelled cannot be reversed. This matches the domain model. If needed later, a grace-period reopen can be added as a separate business action.
+
+## Open Questions
+
+None — the scoping is clear and patterns are established.

--- a/openspec/changes/initiative-management/proposal.md
+++ b/openspec/changes/initiative-management/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Initiative is the evolving context aggregate in Mental Metal — it holds the living brief for every project and workstream the user manages. Without initiative-management, Tier 2 capabilities like commitment-tracking, delegation-tracking, initiative-living-brief, and capture-ai-extraction cannot link work to initiatives. This is one of the last two Tier 1 foundation specs and unblocks 6 of 8 Tier 2 capabilities.
+
+## What Changes
+
+- Add the **Initiative** aggregate with basic metadata and status management
+- Implement the Initiative status state machine: Active → OnHold (resume back), Active → Completed, Active → Cancelled
+- Support milestone tracking with target dates and descriptions
+- Support linking people to initiatives (LinkedPersonIds)
+- Expose minimal API endpoints for CRUD operations and status transitions
+- Add EF Core persistence with PostgreSQL, including migrations
+- Add Angular frontend for listing, creating, editing initiatives and managing milestones
+
+## Non-goals
+
+- **AI-maintained summary** (AiSummary, RefreshSummary) — belongs to `initiative-living-brief` (Tier 2)
+- **Key decisions log, risk tracking, requirements/design snapshots** — belongs to `initiative-living-brief` (Tier 2)
+- **Dependencies tracking** — belongs to `initiative-living-brief` (Tier 2)
+- **Initiative-scoped AI chat** — belongs to `initiative-ai-chat` (Tier 2)
+- **Auto-linking from captures** — belongs to `capture-ai-extraction` (Tier 2)
+
+## Capabilities
+
+### New Capabilities
+- `initiative-management`: Create, edit, and manage initiatives with title, status state machine, milestones, and linked people
+
+### Modified Capabilities
+<!-- No existing spec requirements are changing -->
+
+## Impact
+
+- **Domain layer**: New Initiative aggregate root, InitiativeStatus enum, Milestone value object, domain events, IInitiativeRepository
+- **Application layer**: Vertical slice handlers for create, update, change status, manage milestones, link people, list, get
+- **Infrastructure layer**: EF Core configuration, InitiativeRepository, database migration
+- **Web layer**: Minimal API endpoints under `/api/initiatives`
+- **Frontend**: Initiative list view, create/edit forms, milestone management, person linking
+- **Tier**: Tier 1 — Foundation
+- **Dependencies**: `user-auth-tenancy` (for UserId scoping and authentication), `person-management` (for LinkedPersonIds validation — soft dependency, IDs only)
+- **Dependents**: 6 of 8 Tier 2 specs depend on this

--- a/openspec/changes/initiative-management/specs/initiative-management/spec.md
+++ b/openspec/changes/initiative-management/specs/initiative-management/spec.md
@@ -1,0 +1,245 @@
+## ADDED Requirements
+
+### Requirement: Create an initiative
+
+The system SHALL allow an authenticated user to create a new Initiative with a title. Title MUST NOT be empty. The Initiative SHALL be created with status Active. The system SHALL raise an `InitiativeCreated` domain event. The Initiative SHALL be scoped to the authenticated user's UserId.
+
+#### Scenario: Create an initiative
+
+- **WHEN** an authenticated user sends a POST to `/api/initiatives` with title "Platform Migration Q3"
+- **THEN** the system creates an Initiative with the given title, status Active, sets CreatedAt and UpdatedAt, and returns the created initiative with HTTP 201
+
+#### Scenario: Empty title rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/initiatives` with an empty title
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates an initiative titled "Migration" and User B creates an initiative titled "Migration"
+- **THEN** both operations succeed because initiative titles are not required to be unique
+
+### Requirement: List initiatives
+
+The system SHALL allow an authenticated user to retrieve a list of their initiatives. The list SHALL support optional filtering by status.
+
+#### Scenario: List all initiatives
+
+- **WHEN** an authenticated user sends a GET to `/api/initiatives`
+- **THEN** the system returns all initiatives belonging to that user
+
+#### Scenario: Filter by status
+
+- **WHEN** an authenticated user sends a GET to `/api/initiatives?status=Active`
+- **THEN** the system returns only initiatives with status Active
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no initiatives sends a GET to `/api/initiatives`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get initiative by ID
+
+The system SHALL allow an authenticated user to retrieve a single initiative by ID, including its milestones and linked person IDs.
+
+#### Scenario: Get existing initiative
+
+- **WHEN** an authenticated user sends a GET to `/api/initiatives/{id}` with a valid initiative ID
+- **THEN** the system returns the initiative with all details including milestones and linked person IDs
+
+#### Scenario: Initiative not found
+
+- **WHEN** an authenticated user sends a GET to `/api/initiatives/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Update initiative title
+
+The system SHALL allow an authenticated user to update an initiative's title. Title MUST NOT be empty. The system SHALL reject updates to initiatives in terminal status (Completed, Cancelled). The system SHALL raise an `InitiativeTitleUpdated` domain event.
+
+#### Scenario: Update title successfully
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}` with a new title for an Active initiative
+- **THEN** the system updates the title, sets UpdatedAt, and returns the updated initiative
+
+#### Scenario: Empty title rejected
+
+- **WHEN** an authenticated user sends a PUT with an empty title
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: Update terminal initiative rejected
+
+- **WHEN** an authenticated user sends a PUT to update a Completed or Cancelled initiative
+- **THEN** the system returns HTTP 400 indicating terminal initiatives cannot be modified
+
+### Requirement: Change initiative status
+
+The system SHALL enforce the initiative status state machine. Valid transitions: Active → OnHold, Active → Completed, Active → Cancelled, OnHold → Active. Completed and Cancelled are terminal states with no outward transitions. The system SHALL raise an `InitiativeStatusChanged` domain event.
+
+#### Scenario: Put initiative on hold
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}/status` with status "OnHold" for an Active initiative
+- **THEN** the system changes status to OnHold and returns the updated initiative
+
+#### Scenario: Resume initiative from hold
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}/status` with status "Active" for an OnHold initiative
+- **THEN** the system changes status to Active and returns the updated initiative
+
+#### Scenario: Complete an initiative
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}/status` with status "Completed" for an Active initiative
+- **THEN** the system changes status to Completed and returns the updated initiative
+
+#### Scenario: Cancel an initiative
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}/status` with status "Cancelled" for an Active initiative
+- **THEN** the system changes status to Cancelled and returns the updated initiative
+
+#### Scenario: Invalid transition rejected
+
+- **WHEN** an authenticated user sends a PUT to change status from OnHold to Completed (must go through Active first)
+- **THEN** the system returns HTTP 400 indicating invalid status transition
+
+#### Scenario: Transition from terminal state rejected
+
+- **WHEN** an authenticated user tries to change status of a Completed or Cancelled initiative
+- **THEN** the system returns HTTP 400 indicating terminal status cannot be changed
+
+#### Scenario: Same status is no-op
+
+- **WHEN** an authenticated user sends a PUT to change status to the initiative's current status
+- **THEN** the system returns the initiative unchanged with HTTP 200
+
+### Requirement: Manage milestones
+
+The system SHALL allow an authenticated user to add, update, remove, and complete milestones on an initiative. Milestones have a title (required), target date (required), and optional description. The system SHALL reject milestone operations on terminal initiatives. The system SHALL raise a `MilestoneSet` domain event on add/update and a `MilestoneCompleted` domain event on completion.
+
+#### Scenario: Add a milestone
+
+- **WHEN** an authenticated user sends a POST to `/api/initiatives/{id}/milestones` with title "Alpha Release" and targetDate "2026-06-15"
+- **THEN** the system adds the milestone and returns the updated initiative
+
+#### Scenario: Update a milestone
+
+- **WHEN** an authenticated user sends a PUT to `/api/initiatives/{id}/milestones/{milestoneId}` with an updated targetDate
+- **THEN** the system updates the milestone and returns the updated initiative
+
+#### Scenario: Remove a milestone
+
+- **WHEN** an authenticated user sends a DELETE to `/api/initiatives/{id}/milestones/{milestoneId}`
+- **THEN** the system removes the milestone and returns HTTP 204
+
+#### Scenario: Complete a milestone
+
+- **WHEN** an authenticated user sends a POST to `/api/initiatives/{id}/milestones/{milestoneId}/complete`
+- **THEN** the system marks the milestone as completed and returns the updated initiative
+
+#### Scenario: Milestone on terminal initiative rejected
+
+- **WHEN** an authenticated user tries to add/update/remove a milestone on a Completed or Cancelled initiative
+- **THEN** the system returns HTTP 400 indicating terminal initiatives cannot be modified
+
+#### Scenario: Milestone title required
+
+- **WHEN** an authenticated user sends a POST to add a milestone with an empty title
+- **THEN** the system returns HTTP 400 with a validation error
+
+### Requirement: Link and unlink people
+
+The system SHALL allow an authenticated user to link and unlink people to/from an initiative by person ID. The system SHALL validate that the person ID belongs to the user. The system SHALL reject link operations on terminal initiatives. The system SHALL raise a `PersonLinkedToInitiative` domain event on link and a `PersonUnlinkedFromInitiative` domain event on unlink.
+
+#### Scenario: Link a person
+
+- **WHEN** an authenticated user sends a POST to `/api/initiatives/{id}/link-person` with a valid personId
+- **THEN** the system adds the personId to LinkedPersonIds and returns the updated initiative
+
+#### Scenario: Link duplicate person is idempotent
+
+- **WHEN** an authenticated user links a person who is already linked to the initiative
+- **THEN** the system returns HTTP 200 without duplicating the link or raising a duplicate event
+
+#### Scenario: Unlink a person
+
+- **WHEN** an authenticated user sends a DELETE to `/api/initiatives/{id}/link-person/{personId}`
+- **THEN** the system removes the personId from LinkedPersonIds and returns HTTP 204
+
+#### Scenario: Link person on terminal initiative rejected
+
+- **WHEN** an authenticated user tries to link a person to a Completed or Cancelled initiative
+- **THEN** the system returns HTTP 400 indicating terminal initiatives cannot be modified
+
+#### Scenario: Link non-existent person rejected
+
+- **WHEN** an authenticated user sends a POST to link a personId that does not exist or belongs to another user
+- **THEN** the system returns HTTP 400 indicating the person was not found
+
+### Requirement: Multi-tenant initiative isolation
+
+All initiative data SHALL be automatically scoped to the authenticated user's UserId via EF Core global query filters. A user SHALL NOT be able to access, modify, or list another user's initiatives.
+
+#### Scenario: Cross-tenant access prevented
+
+- **WHEN** User A attempts to GET `/api/initiatives/{id}` with an ID belonging to User B
+- **THEN** the system returns HTTP 404 (not 403, to avoid leaking existence)
+
+### Requirement: Frontend initiatives list page
+
+The Angular application SHALL provide an initiatives list page displaying all initiatives in a PrimeNG Table with columns for title, status, and milestone count. The list SHALL support filtering by status. Status SHALL be displayed as coloured badges.
+
+#### Scenario: View initiatives list
+
+- **WHEN** an authenticated user navigates to the initiatives page
+- **THEN** the page displays a table of all initiatives with title, status badge, and milestone count
+
+#### Scenario: Filter by status
+
+- **WHEN** a user selects a status filter (e.g., "Active")
+- **THEN** the table shows only initiatives with that status
+
+#### Scenario: Empty state
+
+- **WHEN** a user has no initiatives
+- **THEN** the page displays an empty state message with a prompt to create their first initiative
+
+### Requirement: Frontend create initiative form
+
+The Angular application SHALL provide a form (in a PrimeNG Dialog) to create a new initiative. The form SHALL include a title field (required).
+
+#### Scenario: Create initiative via dialog
+
+- **WHEN** a user clicks "New Initiative" and enters a title
+- **THEN** the dialog submits to the API and on success closes the dialog and adds the initiative to the list
+
+#### Scenario: Validation feedback
+
+- **WHEN** a user submits the form with an empty title
+- **THEN** the form displays a validation error without submitting to the API
+
+### Requirement: Frontend initiative detail page
+
+The Angular application SHALL provide a detail page for an initiative. The page SHALL display the title (editable), status with transition buttons, milestones list with add/edit/complete/remove, and linked people as chips with add/remove.
+
+#### Scenario: View initiative details
+
+- **WHEN** a user clicks on an initiative in the list
+- **THEN** the application navigates to the initiative detail page showing title, status, milestones, and linked people
+
+#### Scenario: Edit initiative title
+
+- **WHEN** a user edits the title and saves
+- **THEN** the application sends the update to the API and reflects changes on success
+
+#### Scenario: Change initiative status
+
+- **WHEN** a user clicks a status transition button (e.g., "Put On Hold")
+- **THEN** the application calls the status change endpoint and updates the displayed status and available transition buttons
+
+#### Scenario: Manage milestones
+
+- **WHEN** a user adds, edits, completes, or removes a milestone
+- **THEN** the application calls the appropriate API endpoint and updates the milestones display
+
+#### Scenario: Link and unlink people
+
+- **WHEN** a user adds or removes a linked person
+- **THEN** the application calls the appropriate API endpoint and updates the linked people display

--- a/openspec/changes/initiative-management/specs/initiative-management/spec.md
+++ b/openspec/changes/initiative-management/specs/initiative-management/spec.md
@@ -112,7 +112,7 @@ The system SHALL enforce the initiative status state machine. Valid transitions:
 
 ### Requirement: Manage milestones
 
-The system SHALL allow an authenticated user to add, update, remove, and complete milestones on an initiative. Milestones have a title (required), target date (required), and optional description. The system SHALL reject milestone operations on terminal initiatives. The system SHALL raise a `MilestoneSet` domain event on add/update and a `MilestoneCompleted` domain event on completion.
+The system SHALL allow an authenticated user to add, update, remove, and complete milestones on an initiative. Milestones have a title (required), target date (required, ISO-8601 date format `YYYY-MM-DD`), and optional description. The system SHALL reject milestone operations on terminal initiatives. The system SHALL raise a `MilestoneSet` domain event on add/update and a `MilestoneCompleted` domain event on completion.
 
 #### Scenario: Add a milestone
 
@@ -175,7 +175,7 @@ The system SHALL allow an authenticated user to link and unlink people to/from a
 
 ### Requirement: Multi-tenant initiative isolation
 
-All initiative data SHALL be automatically scoped to the authenticated user's UserId via EF Core global query filters. A user SHALL NOT be able to access, modify, or list another user's initiatives.
+All initiative data SHALL be automatically scoped to the authenticated user's UserId. A user SHALL NOT be able to access, modify, or list another user's initiatives.
 
 #### Scenario: Cross-tenant access prevented
 

--- a/openspec/changes/initiative-management/specs/initiative-management/spec.md
+++ b/openspec/changes/initiative-management/specs/initiative-management/spec.md
@@ -108,7 +108,7 @@ The system SHALL enforce the initiative status state machine. Valid transitions:
 #### Scenario: Same status is no-op
 
 - **WHEN** an authenticated user sends a PUT to change status to the initiative's current status
-- **THEN** the system returns the initiative unchanged with HTTP 200
+- **THEN** the system returns the initiative unchanged with HTTP 200 and does not raise a domain event
 
 ### Requirement: Manage milestones
 
@@ -171,7 +171,7 @@ The system SHALL allow an authenticated user to link and unlink people to/from a
 #### Scenario: Link non-existent person rejected
 
 - **WHEN** an authenticated user sends a POST to link a personId that does not exist or belongs to another user
-- **THEN** the system returns HTTP 400 indicating the person was not found
+- **THEN** the system returns HTTP 404 indicating the person was not found (consistent anti-enumeration: cross-tenant IDs appear as non-existent)
 
 ### Requirement: Multi-tenant initiative isolation
 

--- a/openspec/changes/initiative-management/tasks.md
+++ b/openspec/changes/initiative-management/tasks.md
@@ -1,0 +1,79 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create InitiativeStatus enum (Active, OnHold, Completed, Cancelled) with valid transition logic
+- [ ] 1.2 Create Milestone value object (Id, Title, TargetDate, Description, IsCompleted)
+- [ ] 1.3 Create Initiative aggregate root with core properties (Title, Status, Milestones, LinkedPersonIds), factory Create method, and IUserScoped
+- [ ] 1.4 Implement Initiative business actions: UpdateTitle, ChangeStatus (with state machine validation), SetMilestone, RemoveMilestone, CompleteMilestone, LinkPerson, UnlinkPerson
+- [ ] 1.5 Create domain events: InitiativeCreated, InitiativeTitleUpdated, InitiativeStatusChanged, MilestoneSet, MilestoneCompleted, PersonLinkedToInitiative, PersonUnlinkedFromInitiative
+- [ ] 1.6 Create IInitiativeRepository interface (GetByIdAsync, GetAllAsync, AddAsync)
+
+## 2. Domain Tests
+
+- [ ] 2.1 Test Initiative.Create with valid title and rejects empty title
+- [ ] 2.2 Test ChangeStatus valid transitions (Active→OnHold, OnHold→Active, Active→Completed, Active→Cancelled)
+- [ ] 2.3 Test ChangeStatus rejects invalid transitions (OnHold→Completed, terminal→any)
+- [ ] 2.4 Test UpdateTitle on active/on-hold and rejects on terminal
+- [ ] 2.5 Test milestone operations: add, update, remove, complete, rejects on terminal
+- [ ] 2.6 Test LinkPerson/UnlinkPerson and idempotent link behaviour
+
+## 3. Application Layer
+
+- [ ] 3.1 Create InitiativeDtos (CreateInitiativeRequest, UpdateTitleRequest, ChangeStatusRequest, MilestoneRequest, LinkPersonRequest, InitiativeResponse, MilestoneResponse)
+- [ ] 3.2 Create CreateInitiative handler
+- [ ] 3.3 Create GetInitiative handler
+- [ ] 3.4 Create GetInitiatives handler with status filter
+- [ ] 3.5 Create UpdateInitiativeTitle handler
+- [ ] 3.6 Create ChangeInitiativeStatus handler
+- [ ] 3.7 Create AddMilestone, UpdateMilestone, RemoveMilestone, CompleteMilestone handlers
+- [ ] 3.8 Create LinkPerson and UnlinkPerson handlers (with person existence validation via IPersonRepository)
+
+## 4. Infrastructure Layer
+
+- [ ] 4.1 Create InitiativeConfiguration (EF Core fluent API with OwnsMany for Milestones, separate table for LinkedPersonIds)
+- [ ] 4.2 Create InitiativeRepository implementing IInitiativeRepository
+- [ ] 4.3 Add Initiative DbSet to MentalMetalDbContext and IUserScoped global query filter
+- [ ] 4.4 Create EF Core migration for Initiative and related tables
+- [ ] 4.5 Register InitiativeRepository in DependencyInjection
+
+## 5. Web Layer (API Endpoints)
+
+- [ ] 5.1 Add POST /api/initiatives endpoint (CreateInitiative)
+- [ ] 5.2 Add GET /api/initiatives endpoint (GetInitiatives with status filter)
+- [ ] 5.3 Add GET /api/initiatives/{id} endpoint (GetInitiative)
+- [ ] 5.4 Add PUT /api/initiatives/{id} endpoint (UpdateInitiativeTitle)
+- [ ] 5.5 Add PUT /api/initiatives/{id}/status endpoint (ChangeInitiativeStatus)
+- [ ] 5.6 Add POST /api/initiatives/{id}/milestones endpoint (AddMilestone)
+- [ ] 5.7 Add PUT /api/initiatives/{id}/milestones/{milestoneId} endpoint (UpdateMilestone)
+- [ ] 5.8 Add DELETE /api/initiatives/{id}/milestones/{milestoneId} endpoint (RemoveMilestone)
+- [ ] 5.9 Add POST /api/initiatives/{id}/milestones/{milestoneId}/complete endpoint (CompleteMilestone)
+- [ ] 5.10 Add POST /api/initiatives/{id}/link-person endpoint (LinkPerson)
+- [ ] 5.11 Add DELETE /api/initiatives/{id}/link-person/{personId} endpoint (UnlinkPerson)
+
+## 6. Frontend — Service and Models
+
+- [ ] 6.1 Create Initiative TypeScript models (Initiative, InitiativeStatus, Milestone, CreateInitiativeRequest, UpdateTitleRequest, MilestoneRequest, LinkPersonRequest)
+- [ ] 6.2 Create InitiativesService with all API calls (list, get, create, updateTitle, changeStatus, addMilestone, updateMilestone, removeMilestone, completeMilestone, linkPerson, unlinkPerson)
+
+## 7. Frontend — Initiatives List Page
+
+- [ ] 7.1 Create InitiativesListComponent with PrimeNG Table (title, status badge, milestone count)
+- [ ] 7.2 Add status filter dropdown
+- [ ] 7.3 Add empty state with "New Initiative" prompt
+- [ ] 7.4 Add "New Initiative" button that opens create dialog
+- [ ] 7.5 Create CreateInitiativeDialogComponent with title field
+- [ ] 7.6 Add route for initiatives list page
+
+## 8. Frontend — Initiative Detail Page
+
+- [ ] 8.1 Create InitiativeDetailComponent with title editing and status display
+- [ ] 8.2 Add status transition buttons based on current status
+- [ ] 8.3 Add milestones section with add, edit, complete, and remove functionality
+- [ ] 8.4 Add linked people section with add/remove using person autocomplete
+- [ ] 8.5 Add route for initiative detail page
+
+## 9. Integration Testing
+
+- [ ] 9.1 Add E2E tests for initiative CRUD (create, list, get, update title)
+- [ ] 9.2 Add E2E tests for status transitions (hold, resume, complete, cancel, invalid)
+- [ ] 9.3 Add E2E tests for milestone operations
+- [ ] 9.4 Add E2E test for multi-tenant isolation

--- a/openspec/changes/person-management/.openspec.yaml
+++ b/openspec/changes/person-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/person-management/design.md
+++ b/openspec/changes/person-management/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Mental Metal has two Tier 1 specs implemented (user-auth-tenancy, ai-provider-abstraction). The Person aggregate is defined in the domain model but has no implementation yet. Person is the hub aggregate — most Tier 2 features depend on it. The existing codebase establishes clear patterns: DDD aggregates with rich behaviour, vertical slice handlers, EF Core OwnsOne for value objects, minimal APIs, and Angular standalone components with signals.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement the Person aggregate with full DDD behaviour matching the domain model
+- Provide CRUD API endpoints and Angular UI for managing people
+- Support type-specific value objects (CareerDetails for direct reports, CandidateDetails for candidates)
+- Enforce all domain invariants (unique name per user, type-specific constraints, pipeline state machine)
+
+**Non-Goals:**
+- 1:1 records, observations, goals (people-lens, Tier 2)
+- Linking people to initiatives or captures (handled by those specs)
+- Interview scorecards or detailed pipeline UI (interview-tracking, Tier 3)
+- AI-powered features (no AI in this spec)
+
+## Dependencies
+
+- `user-auth-tenancy` — UserId scoping, ICurrentUserService, authentication
+
+## Decisions
+
+### 1. Person aggregate follows existing User aggregate patterns
+
+**Decision:** Mirror the established patterns — factory method for creation, value objects via EF Core OwnsOne, domain events, IUserScoped interface.
+
+**Rationale:** Consistency reduces cognitive load and leverages proven infrastructure (global query filters, event dispatching). The User aggregate is a well-tested reference implementation.
+
+**Alternatives considered:**
+- Anemic model with service-layer logic: Rejected — violates DDD principles established in CLAUDE.md
+- Generic repository: Rejected — dedicated IPersonRepository allows aggregate-specific query methods
+
+### 2. PersonType as enum, type-specific VOs as nullable owned entities
+
+**Decision:** PersonType is a simple enum (DirectReport, Stakeholder, Candidate). CareerDetails and CandidateDetails are nullable value objects mapped via OwnsOne. Domain methods enforce which VO is valid for which type.
+
+**Rationale:** EF Core OwnsOne handles nullable owned types well. The aggregate enforces invariants (CareerDetails only for DirectReport, CandidateDetails only for Candidate). Simpler than TPH inheritance.
+
+**Alternatives considered:**
+- Table-per-hierarchy with discriminator: Rejected — over-engineering for what is essentially optional VOs on a single entity
+- JSON columns for type-specific data: Rejected — loses queryability and type safety
+
+### 3. Candidate pipeline as a state machine on the value object
+
+**Decision:** PipelineStatus is an enum with valid transitions enforced by the AdvanceCandidatePipeline domain method. Transitions: New → Screening → Interviewing → OfferStage → Hired/Rejected/Withdrawn. Rejected/Withdrawn can happen from any active state.
+
+**Rationale:** Simple enum + guard method is sufficient. No need for a formal state machine library — the transitions are straightforward and the aggregate enforces them.
+
+### 4. Soft archive via IsArchived flag
+
+**Decision:** Archive sets an IsArchived bool + ArchivedAt timestamp. Archived people are excluded from default list queries but remain in the database for referential integrity with future Tier 2 entities.
+
+**Rationale:** Hard delete would break future foreign key references from commitments, delegations, etc. Soft archive is the standard DDD approach for entities with cross-aggregate references.
+
+### 5. API design: RESTful under /api/people
+
+**Decision:** Endpoints follow REST conventions:
+- `GET /api/people` — list (with optional type filter, includes archived=false by default)
+- `GET /api/people/{id}` — get by ID
+- `POST /api/people` — create
+- `PUT /api/people/{id}` — update profile
+- `PUT /api/people/{id}/type` — change type
+- `PUT /api/people/{id}/career-details` — update career details (direct reports only)
+- `PUT /api/people/{id}/candidate-details` — update candidate details (candidates only)
+- `POST /api/people/{id}/advance-pipeline` — advance candidate pipeline
+- `POST /api/people/{id}/archive` — archive
+
+**Rationale:** Matches the domain's business actions. Separate endpoints for type-specific operations provide clear validation boundaries.
+
+### 6. Frontend: PrimeNG DataTable for list, Dialog for create/edit
+
+**Decision:** Use PrimeNG Table component for the people list with filtering by type. Use PrimeNG Dialog with reactive/signal forms for create and edit. Type-specific sections show/hide based on PersonType selection.
+
+**Rationale:** PrimeNG-first approach per CLAUDE.md. DataTable provides sorting, filtering, and pagination out of the box. Dialog keeps the user in context.
+
+### 7. Unique name constraint at both domain and database level
+
+**Decision:** The domain method checks uniqueness via a repository method `ExistsByNameAsync(userId, name, excludeId?)`. The database has a unique filtered index on (UserId, Name) where IsArchived = false.
+
+**Rationale:** Domain validation gives clear error messages. Database index prevents race conditions. Filtered index allows archived people to share names with active ones.
+
+## Risks / Trade-offs
+
+- **[Name uniqueness race condition]** → Mitigated by unique database index. Domain check is for UX; DB constraint is the safety net.
+- **[OwnsOne nullable mapping complexity]** → EF Core handles this well with the existing patterns (see UserConfiguration for AiProviderConfig). Follow the same approach.
+- **[Type change loses details]** → By design: changing from DirectReport clears CareerDetails, changing from Candidate clears CandidateDetails. The domain event captures the transition for audit. Candidate → DirectReport preserves interview history (handled by interview-tracking spec later).
+
+## Open Questions
+
+None — the domain model is well-defined and the implementation patterns are established.

--- a/openspec/changes/person-management/proposal.md
+++ b/openspec/changes/person-management/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Person is the hub aggregate in Mental Metal — most Tier 2 capabilities (commitment-tracking, delegation-tracking, people-lens, capture-ai-extraction) require linking to people. Without person-management, no people can be created and those six dependent specs remain blocked. This is one of the last two Tier 1 foundation specs.
+
+## What Changes
+
+- Add the **Person** aggregate with full DDD behaviour: create, update profile, change type, archive
+- Support three person types: **DirectReport**, **Stakeholder**, **Candidate** — each with type-specific value objects (CareerDetails, CandidateDetails)
+- Enforce invariants: unique name per user, type-specific detail constraints, candidate pipeline state machine
+- Expose minimal API endpoints for CRUD operations and type-specific actions
+- Add EF Core persistence with PostgreSQL, including migrations
+- Add Angular frontend for listing, creating, editing, and archiving people
+
+## Non-goals
+
+- **1:1 records, observations, goals** — those belong to `people-lens` (Tier 2)
+- **Linking people to initiatives or captures** — handled by respective specs
+- **AI-powered features** — no AI extraction or summarisation in this spec
+- **Interview scorecards or pipeline management UI** — belongs to `interview-tracking` (Tier 3)
+- **Bulk import/export** — future enhancement
+
+## Capabilities
+
+### New Capabilities
+- `person-management`: Create, edit, archive, and manage people with types (direct-report, stakeholder, candidate), career details, candidate pipeline tracking, and team assignment
+
+### Modified Capabilities
+<!-- No existing spec requirements are changing -->
+
+## Impact
+
+- **Domain layer**: New Person aggregate root, PersonType enum, CareerDetails/CandidateDetails value objects, domain events, IPersonRepository
+- **Application layer**: Vertical slice handlers for create, update, change type, archive, list, get
+- **Infrastructure layer**: EF Core configuration, PersonRepository, database migration
+- **Web layer**: Minimal API endpoints under `/api/people`
+- **Frontend**: Person list view, create/edit forms with type-specific sections
+- **Tier**: Tier 1 — Foundation
+- **Dependencies**: `user-auth-tenancy` (for UserId scoping and authentication)
+- **Dependents**: 6 of 8 Tier 2 specs depend on this

--- a/openspec/changes/person-management/specs/person-management/spec.md
+++ b/openspec/changes/person-management/specs/person-management/spec.md
@@ -83,8 +83,8 @@ The system SHALL allow an authenticated user to update a person's profile fields
 
 #### Scenario: Full replacement update
 
-- **WHEN** an authenticated user sends a PUT with only name and team (other fields null)
-- **THEN** the system replaces all profile fields with the submitted values — null fields are cleared
+- **WHEN** an authenticated user sends a PUT with name and team provided but email, role, and notes set to null
+- **THEN** the system replaces all profile fields with the submitted values — explicit null clears the field (PUT full-replacement semantics, not PATCH)
 
 #### Scenario: Update with duplicate name rejected
 
@@ -118,7 +118,7 @@ The system SHALL allow an authenticated user to change a person's type. When cha
 #### Scenario: Same type is no-op
 
 - **WHEN** an authenticated user sends a PUT to change type to the person's current type
-- **THEN** the system returns the person unchanged with HTTP 200
+- **THEN** the system returns the person unchanged with HTTP 200 and does not raise a domain event
 
 ### Requirement: Update career details for direct reports
 

--- a/openspec/changes/person-management/specs/person-management/spec.md
+++ b/openspec/changes/person-management/specs/person-management/spec.md
@@ -81,10 +81,10 @@ The system SHALL allow an authenticated user to update a person's profile fields
 - **WHEN** an authenticated user sends a PUT to `/api/people/{id}` with updated name, email, role, team, and notes
 - **THEN** the system updates the person, sets UpdatedAt, and returns the updated person
 
-#### Scenario: Partial update
+#### Scenario: Full replacement update
 
 - **WHEN** an authenticated user sends a PUT with only name and team (other fields null)
-- **THEN** the system updates the provided fields and clears the null fields (full replacement semantics)
+- **THEN** the system replaces all profile fields with the submitted values — null fields are cleared
 
 #### Scenario: Update with duplicate name rejected
 
@@ -154,7 +154,7 @@ The system SHALL allow an authenticated user to advance a candidate's pipeline s
 
 #### Scenario: Advance from New to Screening
 
-- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Screening" for a Candidate with status "New"
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with newStatus "Screening" for a Candidate with pipelineStatus "New"
 - **THEN** the system updates PipelineStatus to Screening and returns the updated person
 
 #### Scenario: Advance through full pipeline
@@ -164,12 +164,12 @@ The system SHALL allow an authenticated user to advance a candidate's pipeline s
 
 #### Scenario: Reject from any active state
 
-- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Rejected" for a Candidate in any non-terminal state
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with newStatus "Rejected" for a Candidate in any non-terminal state
 - **THEN** the system updates PipelineStatus to Rejected
 
 #### Scenario: Withdraw from any active state
 
-- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Withdrawn" for a Candidate in any non-terminal state
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with newStatus "Withdrawn" for a Candidate in any non-terminal state
 - **THEN** the system updates PipelineStatus to Withdrawn
 
 #### Scenario: Invalid transition rejected
@@ -203,7 +203,7 @@ The system SHALL allow an authenticated user to archive a person via soft-delete
 
 ### Requirement: Multi-tenant person isolation
 
-All person data SHALL be automatically scoped to the authenticated user's UserId via EF Core global query filters. A user SHALL NOT be able to access, modify, or list another user's people.
+All person data SHALL be automatically scoped to the authenticated user's UserId. A user SHALL NOT be able to access, modify, or list another user's people.
 
 #### Scenario: Cross-tenant access prevented
 

--- a/openspec/changes/person-management/specs/person-management/spec.md
+++ b/openspec/changes/person-management/specs/person-management/spec.md
@@ -1,0 +1,278 @@
+## ADDED Requirements
+
+### Requirement: Create a person
+
+The system SHALL allow an authenticated user to create a new Person with a name and person type (DirectReport, Stakeholder, or Candidate). Name MUST NOT be empty. Name MUST be unique among the user's non-archived people. The system SHALL raise a `PersonCreated` domain event. The Person SHALL be scoped to the authenticated user's UserId.
+
+#### Scenario: Create a direct report
+
+- **WHEN** an authenticated user sends a POST to `/api/people` with name "Alice Smith" and type "DirectReport"
+- **THEN** the system creates a Person with the given name and type, sets CreatedAt and UpdatedAt, and returns the created person with HTTP 201
+
+#### Scenario: Create a stakeholder with optional fields
+
+- **WHEN** an authenticated user sends a POST to `/api/people` with name "Bob Jones", type "Stakeholder", email "bob@example.com", role "VP Engineering", and team "Platform"
+- **THEN** the system creates a Person with all provided fields and returns HTTP 201
+
+#### Scenario: Create a candidate
+
+- **WHEN** an authenticated user sends a POST to `/api/people` with name "Carol White" and type "Candidate"
+- **THEN** the system creates a Person with type Candidate and initialises CandidateDetails with PipelineStatus "New"
+
+#### Scenario: Empty name rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/people` with an empty name
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: Duplicate name rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/people` with a name that already exists among their non-archived people
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a person named "Alice" and User B creates a person named "Alice"
+- **THEN** both operations succeed because name uniqueness is scoped per user
+
+### Requirement: List people
+
+The system SHALL allow an authenticated user to retrieve a list of their people. The list SHALL exclude archived people by default. The list SHALL support optional filtering by person type.
+
+#### Scenario: List all active people
+
+- **WHEN** an authenticated user sends a GET to `/api/people`
+- **THEN** the system returns all non-archived people belonging to that user
+
+#### Scenario: Filter by type
+
+- **WHEN** an authenticated user sends a GET to `/api/people?type=DirectReport`
+- **THEN** the system returns only non-archived people with type DirectReport
+
+#### Scenario: Include archived
+
+- **WHEN** an authenticated user sends a GET to `/api/people?includeArchived=true`
+- **THEN** the system returns all people including archived ones
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no people sends a GET to `/api/people`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get person by ID
+
+The system SHALL allow an authenticated user to retrieve a single person by ID.
+
+#### Scenario: Get existing person
+
+- **WHEN** an authenticated user sends a GET to `/api/people/{id}` with a valid person ID
+- **THEN** the system returns the person with all details including type-specific details (CareerDetails or CandidateDetails)
+
+#### Scenario: Person not found
+
+- **WHEN** an authenticated user sends a GET to `/api/people/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Update person profile
+
+The system SHALL allow an authenticated user to update a person's profile fields: name, email, role, team, and notes. Name MUST NOT be empty. Updated name MUST be unique among the user's non-archived people. The system SHALL raise a `PersonProfileUpdated` domain event.
+
+#### Scenario: Update profile successfully
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}` with updated name, email, role, team, and notes
+- **THEN** the system updates the person, sets UpdatedAt, and returns the updated person
+
+#### Scenario: Partial update
+
+- **WHEN** an authenticated user sends a PUT with only name and team (other fields null)
+- **THEN** the system updates the provided fields and clears the null fields (full replacement semantics)
+
+#### Scenario: Update with duplicate name rejected
+
+- **WHEN** an authenticated user sends a PUT with a name that belongs to another non-archived person
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: Update archived person rejected
+
+- **WHEN** an authenticated user sends a PUT to update an archived person
+- **THEN** the system returns HTTP 400 indicating archived people cannot be modified
+
+### Requirement: Change person type
+
+The system SHALL allow an authenticated user to change a person's type. When changing from DirectReport, CareerDetails SHALL be cleared. When changing from Candidate, CandidateDetails SHALL be cleared. When changing to Candidate, CandidateDetails SHALL be initialised with PipelineStatus "New". The system SHALL raise a `PersonTypeChanged` domain event.
+
+#### Scenario: Change stakeholder to direct report
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/type` with type "DirectReport"
+- **THEN** the system changes the person's type and returns the updated person
+
+#### Scenario: Change direct report to candidate
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/type` for a DirectReport with type "Candidate"
+- **THEN** the system changes the type, clears CareerDetails, initialises CandidateDetails with PipelineStatus "New"
+
+#### Scenario: Change candidate to direct report
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/type` for a Candidate with type "DirectReport"
+- **THEN** the system changes the type and clears CandidateDetails (interview history preserved by interview-tracking spec)
+
+#### Scenario: Same type is no-op
+
+- **WHEN** an authenticated user sends a PUT to change type to the person's current type
+- **THEN** the system returns the person unchanged with HTTP 200
+
+### Requirement: Update career details for direct reports
+
+The system SHALL allow an authenticated user to update CareerDetails (level, aspirations, growthAreas) for a person with type DirectReport. The system SHALL reject updates for non-DirectReport people. The system SHALL raise a `CareerDetailsUpdated` domain event.
+
+#### Scenario: Update career details successfully
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/career-details` with level, aspirations, and growthAreas for a DirectReport
+- **THEN** the system updates the CareerDetails and returns the updated person
+
+#### Scenario: Career details for non-direct-report rejected
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/career-details` for a Stakeholder or Candidate
+- **THEN** the system returns HTTP 400 indicating career details are only valid for direct reports
+
+### Requirement: Update candidate details
+
+The system SHALL allow an authenticated user to update CandidateDetails (pipelineStatus, cvNotes, sourceChannel) for a person with type Candidate. The system SHALL reject updates for non-Candidate people. The system SHALL raise a `CandidateDetailsUpdated` domain event.
+
+#### Scenario: Update candidate details successfully
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/candidate-details` with cvNotes and sourceChannel for a Candidate
+- **THEN** the system updates the CandidateDetails and returns the updated person
+
+#### Scenario: Candidate details for non-candidate rejected
+
+- **WHEN** an authenticated user sends a PUT to `/api/people/{id}/candidate-details` for a DirectReport or Stakeholder
+- **THEN** the system returns HTTP 400 indicating candidate details are only valid for candidates
+
+### Requirement: Advance candidate pipeline
+
+The system SHALL allow an authenticated user to advance a candidate's pipeline status. Valid transitions: New → Screening → Interviewing → OfferStage → Hired. Rejected and Withdrawn are terminal states reachable from any non-terminal state. The system SHALL raise a `CandidatePipelineAdvanced` domain event.
+
+#### Scenario: Advance from New to Screening
+
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Screening" for a Candidate with status "New"
+- **THEN** the system updates PipelineStatus to Screening and returns the updated person
+
+#### Scenario: Advance through full pipeline
+
+- **WHEN** a candidate progresses New → Screening → Interviewing → OfferStage → Hired
+- **THEN** each transition succeeds and raises a CandidatePipelineAdvanced event
+
+#### Scenario: Reject from any active state
+
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Rejected" for a Candidate in any non-terminal state
+- **THEN** the system updates PipelineStatus to Rejected
+
+#### Scenario: Withdraw from any active state
+
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` with status "Withdrawn" for a Candidate in any non-terminal state
+- **THEN** the system updates PipelineStatus to Withdrawn
+
+#### Scenario: Invalid transition rejected
+
+- **WHEN** an authenticated user tries to advance a candidate from Screening directly to OfferStage (skipping Interviewing)
+- **THEN** the system returns HTTP 400 indicating invalid pipeline transition
+
+#### Scenario: Advance from terminal state rejected
+
+- **WHEN** an authenticated user tries to advance a Hired, Rejected, or Withdrawn candidate
+- **THEN** the system returns HTTP 400 indicating the pipeline is in a terminal state
+
+#### Scenario: Advance non-candidate rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/advance-pipeline` for a non-Candidate person
+- **THEN** the system returns HTTP 400 indicating pipeline advancement is only valid for candidates
+
+### Requirement: Archive a person
+
+The system SHALL allow an authenticated user to archive a person via soft-delete. Archived people SHALL be excluded from default list queries. Archived people SHALL remain in the database for referential integrity. The system SHALL raise a `PersonArchived` domain event.
+
+#### Scenario: Archive a person
+
+- **WHEN** an authenticated user sends a POST to `/api/people/{id}/archive`
+- **THEN** the system sets IsArchived to true and ArchivedAt to the current time, and returns HTTP 204
+
+#### Scenario: Archive already-archived person is idempotent
+
+- **WHEN** an authenticated user archives an already-archived person
+- **THEN** the system returns HTTP 204 without raising a duplicate event
+
+### Requirement: Multi-tenant person isolation
+
+All person data SHALL be automatically scoped to the authenticated user's UserId via EF Core global query filters. A user SHALL NOT be able to access, modify, or list another user's people.
+
+#### Scenario: Cross-tenant access prevented
+
+- **WHEN** User A attempts to GET `/api/people/{id}` with an ID belonging to User B
+- **THEN** the system returns HTTP 404 (not 403, to avoid leaking existence)
+
+### Requirement: Frontend people list page
+
+The Angular application SHALL provide a people list page displaying all active people in a PrimeNG Table with columns for name, type, role, and team. The list SHALL support filtering by person type. The list SHALL support a search/filter for name.
+
+#### Scenario: View people list
+
+- **WHEN** an authenticated user navigates to the people page
+- **THEN** the page displays a table of all active people with name, type, role, and team columns
+
+#### Scenario: Filter by type
+
+- **WHEN** a user selects a type filter (e.g., "Direct Reports")
+- **THEN** the table shows only people of that type
+
+#### Scenario: Empty state
+
+- **WHEN** a user has no people
+- **THEN** the page displays an empty state message with a prompt to add their first person
+
+### Requirement: Frontend create person form
+
+The Angular application SHALL provide a form (in a PrimeNG Dialog) to create a new person. The form SHALL include fields for name (required), type (required), email, role, and team. Type-specific sections SHALL appear based on the selected type.
+
+#### Scenario: Create person via dialog
+
+- **WHEN** a user clicks the "Add Person" button and fills in name and type
+- **THEN** the dialog submits to the API and on success closes the dialog and adds the person to the list
+
+#### Scenario: Validation feedback
+
+- **WHEN** a user submits the form with an empty name
+- **THEN** the form displays a validation error without submitting to the API
+
+### Requirement: Frontend edit person page
+
+The Angular application SHALL provide a detail/edit view for a person. The view SHALL display all person fields and allow editing. Type-specific sections (career details, candidate details) SHALL be shown based on person type.
+
+#### Scenario: View person details
+
+- **WHEN** a user clicks on a person in the list
+- **THEN** the application navigates to the person detail view showing all fields
+
+#### Scenario: Edit person profile
+
+- **WHEN** a user edits profile fields and saves
+- **THEN** the application sends the update to the API and reflects changes on success
+
+#### Scenario: Change person type
+
+- **WHEN** a user changes the person's type in the detail view
+- **THEN** the application calls the type change endpoint and updates the displayed type-specific sections
+
+#### Scenario: Update career details for direct report
+
+- **WHEN** a user edits career details (level, aspirations, growth areas) for a direct report
+- **THEN** the application saves the career details via the API
+
+#### Scenario: Advance candidate pipeline
+
+- **WHEN** a user clicks an advance button for a candidate
+- **THEN** the application calls the advance-pipeline endpoint and updates the displayed status
+
+#### Scenario: Archive person
+
+- **WHEN** a user clicks "Archive" and confirms
+- **THEN** the application calls the archive endpoint and removes the person from the active list

--- a/openspec/changes/person-management/tasks.md
+++ b/openspec/changes/person-management/tasks.md
@@ -1,0 +1,82 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create PersonType enum (DirectReport, Stakeholder, Candidate) and PipelineStatus enum (New, Screening, Interviewing, OfferStage, Hired, Rejected, Withdrawn)
+- [ ] 1.2 Create CareerDetails value object (Level, Aspirations, GrowthAreas)
+- [ ] 1.3 Create CandidateDetails value object (PipelineStatus, CvNotes, SourceChannel) with pipeline transition validation
+- [ ] 1.4 Create Person aggregate root with all properties, factory Create method, and IUserScoped
+- [ ] 1.5 Implement Person business actions: UpdateProfile, ChangeType, UpdateCareerDetails, UpdateCandidateDetails, AdvanceCandidatePipeline, Archive
+- [ ] 1.6 Create domain events: PersonCreated, PersonProfileUpdated, PersonTypeChanged, CareerDetailsUpdated, CandidateDetailsUpdated, CandidatePipelineAdvanced, PersonArchived
+- [ ] 1.7 Create IPersonRepository interface (GetByIdAsync, GetAllAsync, ExistsByNameAsync, AddAsync)
+
+## 2. Domain Tests
+
+- [ ] 2.1 Test Person.Create with valid inputs and all three types
+- [ ] 2.2 Test Person.Create rejects empty name
+- [ ] 2.3 Test UpdateProfile sets fields and raises event
+- [ ] 2.4 Test ChangeType clears/initialises type-specific details correctly
+- [ ] 2.5 Test CareerDetails only settable on DirectReport
+- [ ] 2.6 Test CandidateDetails only settable on Candidate
+- [ ] 2.7 Test AdvanceCandidatePipeline valid transitions and rejects invalid ones
+- [ ] 2.8 Test Archive sets IsArchived and is idempotent
+
+## 3. Application Layer
+
+- [ ] 3.1 Create PersonDtos (CreatePersonRequest, UpdatePersonRequest, ChangeTypeRequest, CareerDetailsRequest, CandidateDetailsRequest, AdvancePipelineRequest, PersonResponse)
+- [ ] 3.2 Create CreatePerson handler with name uniqueness check
+- [ ] 3.3 Create GetPerson handler
+- [ ] 3.4 Create GetPeople handler with type filter and includeArchived support
+- [ ] 3.5 Create UpdatePersonProfile handler with name uniqueness check
+- [ ] 3.6 Create ChangePersonType handler
+- [ ] 3.7 Create UpdateCareerDetails handler
+- [ ] 3.8 Create UpdateCandidateDetails handler
+- [ ] 3.9 Create AdvanceCandidatePipeline handler
+- [ ] 3.10 Create ArchivePerson handler
+
+## 4. Infrastructure Layer
+
+- [ ] 4.1 Create PersonConfiguration (EF Core fluent API with OwnsOne for CareerDetails and CandidateDetails, unique filtered index on UserId+Name)
+- [ ] 4.2 Create PersonRepository implementing IPersonRepository
+- [ ] 4.3 Add Person DbSet to MentalMetalDbContext and IUserScoped global query filter
+- [ ] 4.4 Create EF Core migration for Person table
+- [ ] 4.5 Register PersonRepository in DependencyInjection
+
+## 5. Web Layer (API Endpoints)
+
+- [ ] 5.1 Add POST /api/people endpoint (CreatePerson)
+- [ ] 5.2 Add GET /api/people endpoint (GetPeople with type filter)
+- [ ] 5.3 Add GET /api/people/{id} endpoint (GetPerson)
+- [ ] 5.4 Add PUT /api/people/{id} endpoint (UpdatePersonProfile)
+- [ ] 5.5 Add PUT /api/people/{id}/type endpoint (ChangePersonType)
+- [ ] 5.6 Add PUT /api/people/{id}/career-details endpoint (UpdateCareerDetails)
+- [ ] 5.7 Add PUT /api/people/{id}/candidate-details endpoint (UpdateCandidateDetails)
+- [ ] 5.8 Add POST /api/people/{id}/advance-pipeline endpoint (AdvanceCandidatePipeline)
+- [ ] 5.9 Add POST /api/people/{id}/archive endpoint (ArchivePerson)
+
+## 6. Frontend — Service and Models
+
+- [ ] 6.1 Create Person TypeScript models (Person, PersonType, PipelineStatus, CareerDetails, CandidateDetails, CreatePersonRequest, UpdatePersonRequest)
+- [ ] 6.2 Create PeopleService with all API calls (list, get, create, update, changeType, updateCareerDetails, updateCandidateDetails, advancePipeline, archive)
+
+## 7. Frontend — People List Page
+
+- [ ] 7.1 Create PeopleListComponent with PrimeNG Table (name, type, role, team columns)
+- [ ] 7.2 Add type filter dropdown and name search
+- [ ] 7.3 Add empty state with "Add Person" prompt
+- [ ] 7.4 Add "Add Person" button that opens create dialog
+- [ ] 7.5 Create CreatePersonDialogComponent with form (name, type, email, role, team)
+- [ ] 7.6 Add route for people list page
+
+## 8. Frontend — Person Detail/Edit Page
+
+- [ ] 8.1 Create PersonDetailComponent with profile display and edit form
+- [ ] 8.2 Add type change section with confirmation
+- [ ] 8.3 Add CareerDetails section (visible for DirectReport only)
+- [ ] 8.4 Add CandidateDetails section with pipeline status and advance button (visible for Candidate only)
+- [ ] 8.5 Add archive button with confirmation dialog
+- [ ] 8.6 Add route for person detail page
+
+## 9. Integration Testing
+
+- [ ] 9.1 Add E2E tests for person CRUD (create, list, get, update, archive)
+- [ ] 9.2 Add E2E tests for type-specific operations (career details, candidate pipeline)
+- [ ] 9.3 Add E2E test for multi-tenant isolation


### PR DESCRIPTION
## Summary

Add OpenSpec change artifacts (proposal, design, specs, tasks) for the last two Tier 1 foundation specs: **person-management** and **initiative-management**. These unblock 6 of 8 Tier 2 capabilities.

## Changes

- `openspec/changes/person-management/` — proposal, design, spec (13 requirements), and task list (39 tasks across 9 groups)
- `openspec/changes/initiative-management/` — proposal, design, spec (12 requirements), and task list (38 tasks across 9 groups)

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (81 tests, docs-only change)
- [x] `ng test --watch=false` passes (14 tests)
- [x] All files are documentation only (`.md`, `.yaml`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Tier 1 OpenSpec documentation for foundational person and initiative management capabilities, including domain design, requirements, and implementation task breakdowns for backend and frontend.

Documentation:
- Document detailed functional requirements and user flows for person management, including CRUD, type-specific details, candidate pipeline, archiving, and Angular UI pages.
- Document detailed functional requirements and user flows for initiative management, including CRUD, status state machine, milestones, linked people, and Angular UI pages.
- Capture high-level design decisions, goals, non-goals, dependencies, and risks for the new person-management and initiative-management aggregates.

Chores:
- Introduce OpenSpec metadata and task lists for implementing person-management and initiative-management across domain, application, infrastructure, API, frontend, and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specs and design proposals for Initiative Management: core metadata, status state machine, milestone management, person linking, API surface, and UI list/detail pages.
  * Added comprehensive specs and design proposals for Person Management: profile CRUD, person types and type-specific details, candidate pipeline rules, archive behavior, API surface, and UI list/detail pages.
  * Added metadata and implementation task checklists for both features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->