### PR TITLE
docs: Propose capture-text, commitment-tracking, delegation-tracking specs

### DIFF
--- a/openspec/changes/capture-text/.openspec.yaml
+++ b/openspec/changes/capture-text/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/capture-text/design.md
+++ b/openspec/changes/capture-text/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Mental Metal currently supports managing People and Initiatives (Tier 1). The next step is enabling users to capture raw text input -- the primary data entry point for the system. Captures are the raw material from which AI extraction (a separate spec) will later derive commitments, delegations, and observations.
+
+This design covers the `capture-text` spec, which handles creating, storing, viewing, and managing raw text captures with a processing status lifecycle. It does NOT cover AI extraction or audio capture.
+
+### Dependencies
+
+- `user-auth-tenancy` (Tier 1) -- for UserId scoping and authentication
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement the Capture aggregate with rich domain behaviour following established DDD patterns
+- Support the full processing status state machine (Raw -> Processing -> Processed -> Failed, with retry)
+- Allow captures to be optionally linked to People and Initiatives by ID
+- Provide a low-friction quick-capture UI and a filterable capture list
+- Follow the same vertical slice, CQRS patterns established by person-management and initiative-management
+
+**Non-Goals:**
+
+- AI extraction pipeline (capture-ai-extraction spec)
+- Audio recording and transcription (capture-audio spec)
+- Daily close-out triage flow (daily-close-out spec)
+- Validating that linked PersonIds/InitiativeIds actually exist (eventual consistency; the Capture aggregate stores IDs only)
+- Full-text search across captures (future enhancement)
+
+## Decisions
+
+### 1. Capture aggregate follows existing DDD patterns
+
+**Decision:** Model the Capture aggregate identically to Person and Initiative -- a rich domain entity with factory method, business actions, value objects, and domain events.
+
+**Rationale:** Consistency with established patterns reduces cognitive load. The Person and Initiative implementations provide a proven template. The Capture domain model is well-defined in `design/domain-model.md`.
+
+**Alternatives considered:**
+- Anemic model with logic in handlers -- rejected because it contradicts the project's DDD principles
+
+### 2. Value objects for CaptureType and ProcessingStatus
+
+**Decision:** Implement `CaptureType` as a C# enum (`QuickNote`, `Transcript`, `MeetingNotes`) and `ProcessingStatus` as a C# enum (`Raw`, `Processing`, `Processed`, `Failed`). Status transitions are enforced by the aggregate's business actions.
+
+**Rationale:** Enums are simple, EF Core maps them natively, and the state machine logic lives on the aggregate root where it belongs. This matches how PersonType is implemented.
+
+**Alternatives considered:**
+- Smart enum pattern (e.g., Ardalis.SmartEnum) -- unnecessary complexity for this use case
+- Status as a separate value object class -- over-engineering given the straightforward state machine
+
+### 3. LinkedPersonIds and LinkedInitiativeIds as List<Guid>
+
+**Decision:** Store linked IDs as `List<Guid>` on the Capture entity. No foreign key constraints. No cross-aggregate validation at the domain level.
+
+**Rationale:** DDD aggregate boundaries: aggregates reference each other by ID only. The Capture aggregate cannot validate that a PersonId exists because Person is a separate aggregate. Eventual consistency is acceptable -- if a linked Person is later deleted, the orphaned ID is harmless.
+
+**Alternatives considered:**
+- Foreign key constraints in EF Core -- violates aggregate boundary principles
+- Domain service to validate IDs before linking -- adds coupling; out of scope for capture-text
+
+### 4. Spawned entity ID lists are empty in capture-text scope
+
+**Decision:** The `SpawnedCommitmentIds`, `SpawnedDelegationIds`, and `SpawnedObservationIds` properties exist on the aggregate but are only populated by the `capture-ai-extraction` spec. The `RecordSpawned*` methods will be implemented but not called by any handler in this spec.
+
+**Rationale:** The domain model defines these properties and they must exist for the aggregate to be complete, but the feature that populates them is in a different spec.
+
+### 5. EF Core configuration for collections
+
+**Decision:** Store `LinkedPersonIds`, `LinkedInitiativeIds`, and spawned ID lists as JSON columns in PostgreSQL using EF Core's JSON column support.
+
+**Rationale:** These are simple `List<Guid>` values that don't need their own tables. PostgreSQL JSON columns are well-supported by Npgsql and avoid join overhead. This is simpler than a many-to-many join table approach.
+
+**Alternatives considered:**
+- Separate join tables -- more complex, unnecessary for ID-only lists that are always loaded with the aggregate
+- PostgreSQL arrays -- JSON is more flexible and better supported by EF Core
+
+### 6. API design follows established conventions
+
+**Decision:** Endpoints under `/api/captures` following the same patterns as `/api/people` and `/api/initiatives`.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/captures` | POST | Create a new capture |
+| `/api/captures` | GET | List user's captures (filterable) |
+| `/api/captures/{id}` | GET | Get capture by ID |
+| `/api/captures/{id}` | PUT | Update title/source metadata |
+| `/api/captures/{id}/link-person` | POST | Link to a person |
+| `/api/captures/{id}/link-initiative` | POST | Link to an initiative |
+| `/api/captures/{id}/unlink-person` | POST | Remove person link |
+| `/api/captures/{id}/unlink-initiative` | POST | Remove initiative link |
+
+**Rationale:** Consistent with existing API patterns. Link/unlink are separate endpoints because they are distinct business actions with their own domain events.
+
+### 7. Frontend uses signal-based state and PrimeNG components
+
+**Decision:** The capture UI consists of a quick-capture dialog (PrimeNG Dialog + InputTextarea), a capture list page (PrimeNG DataView with filters), and a capture detail view. All state management uses Angular signals.
+
+**Rationale:** Follows Angular 21 conventions (zoneless, signals, standalone components) and PrimeNG-first component selection as mandated by CLAUDE.md.
+
+## Risks / Trade-offs
+
+- **[Orphaned links]** If a linked Person or Initiative is deleted, the Capture retains a stale ID. **Mitigation:** This is acceptable per DDD aggregate boundaries. Future clean-up can be handled by a background process or during display (show "deleted person" placeholder).
+
+- **[JSON column query performance]** Querying captures by linked PersonId or InitiativeId requires JSON column queries which may be slower at scale. **Mitigation:** These queries are user-scoped (small dataset per user). If needed, a GIN index on the JSON column can be added later.
+
+- **[Processing status without a processor]** The processing status lifecycle exists but nothing transitions captures past `Raw` status until `capture-ai-extraction` is implemented. **Mitigation:** This is by design. The state machine is correct and ready for the next spec. The UI will show captures as "Raw" status until then.
+
+## Open Questions
+
+_(none -- all decisions are straightforward applications of established patterns)_

--- a/openspec/changes/capture-text/proposal.md
+++ b/openspec/changes/capture-text/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Capture is the primary entry point for all data in Mental Metal. Users need a way to quickly dump raw text -- meeting notes, pasted transcripts, quick thoughts -- into the system with minimal friction. This is the foundational "inbox" that all AI extraction, commitment/delegation spawning, and initiative linking builds upon. Without capture-text, there is no raw material for the AI pipeline to process.
+
+This is a Tier 2 spec (`capture-text`) that depends on `user-auth-tenancy` only. It deliberately excludes AI extraction (that's `capture-ai-extraction`, a separate Tier 2 spec).
+
+## Non-goals
+
+- **No AI processing** -- extraction of action items, commitments, risks is out of scope (see `capture-ai-extraction`)
+- **No audio capture** -- recording and transcription is a Tier 3 concern (see `capture-audio`)
+- **No daily close-out triage** -- reviewing/discarding unprocessed captures is a separate spec
+- **No cross-aggregate validation** -- linking to Person/Initiative IDs is stored but not validated at the domain level (eventual consistency)
+
+## What Changes
+
+- **New Capture aggregate** in the Domain layer with the processing status state machine (Raw -> Processing -> Processed / Failed), capture types (quick-note, transcript, meeting-notes), and ID-only links to people and initiatives
+- **CQRS handlers** for creating captures, listing user captures, getting capture details, linking captures to people/initiatives, and managing the title/source metadata
+- **API endpoints** for capture CRUD and linking operations
+- **EF Core persistence** with PostgreSQL for the Capture entity, including migrations
+- **Angular capture UI** -- a quick-capture input component and a capture list view with filtering by type and status
+
+## Capabilities
+
+### New Capabilities
+
+- `capture-text`: Core capture aggregate -- create, list, view, and manage raw text captures with processing status lifecycle, type classification, and optional links to people and initiatives
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Domain:** New `Capture` aggregate root with value objects (`CaptureType`, `ProcessingStatus`)
+- **Application:** New vertical slice handlers for capture use cases
+- **Infrastructure:** New EF Core configuration and migration for `Captures` table
+- **Web API:** New minimal API endpoints under `/api/captures`
+- **Frontend:** New capture components, capture service, and routing
+- **Dependencies:** Only `user-auth-tenancy` (for UserId scoping)

--- a/openspec/changes/capture-text/specs/capture-text/spec.md
+++ b/openspec/changes/capture-text/specs/capture-text/spec.md
@@ -1,0 +1,219 @@
+## ADDED Requirements
+
+### Requirement: Create a capture
+
+The system SHALL allow an authenticated user to create a new Capture with raw text content and a capture type (QuickNote, Transcript, or MeetingNotes). RawContent MUST NOT be empty. The system SHALL set ProcessingStatus to `Raw`, set CapturedAt to the current time, and scope the Capture to the authenticated user's UserId. The system SHALL raise a `CaptureCreated` domain event.
+
+#### Scenario: Create a quick note
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent "Follow up with Sarah on Q3 roadmap" and type "QuickNote"
+- **THEN** the system creates a Capture with the given content, type QuickNote, status Raw, and returns HTTP 201 with the created capture
+
+#### Scenario: Create a transcript capture with optional fields
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing a pasted transcript, type "Transcript", title "Leadership sync 2026-04-10", and source "leadership sync"
+- **THEN** the system creates a Capture with all provided fields and returns HTTP 201
+
+#### Scenario: Create a meeting notes capture
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing meeting notes and type "MeetingNotes"
+- **THEN** the system creates a Capture with type MeetingNotes and returns HTTP 201
+
+#### Scenario: Empty content rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with empty or whitespace-only rawContent
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a capture and User B creates a capture
+- **THEN** each capture is scoped to its respective user's UserId
+
+### Requirement: List captures
+
+The system SHALL allow an authenticated user to retrieve a paginated list of their captures, ordered by CapturedAt descending (newest first). The list SHALL support optional filtering by capture type and processing status.
+
+#### Scenario: List all captures
+
+- **WHEN** an authenticated user sends a GET to `/api/captures`
+- **THEN** the system returns all captures belonging to that user, ordered by CapturedAt descending
+
+#### Scenario: Filter by type
+
+- **WHEN** an authenticated user sends a GET to `/api/captures?type=Transcript`
+- **THEN** the system returns only captures with type Transcript
+
+#### Scenario: Filter by status
+
+- **WHEN** an authenticated user sends a GET to `/api/captures?status=Raw`
+- **THEN** the system returns only captures with status Raw
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no captures sends a GET to `/api/captures`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get capture by ID
+
+The system SHALL allow an authenticated user to retrieve a single capture by ID, including all linked IDs and metadata.
+
+#### Scenario: Get existing capture
+
+- **WHEN** an authenticated user sends a GET to `/api/captures/{id}` with a valid capture ID belonging to them
+- **THEN** the system returns the capture with all fields including linkedPersonIds, linkedInitiativeIds, title, source, and processing status
+
+#### Scenario: Capture not found
+
+- **WHEN** an authenticated user sends a GET to `/api/captures/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Update capture metadata
+
+The system SHALL allow an authenticated user to update a capture's title and source fields. RawContent MUST NOT be modifiable after creation. The system SHALL raise a `CaptureMetadataUpdated` domain event.
+
+#### Scenario: Update title and source
+
+- **WHEN** an authenticated user sends a PUT to `/api/captures/{id}` with title "1:1 with Sarah" and source "weekly 1:1"
+- **THEN** the system updates the title and source, sets UpdatedAt, and returns HTTP 200
+
+#### Scenario: Clear optional fields
+
+- **WHEN** an authenticated user sends a PUT to `/api/captures/{id}` with title null and source null
+- **THEN** the system clears the title and source fields and returns HTTP 200
+
+#### Scenario: Cannot modify raw content
+
+- **WHEN** an authenticated user attempts to modify the rawContent of an existing capture
+- **THEN** the system SHALL NOT allow the change; rawContent is immutable after creation
+
+### Requirement: Link capture to person
+
+The system SHALL allow an authenticated user to link a capture to a Person by ID. The system SHALL store the PersonId in the capture's LinkedPersonIds list. Duplicate links SHALL be ignored (idempotent). The system SHALL raise a `CaptureLinkedToPerson` domain event.
+
+#### Scenario: Link to a person
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/link-person` with personId
+- **THEN** the system adds the personId to LinkedPersonIds and returns HTTP 200
+
+#### Scenario: Duplicate link is idempotent
+
+- **WHEN** an authenticated user links the same personId to a capture twice
+- **THEN** the system does not add a duplicate; LinkedPersonIds contains the personId only once
+
+### Requirement: Link capture to initiative
+
+The system SHALL allow an authenticated user to link a capture to an Initiative by ID. The system SHALL store the InitiativeId in the capture's LinkedInitiativeIds list. Duplicate links SHALL be ignored (idempotent). The system SHALL raise a `CaptureLinkedToInitiative` domain event.
+
+#### Scenario: Link to an initiative
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/link-initiative` with initiativeId
+- **THEN** the system adds the initiativeId to LinkedInitiativeIds and returns HTTP 200
+
+#### Scenario: Duplicate link is idempotent
+
+- **WHEN** an authenticated user links the same initiativeId to a capture twice
+- **THEN** the system does not add a duplicate; LinkedInitiativeIds contains the initiativeId only once
+
+### Requirement: Unlink capture from person
+
+The system SHALL allow an authenticated user to remove a Person link from a capture. Unlinking a non-existent link SHALL be idempotent (no error). The system SHALL raise a `CaptureUnlinkedFromPerson` domain event.
+
+#### Scenario: Unlink a person
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/unlink-person` with a personId that is currently linked
+- **THEN** the system removes the personId from LinkedPersonIds and returns HTTP 200
+
+#### Scenario: Unlink non-existent link
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/unlink-person` with a personId that is not linked
+- **THEN** the system returns HTTP 200 (idempotent, no error)
+
+### Requirement: Unlink capture from initiative
+
+The system SHALL allow an authenticated user to remove an Initiative link from a capture. Unlinking a non-existent link SHALL be idempotent (no error). The system SHALL raise a `CaptureUnlinkedFromInitiative` domain event.
+
+#### Scenario: Unlink an initiative
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/unlink-initiative` with an initiativeId that is currently linked
+- **THEN** the system removes the initiativeId from LinkedInitiativeIds and returns HTTP 200
+
+#### Scenario: Unlink non-existent link
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/unlink-initiative` with an initiativeId that is not linked
+- **THEN** the system returns HTTP 200 (idempotent, no error)
+
+### Requirement: Processing status state machine
+
+The Capture aggregate SHALL enforce a processing status state machine with transitions: Raw -> Processing (via BeginProcessing), Processing -> Processed (via CompleteProcessing), Processing -> Failed (via FailProcessing), Failed -> Raw (via RetryProcessing). Invalid transitions SHALL throw a domain exception. The system SHALL raise corresponding domain events for each transition.
+
+#### Scenario: Begin processing from Raw
+
+- **WHEN** BeginProcessing() is called on a capture with status Raw
+- **THEN** the status transitions to Processing and a `CaptureProcessingStarted` domain event is raised
+
+#### Scenario: Complete processing from Processing
+
+- **WHEN** CompleteProcessing(extraction) is called on a capture with status Processing
+- **THEN** the status transitions to Processed, ProcessedAt is set, and a `CaptureProcessed` domain event is raised
+
+#### Scenario: Fail processing from Processing
+
+- **WHEN** FailProcessing(reason) is called on a capture with status Processing
+- **THEN** the status transitions to Failed and a `CaptureProcessingFailed` domain event is raised
+
+#### Scenario: Retry processing from Failed
+
+- **WHEN** RetryProcessing() is called on a capture with status Failed
+- **THEN** the status transitions back to Raw and a `CaptureRetryRequested` domain event is raised
+
+#### Scenario: Invalid transition rejected
+
+- **WHEN** BeginProcessing() is called on a capture with status Processing or Processed
+- **THEN** the system throws a domain exception indicating an invalid status transition
+
+### Requirement: Capture list UI
+
+The frontend SHALL provide a capture list page that displays captures in reverse chronological order. The list SHALL show the capture type, title (or a content preview if no title), processing status, and CapturedAt timestamp. The list SHALL support filtering by type and status using dropdown filters.
+
+#### Scenario: View capture list
+
+- **WHEN** a user navigates to the captures page
+- **THEN** the system displays all their captures ordered by newest first, with type badge, title or content preview, status indicator, and timestamp
+
+#### Scenario: Filter captures
+
+- **WHEN** a user selects a type or status filter
+- **THEN** the list updates to show only matching captures
+
+### Requirement: Quick capture input
+
+The frontend SHALL provide a quick-capture component allowing users to rapidly enter text, select a capture type, and optionally set a title and source. Submitting the form SHALL create a new capture and add it to the list.
+
+#### Scenario: Quick capture submission
+
+- **WHEN** a user enters text in the quick-capture input, selects a type, and submits
+- **THEN** a new capture is created and appears at the top of the capture list
+
+#### Scenario: Quick capture with optional metadata
+
+- **WHEN** a user enters text, selects type "Transcript", sets title "Standup notes", and submits
+- **THEN** a new capture is created with the provided title and type
+
+### Requirement: Capture detail view
+
+The frontend SHALL provide a detail view for a single capture showing the full raw content, metadata (type, status, title, source, timestamps), and linked people and initiatives. The detail view SHALL allow editing the title and source, and linking/unlinking people and initiatives.
+
+#### Scenario: View capture detail
+
+- **WHEN** a user clicks on a capture in the list
+- **THEN** the system navigates to the detail view showing the full content, metadata, and linked entities
+
+#### Scenario: Edit metadata from detail view
+
+- **WHEN** a user edits the title or source in the detail view and saves
+- **THEN** the metadata is updated and the view reflects the changes
+
+#### Scenario: Link person from detail view
+
+- **WHEN** a user adds a person link from the detail view
+- **THEN** the person appears in the linked people section

--- a/openspec/changes/capture-text/tasks.md
+++ b/openspec/changes/capture-text/tasks.md
@@ -1,0 +1,64 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create `CaptureType` enum (QuickNote, Transcript, MeetingNotes) in `src/MentalMetal.Domain/Captures/`
+- [ ] 1.2 Create `ProcessingStatus` enum (Raw, Processing, Processed, Failed) in `src/MentalMetal.Domain/Captures/`
+- [ ] 1.3 Create `Capture` aggregate root entity with all properties (Id, UserId, RawContent, CaptureType, ProcessingStatus, AiExtraction, LinkedPersonIds, LinkedInitiativeIds, SpawnedCommitmentIds, SpawnedDelegationIds, SpawnedObservationIds, Title, CapturedAt, ProcessedAt, Source)
+- [ ] 1.4 Implement factory method `Create(userId, rawContent, type, source?, title?)` with validation and `CaptureCreated` domain event
+- [ ] 1.5 Implement processing status state machine methods: `BeginProcessing()`, `CompleteProcessing()`, `FailProcessing()`, `RetryProcessing()` with transition validation and domain events
+- [ ] 1.6 Implement `LinkToPerson(personId)`, `UnlinkFromPerson(personId)`, `LinkToInitiative(initiativeId)`, `UnlinkFromInitiative(initiativeId)` with idempotency and domain events
+- [ ] 1.7 Implement `UpdateMetadata(title, source)` with domain event
+- [ ] 1.8 Implement `RecordSpawnedCommitment()`, `RecordSpawnedDelegation()`, `RecordSpawnedObservation()` methods
+- [ ] 1.9 Create `ICaptureRepository` interface in `src/MentalMetal.Domain/Captures/`
+- [ ] 1.10 Create domain event classes: `CaptureCreated`, `CaptureProcessingStarted`, `CaptureProcessed`, `CaptureProcessingFailed`, `CaptureRetryRequested`, `CaptureLinkedToPerson`, `CaptureLinkedToInitiative`, `CaptureUnlinkedFromPerson`, `CaptureUnlinkedFromInitiative`, `CaptureMetadataUpdated`
+
+## 2. Domain Unit Tests
+
+- [ ] 2.1 Test Capture creation with valid inputs and domain event
+- [ ] 2.2 Test Capture creation rejects empty/whitespace rawContent
+- [ ] 2.3 Test processing status state machine: valid transitions (Raw->Processing, Processing->Processed, Processing->Failed, Failed->Raw)
+- [ ] 2.4 Test processing status state machine: invalid transitions throw domain exception
+- [ ] 2.5 Test link/unlink person idempotency
+- [ ] 2.6 Test link/unlink initiative idempotency
+- [ ] 2.7 Test metadata update
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Create `CaptureConfiguration` EF Core entity configuration with JSON columns for ID lists
+- [ ] 3.2 Create `CaptureRepository` implementing `ICaptureRepository`
+- [ ] 3.3 Register `CaptureRepository` in DI
+- [ ] 3.4 Add EF Core migration for Captures table
+
+## 4. Application Layer (Vertical Slice Handlers)
+
+- [ ] 4.1 Create `CreateCapture` command handler (POST /api/captures)
+- [ ] 4.2 Create `GetUserCaptures` query handler (GET /api/captures) with type and status filters
+- [ ] 4.3 Create `GetCaptureById` query handler (GET /api/captures/{id})
+- [ ] 4.4 Create `UpdateCaptureMetadata` command handler (PUT /api/captures/{id})
+- [ ] 4.5 Create `LinkCaptureToPerson` command handler (POST /api/captures/{id}/link-person)
+- [ ] 4.6 Create `LinkCaptureToInitiative` command handler (POST /api/captures/{id}/link-initiative)
+- [ ] 4.7 Create `UnlinkCaptureFromPerson` command handler (POST /api/captures/{id}/unlink-person)
+- [ ] 4.8 Create `UnlinkCaptureFromInitiative` command handler (POST /api/captures/{id}/unlink-initiative)
+
+## 5. Web API Layer
+
+- [ ] 5.1 Create `CaptureEndpoints` minimal API mapping with all routes
+- [ ] 5.2 Create request/response DTOs for capture operations
+
+## 6. Frontend — Service and Models
+
+- [ ] 6.1 Create `Capture` TypeScript model with all fields
+- [ ] 6.2 Create `CaptureService` with methods for all API operations
+- [ ] 6.3 Add captures route to Angular router
+
+## 7. Frontend — Components
+
+- [ ] 7.1 Create capture list page component with PrimeNG DataView and filter dropdowns
+- [ ] 7.2 Create quick-capture dialog component with PrimeNG Dialog, InputTextarea, and type selector
+- [ ] 7.3 Create capture detail view component showing full content, metadata, and linked entities
+- [ ] 7.4 Add link/unlink person and initiative controls to detail view
+
+## 8. E2E Tests
+
+- [ ] 8.1 E2E test: create a capture and verify it appears in the list
+- [ ] 8.2 E2E test: link a capture to a person and verify the link
+- [ ] 8.3 E2E test: user isolation — captures are scoped per user

--- a/openspec/changes/commitment-tracking/.openspec.yaml
+++ b/openspec/changes/commitment-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/commitment-tracking/design.md
+++ b/openspec/changes/commitment-tracking/design.md
@@ -1,0 +1,102 @@
+## Context
+
+Mental Metal has Person and Initiative management (Tier 1) in place. Commitment tracking is a core Tier 2 capability that lets users record bidirectional promises -- things they owe to others and things others owe to them. The Commitment aggregate is well-defined in `design/domain-model.md` and references Person (required) and optionally Initiative and Capture by ID.
+
+### Dependencies
+
+- `person-management` (Tier 1) -- PersonId is a required field on Commitment
+- `initiative-management` (Tier 1) -- InitiativeId is an optional link
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement the Commitment aggregate with rich domain behaviour following established DDD patterns
+- Support bidirectional tracking via CommitmentDirection (MineToThem, TheirsToMe)
+- Implement the status lifecycle (Open -> Completed/Cancelled, Reopen from either terminal state)
+- Support overdue detection based on DueDate
+- Provide list views with filtering by person, initiative, direction, status, and overdue state
+- Follow the same vertical slice, CQRS patterns established by person-management and initiative-management
+
+**Non-Goals:**
+
+- AI extraction of commitments from captures (capture-ai-extraction spec)
+- Nudge/reminder scheduling for overdue commitments (nudges-rhythms spec)
+- Briefing integration showing commitments due today (daily-weekly-briefing spec)
+- Queue-based prioritisation of commitments (my-queue spec)
+- Validating that PersonId/InitiativeId actually exist (eventual consistency per DDD)
+
+## Decisions
+
+### 1. Commitment aggregate follows existing DDD patterns
+
+**Decision:** Model the Commitment aggregate identically to Person and Initiative -- rich domain entity with factory method, business actions, value objects, and domain events.
+
+**Rationale:** Consistency with Tier 1 patterns. The domain model is well-defined.
+
+**Alternatives considered:**
+- Anemic model -- rejected per project DDD principles
+
+### 2. Value objects for Direction and Status
+
+**Decision:** Implement `CommitmentDirection` as a C# enum (`MineToThem`, `TheirsToMe`) and `CommitmentStatus` as a C# enum (`Open`, `Completed`, `Cancelled`). Status transitions are enforced by the aggregate.
+
+**Rationale:** Same approach as CaptureType/ProcessingStatus and PersonType. Simple enums with aggregate-enforced transitions.
+
+### 3. Overdue detection as a domain method
+
+**Decision:** Implement `MarkOverdue()` as a business action on the aggregate that checks `DueDate < today && Status == Open`. Overdue is NOT a separate status -- it is a computed concern. The `CommitmentBecameOverdue` event is raised for notification purposes. A query-time computed property `IsOverdue` is used for filtering.
+
+**Rationale:** Overdue is a temporal concern, not a status transition. A commitment can be open AND overdue. Keeping it as a computed property avoids a complex status matrix. The `MarkOverdue()` action exists for a future background job to raise domain events.
+
+**Alternatives considered:**
+- Overdue as a status value -- rejected because it creates a parallel status axis (open+overdue, but never completed+overdue)
+- Pure query-time computation only -- rejected because we want domain events for notification integration
+
+### 4. PersonId is required, not validated cross-aggregate
+
+**Decision:** PersonId is a required `Guid` on the Commitment, but the Commitment aggregate does not validate that the Person exists. This is consistent with DDD aggregate boundaries.
+
+**Rationale:** Cross-aggregate validation would require a domain service or application-layer check. The application handler can optionally verify the person exists before creating the commitment, but this is not a domain invariant.
+
+### 5. SourceCaptureId for traceability
+
+**Decision:** An optional `SourceCaptureId` field tracks which Capture spawned this commitment. This field is set at creation and is immutable. It is not used in this spec but enables `capture-ai-extraction` to link extracted commitments back to their source.
+
+**Rationale:** Forward-compatible design. The field is cheap to add now and avoids a migration later.
+
+### 6. API design follows established conventions
+
+**Decision:** Endpoints under `/api/commitments` following existing patterns.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/commitments` | POST | Create a new commitment |
+| `/api/commitments` | GET | List user's commitments (filterable) |
+| `/api/commitments/{id}` | GET | Get commitment by ID |
+| `/api/commitments/{id}` | PUT | Update description, notes |
+| `/api/commitments/{id}/complete` | POST | Mark as completed |
+| `/api/commitments/{id}/cancel` | POST | Mark as cancelled |
+| `/api/commitments/{id}/reopen` | POST | Reopen a completed/cancelled commitment |
+| `/api/commitments/{id}/due-date` | PUT | Update due date |
+| `/api/commitments/{id}/link-initiative` | POST | Link to an initiative |
+
+**Rationale:** Status transitions as POST actions (not PATCH on status field) because they are distinct business actions with their own domain events and rules.
+
+### 7. Frontend uses signal-based state and PrimeNG components
+
+**Decision:** Commitment UI consists of a commitment list page (PrimeNG DataView with filters for direction, status, person, overdue), a create/edit dialog (PrimeNG Dialog with form fields), and inline status actions. All state via Angular signals.
+
+**Rationale:** Follows Angular 21 conventions and PrimeNG-first component selection.
+
+## Risks / Trade-offs
+
+- **[Orphaned PersonId]** If a linked Person is deleted, the Commitment retains a stale PersonId. **Mitigation:** Person archival (soft delete) means the person record still exists. Display can show "archived person" if needed.
+
+- **[Overdue detection timing]** Without a background job, overdue detection is purely query-time. Commitments won't raise `CommitmentBecameOverdue` events until a future spec adds a scheduled check. **Mitigation:** Query-time `IsOverdue` computed property handles UI display. Event-based detection is a future concern.
+
+- **[No cascade on Capture deletion]** If a source Capture is deleted, the SourceCaptureId becomes orphaned. **Mitigation:** Captures are not deleted (only discarded), so this is unlikely.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/commitment-tracking/proposal.md
+++ b/openspec/changes/commitment-tracking/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Engineering managers constantly make and receive promises -- "I'll get you headcount approval by Friday" or "Sarah will send the design doc by Wednesday." These commitments easily get lost in the noise of meetings and messages. Commitment tracking gives users a structured way to record, track, and surface bidirectional promises, with overdue detection to prevent things from falling through the cracks.
+
+This is a Tier 2 spec (`commitment-tracking`) that depends on `person-management` and `initiative-management` (Tier 1).
+
+## Non-goals
+
+- **No AI extraction of commitments** -- automatic creation from captures is handled by `capture-ai-extraction`
+- **No nudges or rhythms** -- recurring reminders about commitments are in `nudges-rhythms` (Tier 3)
+- **No briefing integration** -- surfacing overdue commitments in daily briefings is in `daily-weekly-briefing` (Tier 3)
+- **No queue prioritisation** -- commitment-based queue items are in `my-queue` (Tier 3)
+
+## What Changes
+
+- **New Commitment aggregate** in the Domain layer with direction (MineToThem, TheirsToMe), status lifecycle (Open -> Completed/Cancelled, with Reopen), overdue detection, and links to Person (required), Initiative (optional), and Capture (optional)
+- **CQRS handlers** for creating, completing, cancelling, reopening, updating commitments, and querying by person/initiative/status
+- **API endpoints** for commitment CRUD and status transitions
+- **EF Core persistence** with PostgreSQL for the Commitment entity, including migrations
+- **Angular commitment UI** -- commitment list with filters, create/edit forms, status management, and person-scoped views
+
+## Capabilities
+
+### New Capabilities
+
+- `commitment-tracking`: Core commitment aggregate -- create, track, and manage bidirectional promises between the user and their people, with status lifecycle, overdue detection, and links to people and initiatives
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Domain:** New `Commitment` aggregate root with value objects (`CommitmentDirection`, `CommitmentStatus`)
+- **Application:** New vertical slice handlers for commitment use cases
+- **Infrastructure:** New EF Core configuration and migration for `Commitments` table
+- **Web API:** New minimal API endpoints under `/api/commitments`
+- **Frontend:** New commitment components, commitment service, and routing
+- **Dependencies:** `person-management` (PersonId is required), `initiative-management` (optional InitiativeId link)

--- a/openspec/changes/commitment-tracking/specs/commitment-tracking/spec.md
+++ b/openspec/changes/commitment-tracking/specs/commitment-tracking/spec.md
@@ -1,0 +1,253 @@
+## ADDED Requirements
+
+### Requirement: Create a commitment
+
+The system SHALL allow an authenticated user to create a new Commitment with a description, direction (MineToThem or TheirsToMe), and a PersonId. Description MUST NOT be empty. PersonId MUST be provided. The system SHALL set Status to `Open` and set CreatedAt. Optional fields: DueDate, InitiativeId, SourceCaptureId, Notes. The system SHALL raise a `CommitmentCreated` domain event. The Commitment SHALL be scoped to the authenticated user's UserId.
+
+#### Scenario: Create a commitment I owe to someone
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments` with description "Send Q3 roadmap draft", direction "MineToThem", and personId for "Sarah"
+- **THEN** the system creates a Commitment with status Open, direction MineToThem, and returns HTTP 201
+
+#### Scenario: Create a commitment someone owes me
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments` with description "Deliver design doc", direction "TheirsToMe", personId, and dueDate "2026-04-20"
+- **THEN** the system creates a Commitment with status Open, direction TheirsToMe, the due date, and returns HTTP 201
+
+#### Scenario: Create with optional initiative and capture links
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments` with description, direction, personId, initiativeId, and sourceCaptureId
+- **THEN** the system creates a Commitment with all linked IDs and returns HTTP 201
+
+#### Scenario: Empty description rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments` with an empty description
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: Missing personId rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments` without a personId
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a commitment and User B creates a commitment
+- **THEN** each commitment is scoped to its respective user's UserId
+
+### Requirement: List commitments
+
+The system SHALL allow an authenticated user to retrieve a list of their commitments. The list SHALL support optional filtering by direction, status, personId, initiativeId, and overdue state. The list SHALL be ordered by DueDate ascending (soonest first), with null due dates last.
+
+#### Scenario: List all commitments
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments`
+- **THEN** the system returns all commitments belonging to that user, ordered by due date
+
+#### Scenario: Filter by direction
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments?direction=MineToThem`
+- **THEN** the system returns only commitments with direction MineToThem
+
+#### Scenario: Filter by status
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments?status=Open`
+- **THEN** the system returns only commitments with status Open
+
+#### Scenario: Filter by person
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments?personId={id}`
+- **THEN** the system returns only commitments linked to that person
+
+#### Scenario: Filter overdue
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments?overdue=true`
+- **THEN** the system returns only open commitments whose DueDate is in the past
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no commitments sends a GET to `/api/commitments`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get commitment by ID
+
+The system SHALL allow an authenticated user to retrieve a single commitment by ID.
+
+#### Scenario: Get existing commitment
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments/{id}` with a valid commitment ID
+- **THEN** the system returns the commitment with all fields including linked IDs and computed IsOverdue
+
+#### Scenario: Commitment not found
+
+- **WHEN** an authenticated user sends a GET to `/api/commitments/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Update commitment
+
+The system SHALL allow an authenticated user to update a commitment's description and notes. Description MUST NOT be empty. The system SHALL raise a `CommitmentDescriptionUpdated` domain event when the description changes.
+
+#### Scenario: Update description
+
+- **WHEN** an authenticated user sends a PUT to `/api/commitments/{id}` with a new description
+- **THEN** the system updates the description, sets UpdatedAt, and returns HTTP 200
+
+#### Scenario: Update notes
+
+- **WHEN** an authenticated user sends a PUT to `/api/commitments/{id}` with new notes
+- **THEN** the system updates the notes and returns HTTP 200
+
+#### Scenario: Empty description rejected
+
+- **WHEN** an authenticated user sends a PUT to `/api/commitments/{id}` with an empty description
+- **THEN** the system returns HTTP 400
+
+### Requirement: Complete a commitment
+
+The system SHALL allow an authenticated user to mark an open commitment as completed. The system SHALL set CompletedAt and optionally accept completion notes. The system SHALL raise a `CommitmentCompleted` domain event. Only commitments with status `Open` can be completed.
+
+#### Scenario: Complete an open commitment
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/complete` for an open commitment
+- **THEN** the system sets status to Completed, sets CompletedAt, and returns HTTP 200
+
+#### Scenario: Complete with notes
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/complete` with notes "Delivered in leadership sync"
+- **THEN** the system sets status to Completed, appends the notes, and returns HTTP 200
+
+#### Scenario: Complete non-open commitment rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/complete` for a commitment that is already Completed or Cancelled
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Cancel a commitment
+
+The system SHALL allow an authenticated user to cancel an open commitment. The system SHALL optionally accept a cancellation reason. The system SHALL raise a `CommitmentCancelled` domain event. Only commitments with status `Open` can be cancelled.
+
+#### Scenario: Cancel an open commitment
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/cancel` for an open commitment
+- **THEN** the system sets status to Cancelled and returns HTTP 200
+
+#### Scenario: Cancel with reason
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/cancel` with reason "No longer relevant after reorg"
+- **THEN** the system sets status to Cancelled, stores the reason in notes, and returns HTTP 200
+
+#### Scenario: Cancel non-open commitment rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/cancel` for a commitment that is already Completed or Cancelled
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Reopen a commitment
+
+The system SHALL allow an authenticated user to reopen a completed or cancelled commitment. The system SHALL set status back to Open, clear CompletedAt, and raise a `CommitmentReopened` domain event. Only commitments with status `Completed` or `Cancelled` can be reopened.
+
+#### Scenario: Reopen a completed commitment
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/reopen` for a completed commitment
+- **THEN** the system sets status to Open, clears CompletedAt, and returns HTTP 200
+
+#### Scenario: Reopen a cancelled commitment
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/reopen` for a cancelled commitment
+- **THEN** the system sets status to Open and returns HTTP 200
+
+#### Scenario: Reopen an open commitment rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/reopen` for a commitment that is already Open
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Update due date
+
+The system SHALL allow an authenticated user to update or clear a commitment's due date. The system SHALL raise a `CommitmentDueDateChanged` domain event.
+
+#### Scenario: Set due date
+
+- **WHEN** an authenticated user sends a PUT to `/api/commitments/{id}/due-date` with dueDate "2026-05-01"
+- **THEN** the system updates the due date and returns HTTP 200
+
+#### Scenario: Clear due date
+
+- **WHEN** an authenticated user sends a PUT to `/api/commitments/{id}/due-date` with dueDate null
+- **THEN** the system clears the due date and returns HTTP 200
+
+### Requirement: Link commitment to initiative
+
+The system SHALL allow an authenticated user to link a commitment to an Initiative by ID. The system SHALL raise a `CommitmentLinkedToInitiative` domain event. Linking when already linked to the same initiative SHALL be idempotent.
+
+#### Scenario: Link to an initiative
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/link-initiative` with initiativeId
+- **THEN** the system sets the InitiativeId and returns HTTP 200
+
+#### Scenario: Replace initiative link
+
+- **WHEN** an authenticated user sends a POST to `/api/commitments/{id}/link-initiative` with a different initiativeId
+- **THEN** the system updates the InitiativeId to the new value and returns HTTP 200
+
+### Requirement: Overdue detection
+
+The system SHALL compute an `IsOverdue` property for each commitment. A commitment is overdue when its Status is `Open` and its DueDate is before the current date. Completed and cancelled commitments are never overdue. Commitments without a DueDate are never overdue.
+
+#### Scenario: Open commitment past due date
+
+- **WHEN** a commitment has status Open and DueDate is in the past
+- **THEN** the system reports IsOverdue as true
+
+#### Scenario: Completed commitment past due date
+
+- **WHEN** a commitment has status Completed and DueDate is in the past
+- **THEN** the system reports IsOverdue as false
+
+#### Scenario: Open commitment with no due date
+
+- **WHEN** a commitment has status Open and DueDate is null
+- **THEN** the system reports IsOverdue as false
+
+#### Scenario: Open commitment with future due date
+
+- **WHEN** a commitment has status Open and DueDate is in the future
+- **THEN** the system reports IsOverdue as false
+
+### Requirement: Commitment list UI
+
+The frontend SHALL provide a commitment list page that displays commitments with direction indicator, description, person name, status badge, due date, and overdue indicator. The list SHALL support filtering by direction, status, and overdue state.
+
+#### Scenario: View commitment list
+
+- **WHEN** a user navigates to the commitments page
+- **THEN** the system displays all their commitments with direction, description, person, status, due date, and overdue indicators
+
+#### Scenario: Filter commitments
+
+- **WHEN** a user selects direction, status, or overdue filters
+- **THEN** the list updates to show only matching commitments
+
+### Requirement: Commitment create/edit form
+
+The frontend SHALL provide a form for creating and editing commitments. The form SHALL include fields for description, direction selector, person selector, due date picker, initiative selector (optional), and notes. The person selector SHALL show the user's active people.
+
+#### Scenario: Create commitment via form
+
+- **WHEN** a user fills in the commitment form with description, selects direction, picks a person, and submits
+- **THEN** a new commitment is created and appears in the list
+
+#### Scenario: Edit commitment
+
+- **WHEN** a user edits a commitment's description or notes and saves
+- **THEN** the commitment is updated and the view reflects the changes
+
+### Requirement: Commitment status actions
+
+The frontend SHALL provide action buttons to complete, cancel, and reopen commitments directly from the list or detail view. Status transitions SHALL provide appropriate confirmation or optional notes input.
+
+#### Scenario: Complete from list
+
+- **WHEN** a user clicks "Complete" on an open commitment in the list
+- **THEN** the commitment is marked as completed and the status badge updates
+
+#### Scenario: Cancel with reason
+
+- **WHEN** a user clicks "Cancel" on an open commitment and provides a reason
+- **THEN** the commitment is marked as cancelled with the reason stored

--- a/openspec/changes/commitment-tracking/tasks.md
+++ b/openspec/changes/commitment-tracking/tasks.md
@@ -1,0 +1,68 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create `CommitmentDirection` enum (MineToThem, TheirsToMe) in `src/MentalMetal.Domain/Commitments/`
+- [ ] 1.2 Create `CommitmentStatus` enum (Open, Completed, Cancelled) in `src/MentalMetal.Domain/Commitments/`
+- [ ] 1.3 Create `Commitment` aggregate root entity with all properties (Id, UserId, Description, Direction, PersonId, InitiativeId, SourceCaptureId, DueDate, Status, CompletedAt, Notes, CreatedAt, UpdatedAt)
+- [ ] 1.4 Implement factory method `Create(userId, description, direction, personId, dueDate?, initiativeId?, sourceCaptureId?)` with validation and `CommitmentCreated` domain event
+- [ ] 1.5 Implement status transition methods: `Complete(notes?)`, `Cancel(reason?)`, `Reopen()` with transition validation and domain events
+- [ ] 1.6 Implement `UpdateDueDate(newDate)` with `CommitmentDueDateChanged` domain event
+- [ ] 1.7 Implement `UpdateDescription(description)` with validation and `CommitmentDescriptionUpdated` domain event
+- [ ] 1.8 Implement `LinkToInitiative(initiativeId)` with `CommitmentLinkedToInitiative` domain event
+- [ ] 1.9 Implement `MarkOverdue()` with guard (DueDate in past, status Open) and `CommitmentBecameOverdue` domain event
+- [ ] 1.10 Add computed `IsOverdue` property (Status == Open && DueDate != null && DueDate < today)
+- [ ] 1.11 Create `ICommitmentRepository` interface in `src/MentalMetal.Domain/Commitments/`
+- [ ] 1.12 Create domain event classes: `CommitmentCreated`, `CommitmentCompleted`, `CommitmentCancelled`, `CommitmentReopened`, `CommitmentDueDateChanged`, `CommitmentDescriptionUpdated`, `CommitmentLinkedToInitiative`, `CommitmentBecameOverdue`
+
+## 2. Domain Unit Tests
+
+- [ ] 2.1 Test Commitment creation with valid inputs and domain event
+- [ ] 2.2 Test creation rejects empty description and missing personId
+- [ ] 2.3 Test status transitions: Open->Completed, Open->Cancelled, Completed->Open, Cancelled->Open
+- [ ] 2.4 Test invalid status transitions throw domain exception (Completed->Completed, Cancelled->Cancelled, Open->Reopen)
+- [ ] 2.5 Test CompletedAt is set on completion and cleared on reopen
+- [ ] 2.6 Test IsOverdue computation for all status/date combinations
+- [ ] 2.7 Test MarkOverdue raises event only when conditions met
+- [ ] 2.8 Test UpdateDueDate and UpdateDescription
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Create `CommitmentConfiguration` EF Core entity configuration
+- [ ] 3.2 Create `CommitmentRepository` implementing `ICommitmentRepository` with filtering support
+- [ ] 3.3 Register `CommitmentRepository` in DI
+- [ ] 3.4 Add EF Core migration for Commitments table
+
+## 4. Application Layer (Vertical Slice Handlers)
+
+- [ ] 4.1 Create `CreateCommitment` command handler (POST /api/commitments)
+- [ ] 4.2 Create `GetUserCommitments` query handler (GET /api/commitments) with direction, status, personId, initiativeId, and overdue filters
+- [ ] 4.3 Create `GetCommitmentById` query handler (GET /api/commitments/{id})
+- [ ] 4.4 Create `UpdateCommitment` command handler (PUT /api/commitments/{id})
+- [ ] 4.5 Create `CompleteCommitment` command handler (POST /api/commitments/{id}/complete)
+- [ ] 4.6 Create `CancelCommitment` command handler (POST /api/commitments/{id}/cancel)
+- [ ] 4.7 Create `ReopenCommitment` command handler (POST /api/commitments/{id}/reopen)
+- [ ] 4.8 Create `UpdateCommitmentDueDate` command handler (PUT /api/commitments/{id}/due-date)
+- [ ] 4.9 Create `LinkCommitmentToInitiative` command handler (POST /api/commitments/{id}/link-initiative)
+
+## 5. Web API Layer
+
+- [ ] 5.1 Create `CommitmentEndpoints` minimal API mapping with all routes
+- [ ] 5.2 Create request/response DTOs for commitment operations
+
+## 6. Frontend — Service and Models
+
+- [ ] 6.1 Create `Commitment` TypeScript model with all fields including computed IsOverdue
+- [ ] 6.2 Create `CommitmentService` with methods for all API operations
+- [ ] 6.3 Add commitments route to Angular router
+
+## 7. Frontend — Components
+
+- [ ] 7.1 Create commitment list page component with PrimeNG DataView and filter dropdowns (direction, status, overdue)
+- [ ] 7.2 Create commitment create/edit dialog component with PrimeNG Dialog, direction selector, person dropdown, date picker, initiative dropdown
+- [ ] 7.3 Add status action buttons (Complete, Cancel, Reopen) to list items and detail view
+- [ ] 7.4 Create commitment detail view showing all fields and linked entities
+
+## 8. E2E Tests
+
+- [ ] 8.1 E2E test: create a commitment and verify it appears in the list
+- [ ] 8.2 E2E test: complete and reopen a commitment
+- [ ] 8.3 E2E test: user isolation — commitments are scoped per user

--- a/openspec/changes/delegation-tracking/.openspec.yaml
+++ b/openspec/changes/delegation-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/delegation-tracking/design.md
+++ b/openspec/changes/delegation-tracking/design.md
@@ -1,0 +1,100 @@
+## Context
+
+Mental Metal has Person and Initiative management (Tier 1) in place. Delegation tracking is a core Tier 2 capability that lets users assign tasks to people and retain follow-up ownership. Unlike commitments (bidirectional), delegations flow in one direction: the user assigns, the delegate executes. The Delegation aggregate is well-defined in `design/domain-model.md`.
+
+### Dependencies
+
+- `person-management` (Tier 1) -- DelegatePersonId is a required field
+- `initiative-management` (Tier 1) -- InitiativeId is an optional link
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement the Delegation aggregate with rich domain behaviour following established DDD patterns
+- Support the full status state machine (Assigned -> InProgress -> Completed, with Blocked/Unblock paths)
+- Support priority levels (Low, Medium, High, Urgent)
+- Track follow-up activity with timestamps
+- Support reassignment to a different person
+- Provide list views with filtering by person, initiative, status, and priority
+- Follow the same vertical slice, CQRS patterns established by person-management and initiative-management
+
+**Non-Goals:**
+
+- AI extraction of delegations from captures (capture-ai-extraction spec)
+- Nudge/reminder scheduling for follow-ups (nudges-rhythms spec)
+- Briefing integration (daily-weekly-briefing spec)
+- Queue-based prioritisation (my-queue spec)
+- People-lens per-person delegation view (people-lens spec)
+- Validating that PersonId/InitiativeId actually exist (eventual consistency per DDD)
+
+## Decisions
+
+### 1. Delegation aggregate follows existing DDD patterns
+
+**Decision:** Model the Delegation aggregate identically to Person, Initiative, and Commitment -- rich domain entity with factory method, business actions, value objects, and domain events.
+
+**Rationale:** Consistency with established patterns.
+
+### 2. Value objects for DelegationStatus and Priority
+
+**Decision:** Implement `DelegationStatus` as a C# enum (`Assigned`, `InProgress`, `Completed`, `Blocked`) and `Priority` as a C# enum (`Low`, `Medium`, `High`, `Urgent`). Status transitions are enforced by the aggregate following the state machine in the domain model.
+
+**Rationale:** Same approach as other aggregates. The state machine is richer than Commitment (four statuses, blocked/unblock paths) but still simple enough for enum + aggregate methods.
+
+### 3. Follow-up tracking via LastFollowedUpAt
+
+**Decision:** `RecordFollowUp(notes?)` updates `LastFollowedUpAt` to the current time and optionally appends to notes. This is a simple timestamp, not a log of all follow-ups.
+
+**Rationale:** A full follow-up history would require a child entity or event sourcing, which is over-engineering for v1. The last follow-up timestamp is sufficient for "haven't checked in on this in X days" queries. If richer history is needed later, it can be added as an Observation linked to the person.
+
+**Alternatives considered:**
+- Follow-up log as a collection of value objects -- more complex, deferred to a future enhancement
+- Separate FollowUp entity -- violates aggregate boundaries for minimal benefit
+
+### 4. Reassignment as a business action
+
+**Decision:** `Reassign(newPersonId)` changes `DelegatePersonId` and raises `DelegationReassigned`. The old person ID is not preserved in the aggregate (but the event captures it).
+
+**Rationale:** Reassignment is a common real-world operation. Keeping a history of reassignments is a "nice to have" that the domain event provides for audit purposes.
+
+### 5. No terminal status for Blocked
+
+**Decision:** Blocked is a temporary state, not a terminal one. Blocked delegations can be unblocked (returning to InProgress) or completed directly. This matches the state machine in the domain model.
+
+**Rationale:** Real-world blockers get resolved. A delegation shouldn't be stuck in Blocked forever with no way out.
+
+### 6. API design follows established conventions
+
+**Decision:** Endpoints under `/api/delegations`.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/delegations` | POST | Create a new delegation |
+| `/api/delegations` | GET | List user's delegations (filterable) |
+| `/api/delegations/{id}` | GET | Get delegation by ID |
+| `/api/delegations/{id}` | PUT | Update description, notes |
+| `/api/delegations/{id}/start` | POST | Mark as in-progress |
+| `/api/delegations/{id}/complete` | POST | Mark as completed |
+| `/api/delegations/{id}/block` | POST | Mark as blocked |
+| `/api/delegations/{id}/unblock` | POST | Remove blocker |
+| `/api/delegations/{id}/follow-up` | POST | Record follow-up |
+| `/api/delegations/{id}/due-date` | PUT | Update due date |
+| `/api/delegations/{id}/priority` | PUT | Change priority |
+| `/api/delegations/{id}/reassign` | POST | Reassign to different person |
+
+### 7. Frontend uses signal-based state and PrimeNG components
+
+**Decision:** Delegation UI consists of a delegation list page (PrimeNG DataView with filters), a create/edit dialog, and inline status actions with follow-up recording. All state via Angular signals.
+
+## Risks / Trade-offs
+
+- **[Orphaned DelegatePersonId]** If a Person is archived, the Delegation retains the stale ID. **Mitigation:** Person archival is soft delete; display can show "archived person" if needed.
+
+- **[State machine complexity]** The Delegation state machine has more paths than Commitment (blocked/unblock, direct completion from multiple states). **Mitigation:** Thorough domain unit tests for every valid and invalid transition.
+
+- **[Follow-up history lost]** Only the last follow-up timestamp is stored. **Mitigation:** Acceptable for v1. Domain events capture history for audit. A future enhancement could add follow-up log.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/delegation-tracking/proposal.md
+++ b/openspec/changes/delegation-tracking/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Engineering managers delegate work constantly but often lose track of what they have assigned and to whom. Unlike commitments (bidirectional promises), delegations are one-directional: the user assigns work to a person and retains follow-up ownership. Delegation tracking gives users a structured way to assign, track, follow up on, and manage delegated tasks with priority, status, and accountability.
+
+This is a Tier 2 spec (`delegation-tracking`) that depends on `person-management` and `initiative-management` (Tier 1).
+
+## Non-goals
+
+- **No AI extraction of delegations** -- automatic creation from captures is handled by `capture-ai-extraction`
+- **No nudges or rhythms** -- recurring follow-up reminders are in `nudges-rhythms` (Tier 3)
+- **No briefing integration** -- surfacing delegations in daily briefings is in `daily-weekly-briefing` (Tier 3)
+- **No queue prioritisation** -- delegation-based queue items are in `my-queue` (Tier 3)
+- **No people-lens integration** -- viewing delegations per person is in `people-lens`
+
+## What Changes
+
+- **New Delegation aggregate** in the Domain layer with status lifecycle (Assigned -> InProgress -> Completed, with Blocked/Unblock), priority levels, follow-up tracking, and links to Person (required), Initiative (optional), and Capture (optional)
+- **CQRS handlers** for creating, updating status, reassigning, following up on, and querying delegations
+- **API endpoints** for delegation CRUD, status transitions, and follow-up recording
+- **EF Core persistence** with PostgreSQL for the Delegation entity, including migrations
+- **Angular delegation UI** -- delegation list with filters, create/edit forms, status management, and follow-up recording
+
+## Capabilities
+
+### New Capabilities
+
+- `delegation-tracking`: Core delegation aggregate -- assign tasks to people, track status (Assigned, InProgress, Completed, Blocked), manage priority, record follow-ups, and link to initiatives
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Domain:** New `Delegation` aggregate root with value objects (`DelegationStatus`, `Priority`)
+- **Application:** New vertical slice handlers for delegation use cases
+- **Infrastructure:** New EF Core configuration and migration for `Delegations` table
+- **Web API:** New minimal API endpoints under `/api/delegations`
+- **Frontend:** New delegation components, delegation service, and routing
+- **Dependencies:** `person-management` (DelegatePersonId is required), `initiative-management` (optional InitiativeId link)

--- a/openspec/changes/delegation-tracking/specs/delegation-tracking/spec.md
+++ b/openspec/changes/delegation-tracking/specs/delegation-tracking/spec.md
@@ -1,0 +1,256 @@
+## ADDED Requirements
+
+### Requirement: Create a delegation
+
+The system SHALL allow an authenticated user to create a new Delegation with a description and a DelegatePersonId (the person doing the work). Description MUST NOT be empty. DelegatePersonId MUST be provided. The system SHALL set Status to `Assigned` and set CreatedAt. Optional fields: DueDate, InitiativeId, SourceCaptureId, Priority (defaults to Medium), Notes. The system SHALL raise a `DelegationCreated` domain event. The Delegation SHALL be scoped to the authenticated user's UserId.
+
+#### Scenario: Create a delegation with defaults
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations` with description "Write the API spec for payments service" and delegatePersonId
+- **THEN** the system creates a Delegation with status Assigned, priority Medium, and returns HTTP 201
+
+#### Scenario: Create a delegation with all fields
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations` with description, delegatePersonId, dueDate "2026-04-25", priority "High", initiativeId, and notes "Discussed in team standup"
+- **THEN** the system creates a Delegation with all provided fields and returns HTTP 201
+
+#### Scenario: Empty description rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations` with an empty description
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: Missing delegatePersonId rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations` without a delegatePersonId
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a delegation and User B creates a delegation
+- **THEN** each delegation is scoped to its respective user's UserId
+
+### Requirement: List delegations
+
+The system SHALL allow an authenticated user to retrieve a list of their delegations. The list SHALL support optional filtering by status, priority, delegatePersonId, and initiativeId. The list SHALL be ordered by priority descending then DueDate ascending (soonest first), with null due dates last.
+
+#### Scenario: List all delegations
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations`
+- **THEN** the system returns all delegations belonging to that user, ordered by priority then due date
+
+#### Scenario: Filter by status
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations?status=Assigned`
+- **THEN** the system returns only delegations with status Assigned
+
+#### Scenario: Filter by priority
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations?priority=High`
+- **THEN** the system returns only delegations with priority High
+
+#### Scenario: Filter by person
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations?delegatePersonId={id}`
+- **THEN** the system returns only delegations assigned to that person
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no delegations sends a GET to `/api/delegations`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get delegation by ID
+
+The system SHALL allow an authenticated user to retrieve a single delegation by ID.
+
+#### Scenario: Get existing delegation
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations/{id}` with a valid delegation ID
+- **THEN** the system returns the delegation with all fields including linked IDs and LastFollowedUpAt
+
+#### Scenario: Delegation not found
+
+- **WHEN** an authenticated user sends a GET to `/api/delegations/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Update delegation
+
+The system SHALL allow an authenticated user to update a delegation's description and notes. Description MUST NOT be empty. The system SHALL set UpdatedAt.
+
+#### Scenario: Update description
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}` with a new description
+- **THEN** the system updates the description and returns HTTP 200
+
+#### Scenario: Update notes
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}` with new notes
+- **THEN** the system updates the notes and returns HTTP 200
+
+#### Scenario: Empty description rejected
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}` with an empty description
+- **THEN** the system returns HTTP 400
+
+### Requirement: Mark delegation in progress
+
+The system SHALL allow an authenticated user to mark an assigned delegation as in-progress. The system SHALL raise a `DelegationStarted` domain event. Only delegations with status `Assigned` can be marked in-progress.
+
+#### Scenario: Start an assigned delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/start` for an assigned delegation
+- **THEN** the system sets status to InProgress and returns HTTP 200
+
+#### Scenario: Start non-assigned delegation rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/start` for a delegation that is not in Assigned status
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Complete a delegation
+
+The system SHALL allow an authenticated user to mark a delegation as completed. The system SHALL set CompletedAt and optionally accept completion notes. The system SHALL raise a `DelegationCompleted` domain event. Only delegations with status `Assigned`, `InProgress`, or `Blocked` can be completed.
+
+#### Scenario: Complete an in-progress delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/complete` for an in-progress delegation
+- **THEN** the system sets status to Completed, sets CompletedAt, and returns HTTP 200
+
+#### Scenario: Complete an assigned delegation directly
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/complete` for an assigned delegation
+- **THEN** the system sets status to Completed, sets CompletedAt, and returns HTTP 200
+
+#### Scenario: Complete a blocked delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/complete` for a blocked delegation
+- **THEN** the system sets status to Completed, sets CompletedAt, and returns HTTP 200
+
+#### Scenario: Complete already-completed delegation rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/complete` for a delegation already in Completed status
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Mark delegation as blocked
+
+The system SHALL allow an authenticated user to mark a delegation as blocked with a reason. The system SHALL raise a `DelegationBlocked` domain event. Only delegations with status `Assigned` or `InProgress` can be blocked.
+
+#### Scenario: Block an in-progress delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/block` with reason "Waiting on third-party API access"
+- **THEN** the system sets status to Blocked, stores the reason, and returns HTTP 200
+
+#### Scenario: Block an assigned delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/block` with reason
+- **THEN** the system sets status to Blocked and returns HTTP 200
+
+#### Scenario: Block already blocked/completed rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/block` for a delegation in Blocked or Completed status
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Unblock a delegation
+
+The system SHALL allow an authenticated user to unblock a blocked delegation, returning it to InProgress status. The system SHALL raise a `DelegationUnblocked` domain event. Only delegations with status `Blocked` can be unblocked.
+
+#### Scenario: Unblock a blocked delegation
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/unblock` for a blocked delegation
+- **THEN** the system sets status to InProgress and returns HTTP 200
+
+#### Scenario: Unblock non-blocked delegation rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/unblock` for a delegation not in Blocked status
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: Record follow-up
+
+The system SHALL allow an authenticated user to record a follow-up on a delegation. The system SHALL update LastFollowedUpAt to the current time and optionally accept follow-up notes. The system SHALL raise a `DelegationFollowedUp` domain event.
+
+#### Scenario: Record follow-up
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/follow-up` with optional notes "Checked in, on track for Friday"
+- **THEN** the system updates LastFollowedUpAt and returns HTTP 200
+
+#### Scenario: Record follow-up without notes
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/follow-up` without notes
+- **THEN** the system updates LastFollowedUpAt and returns HTTP 200
+
+### Requirement: Update due date
+
+The system SHALL allow an authenticated user to update or clear a delegation's due date. The system SHALL raise a `DelegationDueDateChanged` domain event.
+
+#### Scenario: Set due date
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}/due-date` with dueDate "2026-05-01"
+- **THEN** the system updates the due date and returns HTTP 200
+
+#### Scenario: Clear due date
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}/due-date` with dueDate null
+- **THEN** the system clears the due date and returns HTTP 200
+
+### Requirement: Change priority
+
+The system SHALL allow an authenticated user to change a delegation's priority (Low, Medium, High, Urgent). The system SHALL raise a `DelegationReprioritized` domain event.
+
+#### Scenario: Change priority
+
+- **WHEN** an authenticated user sends a PUT to `/api/delegations/{id}/priority` with priority "Urgent"
+- **THEN** the system updates the priority and returns HTTP 200
+
+### Requirement: Reassign delegation
+
+The system SHALL allow an authenticated user to reassign a delegation to a different person. The system SHALL update DelegatePersonId and raise a `DelegationReassigned` domain event.
+
+#### Scenario: Reassign to a different person
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/reassign` with a new delegatePersonId
+- **THEN** the system updates the DelegatePersonId and returns HTTP 200
+
+#### Scenario: Reassign to same person is idempotent
+
+- **WHEN** an authenticated user sends a POST to `/api/delegations/{id}/reassign` with the current delegatePersonId
+- **THEN** the system returns HTTP 200 without raising an event
+
+### Requirement: Delegation list UI
+
+The frontend SHALL provide a delegation list page that displays delegations with description, delegate person name, status badge, priority indicator, due date, and last follow-up timestamp. The list SHALL support filtering by status and priority.
+
+#### Scenario: View delegation list
+
+- **WHEN** a user navigates to the delegations page
+- **THEN** the system displays all their delegations with description, person, status, priority, due date, and last follow-up time
+
+#### Scenario: Filter delegations
+
+- **WHEN** a user selects status or priority filters
+- **THEN** the list updates to show only matching delegations
+
+### Requirement: Delegation create/edit form
+
+The frontend SHALL provide a form for creating and editing delegations. The form SHALL include fields for description, person selector, due date picker, priority selector, initiative selector (optional), and notes.
+
+#### Scenario: Create delegation via form
+
+- **WHEN** a user fills in the delegation form with description, picks a person, and submits
+- **THEN** a new delegation is created and appears in the list
+
+#### Scenario: Edit delegation
+
+- **WHEN** a user edits a delegation's description or notes and saves
+- **THEN** the delegation is updated and the view reflects the changes
+
+### Requirement: Delegation status and follow-up actions
+
+The frontend SHALL provide action buttons for status transitions (Start, Complete, Block, Unblock) and follow-up recording directly from the list or detail view.
+
+#### Scenario: Complete from list
+
+- **WHEN** a user clicks "Complete" on a delegation in the list
+- **THEN** the delegation is marked as completed and the status badge updates
+
+#### Scenario: Record follow-up from detail
+
+- **WHEN** a user clicks "Follow Up" on a delegation and optionally adds notes
+- **THEN** the LastFollowedUpAt updates and the follow-up is recorded

--- a/openspec/changes/delegation-tracking/tasks.md
+++ b/openspec/changes/delegation-tracking/tasks.md
@@ -1,0 +1,70 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Create `DelegationStatus` enum (Assigned, InProgress, Completed, Blocked) in `src/MentalMetal.Domain/Delegations/`
+- [ ] 1.2 Create `Priority` enum (Low, Medium, High, Urgent) in `src/MentalMetal.Domain/Delegations/`
+- [ ] 1.3 Create `Delegation` aggregate root entity with all properties (Id, UserId, Description, DelegatePersonId, InitiativeId, SourceCaptureId, DueDate, Status, Priority, CompletedAt, Notes, LastFollowedUpAt, CreatedAt, UpdatedAt)
+- [ ] 1.4 Implement factory method `Create(userId, description, delegatePersonId, dueDate?, initiativeId?, priority?, sourceCaptureId?)` with validation and `DelegationCreated` domain event
+- [ ] 1.5 Implement status transition methods: `MarkInProgress()`, `MarkCompleted(notes?)`, `MarkBlocked(reason)`, `Unblock()` with state machine validation and domain events
+- [ ] 1.6 Implement `RecordFollowUp(notes?)` updating LastFollowedUpAt with `DelegationFollowedUp` domain event
+- [ ] 1.7 Implement `UpdateDueDate(newDate)` with `DelegationDueDateChanged` domain event
+- [ ] 1.8 Implement `Reprioritize(newPriority)` with `DelegationReprioritized` domain event
+- [ ] 1.9 Implement `Reassign(newPersonId)` with `DelegationReassigned` domain event
+- [ ] 1.10 Create `IDelegationRepository` interface in `src/MentalMetal.Domain/Delegations/`
+- [ ] 1.11 Create domain event classes: `DelegationCreated`, `DelegationStarted`, `DelegationCompleted`, `DelegationBlocked`, `DelegationUnblocked`, `DelegationFollowedUp`, `DelegationDueDateChanged`, `DelegationReprioritized`, `DelegationReassigned`
+
+## 2. Domain Unit Tests
+
+- [ ] 2.1 Test Delegation creation with valid inputs and domain event
+- [ ] 2.2 Test creation rejects empty description and missing delegatePersonId
+- [ ] 2.3 Test valid status transitions: Assigned->InProgress, Assigned->Completed, Assigned->Blocked, InProgress->Completed, InProgress->Blocked, Blocked->InProgress, Blocked->Completed
+- [ ] 2.4 Test invalid status transitions throw domain exception (Completed->InProgress, Completed->Blocked, etc.)
+- [ ] 2.5 Test CompletedAt is set on completion
+- [ ] 2.6 Test RecordFollowUp updates LastFollowedUpAt
+- [ ] 2.7 Test Reassign changes DelegatePersonId and raises event (idempotent for same person)
+- [ ] 2.8 Test Reprioritize and UpdateDueDate
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Create `DelegationConfiguration` EF Core entity configuration
+- [ ] 3.2 Create `DelegationRepository` implementing `IDelegationRepository` with filtering support
+- [ ] 3.3 Register `DelegationRepository` in DI
+- [ ] 3.4 Add EF Core migration for Delegations table
+
+## 4. Application Layer (Vertical Slice Handlers)
+
+- [ ] 4.1 Create `CreateDelegation` command handler (POST /api/delegations)
+- [ ] 4.2 Create `GetUserDelegations` query handler (GET /api/delegations) with status, priority, delegatePersonId, and initiativeId filters
+- [ ] 4.3 Create `GetDelegationById` query handler (GET /api/delegations/{id})
+- [ ] 4.4 Create `UpdateDelegation` command handler (PUT /api/delegations/{id})
+- [ ] 4.5 Create `StartDelegation` command handler (POST /api/delegations/{id}/start)
+- [ ] 4.6 Create `CompleteDelegation` command handler (POST /api/delegations/{id}/complete)
+- [ ] 4.7 Create `BlockDelegation` command handler (POST /api/delegations/{id}/block)
+- [ ] 4.8 Create `UnblockDelegation` command handler (POST /api/delegations/{id}/unblock)
+- [ ] 4.9 Create `RecordDelegationFollowUp` command handler (POST /api/delegations/{id}/follow-up)
+- [ ] 4.10 Create `UpdateDelegationDueDate` command handler (PUT /api/delegations/{id}/due-date)
+- [ ] 4.11 Create `ReprioritizeDelegation` command handler (PUT /api/delegations/{id}/priority)
+- [ ] 4.12 Create `ReassignDelegation` command handler (POST /api/delegations/{id}/reassign)
+
+## 5. Web API Layer
+
+- [ ] 5.1 Create `DelegationEndpoints` minimal API mapping with all routes
+- [ ] 5.2 Create request/response DTOs for delegation operations
+
+## 6. Frontend — Service and Models
+
+- [ ] 6.1 Create `Delegation` TypeScript model with all fields
+- [ ] 6.2 Create `DelegationService` with methods for all API operations
+- [ ] 6.3 Add delegations route to Angular router
+
+## 7. Frontend — Components
+
+- [ ] 7.1 Create delegation list page component with PrimeNG DataView and filter dropdowns (status, priority)
+- [ ] 7.2 Create delegation create/edit dialog component with PrimeNG Dialog, person dropdown, date picker, priority selector, initiative dropdown
+- [ ] 7.3 Add status action buttons (Start, Complete, Block, Unblock) and follow-up recording to list items and detail view
+- [ ] 7.4 Create delegation detail view showing all fields and linked entities
+
+## 8. E2E Tests
+
+- [ ] 8.1 E2E test: create a delegation and verify it appears in the list
+- [ ] 8.2 E2E test: transition delegation through status lifecycle (Assigned -> InProgress -> Completed)
+- [ ] 8.3 E2E test: user isolation — delegations are scoped per user


### PR DESCRIPTION
## Summary

Proposes three Tier 2A OpenSpec changes with full artifacts (proposal, design, specs, tasks) for the next wave of implementation: capture-text, commitment-tracking, and delegation-tracking.

- **capture-text**: Capture aggregate for raw text input (quick notes, transcripts, meeting notes) with processing status lifecycle. Depends on user-auth-tenancy only.
- **commitment-tracking**: Commitment aggregate for bidirectional promises (MineToThem/TheirsToMe) with status lifecycle and overdue detection. Depends on person-management, initiative-management.
- **delegation-tracking**: Delegation aggregate for assigned tasks with status tracking, priority, follow-up ownership, and reassignment. Depends on person-management, initiative-management.

## Changes

- Add `openspec/changes/capture-text/` with proposal, design, spec, and tasks
- Add `openspec/changes/commitment-tracking/` with proposal, design, spec, and tasks
- Add `openspec/changes/delegation-tracking/` with proposal, design, spec, and tasks

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (164 tests, docs-only change)
- [x] All artifacts consistent with domain model (`design/domain-model.md`)
- [x] All artifacts consistent with spec plan (`design/spec-plan.md`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications and design documentation for three new capabilities: text capture management (inbox-style ingestion of notes and transcripts), commitment tracking (with status lifecycle and due-date management), and delegation tracking (with priority and follow-up recording).
  * Included end-to-end requirements, task plans, and implementation roadmaps for each capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->