### PR TITLE
feat: Implement commitment-tracking (Tier 2A)

### DIFF
--- a/openspec/changes/commitment-tracking/tasks.md
+++ b/openspec/changes/commitment-tracking/tasks.md
@@ -1,68 +1,68 @@
 ## 1. Domain Layer
 
-- [ ] 1.1 Create `CommitmentDirection` enum (MineToThem, TheirsToMe) in `src/MentalMetal.Domain/Commitments/`
-- [ ] 1.2 Create `CommitmentStatus` enum (Open, Completed, Cancelled) in `src/MentalMetal.Domain/Commitments/`
-- [ ] 1.3 Create `Commitment` aggregate root entity with all properties (Id, UserId, Description, Direction, PersonId, InitiativeId, SourceCaptureId, DueDate, Status, CompletedAt, Notes, CreatedAt, UpdatedAt)
-- [ ] 1.4 Implement factory method `Create(userId, description, direction, personId, dueDate?, initiativeId?, sourceCaptureId?)` with validation and `CommitmentCreated` domain event
-- [ ] 1.5 Implement status transition methods: `Complete(notes?)`, `Cancel(reason?)`, `Reopen()` with transition validation and domain events
-- [ ] 1.6 Implement `UpdateDueDate(newDate)` with `CommitmentDueDateChanged` domain event
-- [ ] 1.7 Implement `UpdateDescription(description)` with validation and `CommitmentDescriptionUpdated` domain event
-- [ ] 1.8 Implement `LinkToInitiative(initiativeId)` with `CommitmentLinkedToInitiative` domain event
-- [ ] 1.9 Implement `MarkOverdue()` with guard (DueDate in past, status Open) and `CommitmentBecameOverdue` domain event
-- [ ] 1.10 Add computed `IsOverdue` property (Status == Open && DueDate != null && DueDate < today)
-- [ ] 1.11 Create `ICommitmentRepository` interface in `src/MentalMetal.Domain/Commitments/`
-- [ ] 1.12 Create domain event classes: `CommitmentCreated`, `CommitmentCompleted`, `CommitmentCancelled`, `CommitmentReopened`, `CommitmentDueDateChanged`, `CommitmentDescriptionUpdated`, `CommitmentLinkedToInitiative`, `CommitmentBecameOverdue`
+- [x] 1.1 Create `CommitmentDirection` enum (MineToThem, TheirsToMe) in `src/MentalMetal.Domain/Commitments/`
+- [x] 1.2 Create `CommitmentStatus` enum (Open, Completed, Cancelled) in `src/MentalMetal.Domain/Commitments/`
+- [x] 1.3 Create `Commitment` aggregate root entity with all properties (Id, UserId, Description, Direction, PersonId, InitiativeId, SourceCaptureId, DueDate, Status, CompletedAt, Notes, CreatedAt, UpdatedAt)
+- [x] 1.4 Implement factory method `Create(userId, description, direction, personId, dueDate?, initiativeId?, sourceCaptureId?)` with validation and `CommitmentCreated` domain event
+- [x] 1.5 Implement status transition methods: `Complete(notes?)`, `Cancel(reason?)`, `Reopen()` with transition validation and domain events
+- [x] 1.6 Implement `UpdateDueDate(newDate)` with `CommitmentDueDateChanged` domain event
+- [x] 1.7 Implement `UpdateDescription(description)` with validation and `CommitmentDescriptionUpdated` domain event
+- [x] 1.8 Implement `LinkToInitiative(initiativeId)` with `CommitmentLinkedToInitiative` domain event
+- [x] 1.9 Implement `MarkOverdue()` with guard (DueDate in past, status Open) and `CommitmentBecameOverdue` domain event
+- [x] 1.10 Add computed `IsOverdue` property (Status == Open && DueDate != null && DueDate < today)
+- [x] 1.11 Create `ICommitmentRepository` interface in `src/MentalMetal.Domain/Commitments/`
+- [x] 1.12 Create domain event classes: `CommitmentCreated`, `CommitmentCompleted`, `CommitmentCancelled`, `CommitmentReopened`, `CommitmentDueDateChanged`, `CommitmentDescriptionUpdated`, `CommitmentLinkedToInitiative`, `CommitmentBecameOverdue`
 
 ## 2. Domain Unit Tests
 
-- [ ] 2.1 Test Commitment creation with valid inputs and domain event
-- [ ] 2.2 Test creation rejects empty description and missing personId
-- [ ] 2.3 Test status transitions: Open->Completed, Open->Cancelled, Completed->Open, Cancelled->Open
-- [ ] 2.4 Test invalid status transitions throw domain exception (Completed->Completed, Cancelled->Cancelled, Open->Reopen)
-- [ ] 2.5 Test CompletedAt is set on completion and cleared on reopen
-- [ ] 2.6 Test IsOverdue computation for all status/date combinations
-- [ ] 2.7 Test MarkOverdue raises event only when conditions met
-- [ ] 2.8 Test UpdateDueDate and UpdateDescription
+- [x] 2.1 Test Commitment creation with valid inputs and domain event
+- [x] 2.2 Test creation rejects empty description and missing personId
+- [x] 2.3 Test status transitions: Open->Completed, Open->Cancelled, Completed->Open, Cancelled->Open
+- [x] 2.4 Test invalid status transitions throw domain exception (Completed->Completed, Cancelled->Cancelled, Open->Reopen)
+- [x] 2.5 Test CompletedAt is set on completion and cleared on reopen
+- [x] 2.6 Test IsOverdue computation for all status/date combinations
+- [x] 2.7 Test MarkOverdue raises event only when conditions met
+- [x] 2.8 Test UpdateDueDate and UpdateDescription
 
 ## 3. Infrastructure Layer
 
-- [ ] 3.1 Create `CommitmentConfiguration` EF Core entity configuration
-- [ ] 3.2 Create `CommitmentRepository` implementing `ICommitmentRepository` with filtering support
-- [ ] 3.3 Register `CommitmentRepository` in DI
-- [ ] 3.4 Add EF Core migration for Commitments table
+- [x] 3.1 Create `CommitmentConfiguration` EF Core entity configuration
+- [x] 3.2 Create `CommitmentRepository` implementing `ICommitmentRepository` with filtering support
+- [x] 3.3 Register `CommitmentRepository` in DI
+- [x] 3.4 Add EF Core migration for Commitments table
 
 ## 4. Application Layer (Vertical Slice Handlers)
 
-- [ ] 4.1 Create `CreateCommitment` command handler (POST /api/commitments)
-- [ ] 4.2 Create `GetUserCommitments` query handler (GET /api/commitments) with direction, status, personId, initiativeId, and overdue filters
-- [ ] 4.3 Create `GetCommitmentById` query handler (GET /api/commitments/{id})
-- [ ] 4.4 Create `UpdateCommitment` command handler (PUT /api/commitments/{id})
-- [ ] 4.5 Create `CompleteCommitment` command handler (POST /api/commitments/{id}/complete)
-- [ ] 4.6 Create `CancelCommitment` command handler (POST /api/commitments/{id}/cancel)
-- [ ] 4.7 Create `ReopenCommitment` command handler (POST /api/commitments/{id}/reopen)
-- [ ] 4.8 Create `UpdateCommitmentDueDate` command handler (PUT /api/commitments/{id}/due-date)
-- [ ] 4.9 Create `LinkCommitmentToInitiative` command handler (POST /api/commitments/{id}/link-initiative)
+- [x] 4.1 Create `CreateCommitment` command handler (POST /api/commitments)
+- [x] 4.2 Create `GetUserCommitments` query handler (GET /api/commitments) with direction, status, personId, initiativeId, and overdue filters
+- [x] 4.3 Create `GetCommitmentById` query handler (GET /api/commitments/{id})
+- [x] 4.4 Create `UpdateCommitment` command handler (PUT /api/commitments/{id})
+- [x] 4.5 Create `CompleteCommitment` command handler (POST /api/commitments/{id}/complete)
+- [x] 4.6 Create `CancelCommitment` command handler (POST /api/commitments/{id}/cancel)
+- [x] 4.7 Create `ReopenCommitment` command handler (POST /api/commitments/{id}/reopen)
+- [x] 4.8 Create `UpdateCommitmentDueDate` command handler (PUT /api/commitments/{id}/due-date)
+- [x] 4.9 Create `LinkCommitmentToInitiative` command handler (POST /api/commitments/{id}/link-initiative)
 
 ## 5. Web API Layer
 
-- [ ] 5.1 Create `CommitmentEndpoints` minimal API mapping with all routes
-- [ ] 5.2 Create request/response DTOs for commitment operations
+- [x] 5.1 Create `CommitmentEndpoints` minimal API mapping with all routes
+- [x] 5.2 Create request/response DTOs for commitment operations
 
 ## 6. Frontend — Service and Models
 
-- [ ] 6.1 Create `Commitment` TypeScript model with all fields including computed IsOverdue
-- [ ] 6.2 Create `CommitmentService` with methods for all API operations
-- [ ] 6.3 Add commitments route to Angular router
+- [x] 6.1 Create `Commitment` TypeScript model with all fields including computed IsOverdue
+- [x] 6.2 Create `CommitmentService` with methods for all API operations
+- [x] 6.3 Add commitments route to Angular router
 
 ## 7. Frontend — Components
 
-- [ ] 7.1 Create commitment list page component with PrimeNG DataView and filter dropdowns (direction, status, overdue)
-- [ ] 7.2 Create commitment create/edit dialog component with PrimeNG Dialog, direction selector, person dropdown, date picker, initiative dropdown
-- [ ] 7.3 Add status action buttons (Complete, Cancel, Reopen) to list items and detail view
-- [ ] 7.4 Create commitment detail view showing all fields and linked entities
+- [x] 7.1 Create commitment list page component with PrimeNG DataView and filter dropdowns (direction, status, overdue)
+- [x] 7.2 Create commitment create/edit dialog component with PrimeNG Dialog, direction selector, person dropdown, date picker, initiative dropdown
+- [x] 7.3 Add status action buttons (Complete, Cancel, Reopen) to list items and detail view
+- [x] 7.4 Create commitment detail view showing all fields and linked entities
 
 ## 8. E2E Tests
 
-- [ ] 8.1 E2E test: create a commitment and verify it appears in the list
-- [ ] 8.2 E2E test: complete and reopen a commitment
-- [ ] 8.3 E2E test: user isolation — commitments are scoped per user
+- [x] 8.1 E2E test: create a commitment and verify it appears in the list
+- [x] 8.2 E2E test: complete and reopen a commitment
+- [x] 8.3 E2E test: user isolation — commitments are scoped per user

--- a/src/MentalMetal.Application/Commitments/CancelCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/CancelCommitment.cs
@@ -1,0 +1,27 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class CancelCommitmentHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, CancelCommitmentRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.Cancel(request.Reason);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
+++ b/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
@@ -19,7 +19,7 @@ public sealed record CancelCommitmentRequest(string? Reason = null);
 
 public sealed record UpdateDueDateRequest(DateOnly? DueDate);
 
-public sealed record LinkInitiativeRequest(Guid InitiativeId);
+public sealed record LinkCommitmentToInitiativeRequest(Guid InitiativeId);
 
 public sealed record CommitmentResponse(
     Guid Id,

--- a/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
+++ b/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
@@ -1,0 +1,55 @@
+using MentalMetal.Domain.Commitments;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed record CreateCommitmentRequest(
+    string Description,
+    CommitmentDirection Direction,
+    Guid PersonId,
+    DateOnly? DueDate = null,
+    Guid? InitiativeId = null,
+    Guid? SourceCaptureId = null,
+    string? Notes = null);
+
+public sealed record UpdateCommitmentRequest(string Description, string? Notes);
+
+public sealed record CompleteCommitmentRequest(string? Notes = null);
+
+public sealed record CancelCommitmentRequest(string? Reason = null);
+
+public sealed record UpdateDueDateRequest(DateOnly? DueDate);
+
+public sealed record LinkInitiativeRequest(Guid InitiativeId);
+
+public sealed record CommitmentResponse(
+    Guid Id,
+    Guid UserId,
+    string Description,
+    CommitmentDirection Direction,
+    Guid PersonId,
+    Guid? InitiativeId,
+    Guid? SourceCaptureId,
+    DateOnly? DueDate,
+    CommitmentStatus Status,
+    DateTimeOffset? CompletedAt,
+    string? Notes,
+    bool IsOverdue,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt)
+{
+    public static CommitmentResponse From(Commitment commitment) => new(
+        commitment.Id,
+        commitment.UserId,
+        commitment.Description,
+        commitment.Direction,
+        commitment.PersonId,
+        commitment.InitiativeId,
+        commitment.SourceCaptureId,
+        commitment.DueDate,
+        commitment.Status,
+        commitment.CompletedAt,
+        commitment.Notes,
+        commitment.IsOverdue,
+        commitment.CreatedAt,
+        commitment.UpdatedAt);
+}

--- a/src/MentalMetal.Application/Commitments/CompleteCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/CompleteCommitment.cs
@@ -1,0 +1,27 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class CompleteCommitmentHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, CompleteCommitmentRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.Complete(request.Notes);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/CreateCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/CreateCommitment.cs
@@ -1,0 +1,32 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class CreateCommitmentHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        CreateCommitmentRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = Commitment.Create(
+            currentUserService.UserId,
+            request.Description,
+            request.Direction,
+            request.PersonId,
+            request.DueDate,
+            request.InitiativeId,
+            request.SourceCaptureId);
+
+        if (!string.IsNullOrWhiteSpace(request.Notes))
+            commitment.UpdateNotes(request.Notes);
+
+        await commitmentRepository.AddAsync(commitment, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/GetCommitmentById.cs
+++ b/src/MentalMetal.Application/Commitments/GetCommitmentById.cs
@@ -1,0 +1,20 @@
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class GetCommitmentByIdHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService)
+{
+    public async Task<CommitmentResponse?> HandleAsync(
+        Guid commitmentId, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken);
+
+        if (commitment is null || commitment.UserId != currentUserService.UserId)
+            return null;
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/GetUserCommitments.cs
+++ b/src/MentalMetal.Application/Commitments/GetUserCommitments.cs
@@ -1,0 +1,29 @@
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class GetUserCommitmentsHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService)
+{
+    public async Task<List<CommitmentResponse>> HandleAsync(
+        CommitmentDirection? directionFilter,
+        CommitmentStatus? statusFilter,
+        Guid? personIdFilter,
+        Guid? initiativeIdFilter,
+        bool? overdueFilter,
+        CancellationToken cancellationToken)
+    {
+        var commitments = await commitmentRepository.GetAllAsync(
+            currentUserService.UserId,
+            directionFilter,
+            statusFilter,
+            personIdFilter,
+            initiativeIdFilter,
+            overdueFilter,
+            cancellationToken);
+
+        return commitments.Select(CommitmentResponse.From).ToList();
+    }
+}

--- a/src/MentalMetal.Application/Commitments/LinkCommitmentToInitiative.cs
+++ b/src/MentalMetal.Application/Commitments/LinkCommitmentToInitiative.cs
@@ -1,0 +1,27 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class LinkCommitmentToInitiativeHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, LinkInitiativeRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.LinkToInitiative(request.InitiativeId);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/LinkCommitmentToInitiative.cs
+++ b/src/MentalMetal.Application/Commitments/LinkCommitmentToInitiative.cs
@@ -10,7 +10,7 @@ public sealed class LinkCommitmentToInitiativeHandler(
     IUnitOfWork unitOfWork)
 {
     public async Task<CommitmentResponse> HandleAsync(
-        Guid commitmentId, LinkInitiativeRequest request, CancellationToken cancellationToken)
+        Guid commitmentId, LinkCommitmentToInitiativeRequest request, CancellationToken cancellationToken)
     {
         var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
             ?? throw new InvalidOperationException("Commitment not found.");

--- a/src/MentalMetal.Application/Commitments/ReopenCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/ReopenCommitment.cs
@@ -1,0 +1,27 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class ReopenCommitmentHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.Reopen();
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/UpdateCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/UpdateCommitment.cs
@@ -1,0 +1,28 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class UpdateCommitmentHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, UpdateCommitmentRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.UpdateDescription(request.Description);
+        commitment.UpdateNotes(request.Notes);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Application/Commitments/UpdateCommitmentDueDate.cs
+++ b/src/MentalMetal.Application/Commitments/UpdateCommitmentDueDate.cs
@@ -1,0 +1,27 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Commitments;
+
+public sealed class UpdateCommitmentDueDateHandler(
+    ICommitmentRepository commitmentRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CommitmentResponse> HandleAsync(
+        Guid commitmentId, UpdateDueDateRequest request, CancellationToken cancellationToken)
+    {
+        var commitment = await commitmentRepository.GetByIdAsync(commitmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Commitment not found.");
+
+        if (commitment.UserId != currentUserService.UserId)
+            throw new InvalidOperationException("Commitment not found.");
+
+        commitment.UpdateDueDate(request.DueDate);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CommitmentResponse.From(commitment);
+    }
+}

--- a/src/MentalMetal.Domain/Commitments/Commitment.cs
+++ b/src/MentalMetal.Domain/Commitments/Commitment.cs
@@ -1,0 +1,149 @@
+using MentalMetal.Domain.Common;
+
+namespace MentalMetal.Domain.Commitments;
+
+public sealed class Commitment : AggregateRoot, IUserScoped
+{
+    public Guid UserId { get; private set; }
+    public string Description { get; private set; } = null!;
+    public CommitmentDirection Direction { get; private set; }
+    public Guid PersonId { get; private set; }
+    public Guid? InitiativeId { get; private set; }
+    public Guid? SourceCaptureId { get; private set; }
+    public DateOnly? DueDate { get; private set; }
+    public CommitmentStatus Status { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+    public string? Notes { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public bool IsOverdue =>
+        Status == CommitmentStatus.Open
+        && DueDate is not null
+        && DueDate < DateOnly.FromDateTime(DateTime.UtcNow);
+
+    private Commitment() { } // EF Core
+
+    public static Commitment Create(
+        Guid userId,
+        string description,
+        CommitmentDirection direction,
+        Guid personId,
+        DateOnly? dueDate = null,
+        Guid? initiativeId = null,
+        Guid? sourceCaptureId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(description, nameof(description));
+
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
+        var now = DateTimeOffset.UtcNow;
+
+        var commitment = new Commitment
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Description = description.Trim(),
+            Direction = direction,
+            PersonId = personId,
+            InitiativeId = initiativeId,
+            SourceCaptureId = sourceCaptureId,
+            DueDate = dueDate,
+            Status = CommitmentStatus.Open,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        commitment.RaiseDomainEvent(new CommitmentCreated(commitment.Id, userId, direction, personId));
+
+        return commitment;
+    }
+
+    public void Complete(string? notes = null)
+    {
+        if (Status != CommitmentStatus.Open)
+            throw new InvalidOperationException(
+                $"Cannot complete a commitment with status '{Status}'. Must be 'Open'.");
+
+        Status = CommitmentStatus.Completed;
+        CompletedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (!string.IsNullOrWhiteSpace(notes))
+            Notes = string.IsNullOrWhiteSpace(Notes) ? notes.Trim() : $"{Notes}\n{notes.Trim()}";
+
+        RaiseDomainEvent(new CommitmentCompleted(Id, notes));
+    }
+
+    public void Cancel(string? reason = null)
+    {
+        if (Status != CommitmentStatus.Open)
+            throw new InvalidOperationException(
+                $"Cannot cancel a commitment with status '{Status}'. Must be 'Open'.");
+
+        Status = CommitmentStatus.Cancelled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (!string.IsNullOrWhiteSpace(reason))
+            Notes = string.IsNullOrWhiteSpace(Notes) ? reason.Trim() : $"{Notes}\n{reason.Trim()}";
+
+        RaiseDomainEvent(new CommitmentCancelled(Id, reason));
+    }
+
+    public void Reopen()
+    {
+        if (Status == CommitmentStatus.Open)
+            throw new InvalidOperationException(
+                "Cannot reopen a commitment that is already 'Open'.");
+
+        Status = CommitmentStatus.Open;
+        CompletedAt = null;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CommitmentReopened(Id));
+    }
+
+    public void UpdateDueDate(DateOnly? newDate)
+    {
+        DueDate = newDate;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CommitmentDueDateChanged(Id, newDate));
+    }
+
+    public void UpdateDescription(string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(description, nameof(description));
+
+        Description = description.Trim();
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CommitmentDescriptionUpdated(Id));
+    }
+
+    public void LinkToInitiative(Guid initiativeId)
+    {
+        if (InitiativeId == initiativeId)
+            return; // idempotent
+
+        InitiativeId = initiativeId;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CommitmentLinkedToInitiative(Id, initiativeId));
+    }
+
+    public void MarkOverdue()
+    {
+        if (!IsOverdue)
+            return; // guard: only raise event when actually overdue
+
+        RaiseDomainEvent(new CommitmentBecameOverdue(Id, DueDate!.Value));
+    }
+
+    public void UpdateNotes(string? notes)
+    {
+        Notes = notes?.Trim();
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/MentalMetal.Domain/Commitments/Commitment.cs
+++ b/src/MentalMetal.Domain/Commitments/Commitment.cs
@@ -35,6 +35,9 @@ public sealed class Commitment : AggregateRoot, IUserScoped
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(description, nameof(description));
 
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId is required.", nameof(userId));
+
         if (personId == Guid.Empty)
             throw new ArgumentException("PersonId is required.", nameof(personId));
 

--- a/src/MentalMetal.Domain/Commitments/CommitmentDirection.cs
+++ b/src/MentalMetal.Domain/Commitments/CommitmentDirection.cs
@@ -1,0 +1,7 @@
+namespace MentalMetal.Domain.Commitments;
+
+public enum CommitmentDirection
+{
+    MineToThem,
+    TheirsToMe
+}

--- a/src/MentalMetal.Domain/Commitments/CommitmentEvents.cs
+++ b/src/MentalMetal.Domain/Commitments/CommitmentEvents.cs
@@ -1,0 +1,43 @@
+using MentalMetal.Domain.Common;
+
+namespace MentalMetal.Domain.Commitments;
+
+public sealed record CommitmentCreated(Guid CommitmentId, Guid UserId, CommitmentDirection Direction, Guid PersonId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentCompleted(Guid CommitmentId, string? Notes) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentCancelled(Guid CommitmentId, string? Reason) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentReopened(Guid CommitmentId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentDueDateChanged(Guid CommitmentId, DateOnly? NewDueDate) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentDescriptionUpdated(Guid CommitmentId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentLinkedToInitiative(Guid CommitmentId, Guid InitiativeId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CommitmentBecameOverdue(Guid CommitmentId, DateOnly DueDate) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Domain/Commitments/CommitmentStatus.cs
+++ b/src/MentalMetal.Domain/Commitments/CommitmentStatus.cs
@@ -1,0 +1,8 @@
+namespace MentalMetal.Domain.Commitments;
+
+public enum CommitmentStatus
+{
+    Open,
+    Completed,
+    Cancelled
+}

--- a/src/MentalMetal.Domain/Commitments/ICommitmentRepository.cs
+++ b/src/MentalMetal.Domain/Commitments/ICommitmentRepository.cs
@@ -1,0 +1,15 @@
+namespace MentalMetal.Domain.Commitments;
+
+public interface ICommitmentRepository
+{
+    Task<Commitment?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Commitment>> GetAllAsync(
+        Guid userId,
+        CommitmentDirection? directionFilter,
+        CommitmentStatus? statusFilter,
+        Guid? personIdFilter,
+        Guid? initiativeIdFilter,
+        bool? overdueFilter,
+        CancellationToken cancellationToken);
+    Task AddAsync(Commitment commitment, CancellationToken cancellationToken);
+}

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Captures;
+using MentalMetal.Application.Commitments;
 using MentalMetal.Application.Common;
 using MentalMetal.Application.Common.Ai;
 using MentalMetal.Application.Common.Auth;
@@ -6,6 +7,7 @@ using MentalMetal.Application.Initiatives;
 using MentalMetal.Application.People;
 using MentalMetal.Application.Users;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.People;
 using MentalMetal.Domain.Users;
@@ -47,6 +49,7 @@ public static class DependencyInjection
         services.AddScoped<IPersonRepository, PersonRepository>();
         services.AddScoped<IInitiativeRepository, InitiativeRepository>();
         services.AddScoped<ICaptureRepository, CaptureRepository>();
+        services.AddScoped<ICommitmentRepository, CommitmentRepository>();
         services.AddScoped<ITokenService, TokenService>();
 
         // AI provider services
@@ -97,6 +100,17 @@ public static class DependencyInjection
         services.AddScoped<CompleteMilestoneHandler>();
         services.AddScoped<LinkPersonHandler>();
         services.AddScoped<UnlinkPersonHandler>();
+
+        // Commitment handlers
+        services.AddScoped<CreateCommitmentHandler>();
+        services.AddScoped<GetCommitmentByIdHandler>();
+        services.AddScoped<GetUserCommitmentsHandler>();
+        services.AddScoped<UpdateCommitmentHandler>();
+        services.AddScoped<CompleteCommitmentHandler>();
+        services.AddScoped<CancelCommitmentHandler>();
+        services.AddScoped<ReopenCommitmentHandler>();
+        services.AddScoped<UpdateCommitmentDueDateHandler>();
+        services.AddScoped<LinkCommitmentToInitiativeHandler>();
 
         // Capture handlers
         services.AddScoped<CreateCaptureHandler>();

--- a/src/MentalMetal.Infrastructure/Migrations/20260412215543_AddCommitments.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260412215543_AddCommitments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412215543_AddCommitments")]
+    partial class AddCommitments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260412215543_AddCommitments.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260412215543_AddCommitments.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommitments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Commitments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    Direction = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    PersonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    InitiativeId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SourceCaptureId = table.Column<Guid>(type: "uuid", nullable: true),
+                    DueDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Notes = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Commitments", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Commitments_InitiativeId",
+                table: "Commitments",
+                column: "InitiativeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Commitments_PersonId",
+                table: "Commitments",
+                column: "PersonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Commitments_UserId",
+                table: "Commitments",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Commitments");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CommitmentConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CommitmentConfiguration.cs
@@ -1,0 +1,44 @@
+using MentalMetal.Domain.Commitments;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MentalMetal.Infrastructure.Persistence.Configurations;
+
+public sealed class CommitmentConfiguration : IEntityTypeConfiguration<Commitment>
+{
+    public void Configure(EntityTypeBuilder<Commitment> builder)
+    {
+        builder.ToTable("Commitments");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Description)
+            .IsRequired()
+            .HasMaxLength(2000);
+
+        builder.Property(c => c.Direction)
+            .HasConversion<string>()
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(c => c.Status)
+            .HasConversion<string>()
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(c => c.PersonId)
+            .IsRequired();
+
+        builder.Property(c => c.Notes)
+            .HasMaxLength(4000);
+
+        builder.Property(c => c.UserId)
+            .IsRequired();
+
+        builder.HasIndex(c => c.UserId);
+        builder.HasIndex(c => c.PersonId);
+        builder.HasIndex(c => c.InitiativeId);
+
+        builder.Ignore(c => c.IsOverdue);
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/MentalMetalDbContext.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/MentalMetalDbContext.cs
@@ -1,5 +1,6 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
 using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.People;
@@ -20,6 +21,7 @@ public sealed class MentalMetalDbContext(
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<Initiative> Initiatives => Set<Initiative>();
     public DbSet<Capture> Captures => Set<Capture>();
+    public DbSet<Commitment> Commitments => Set<Commitment>();
     public DbSet<AiTasteBudget> AiTasteBudgets => Set<AiTasteBudget>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -31,5 +33,6 @@ public sealed class MentalMetalDbContext(
         modelBuilder.Entity<Person>().HasQueryFilter(p => p.UserId == currentUserService.UserId);
         modelBuilder.Entity<Initiative>().HasQueryFilter(i => i.UserId == currentUserService.UserId);
         modelBuilder.Entity<Capture>().HasQueryFilter(c => c.UserId == currentUserService.UserId);
+        modelBuilder.Entity<Commitment>().HasQueryFilter(c => c.UserId == currentUserService.UserId);
     }
 }

--- a/src/MentalMetal.Infrastructure/Repositories/CommitmentRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/CommitmentRepository.cs
@@ -37,6 +37,11 @@ public sealed class CommitmentRepository(MentalMetalDbContext dbContext) : IComm
             var today = DateOnly.FromDateTime(DateTime.UtcNow);
             query = query.Where(c => c.Status == CommitmentStatus.Open && c.DueDate != null && c.DueDate < today);
         }
+        else if (overdueFilter == false)
+        {
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            query = query.Where(c => c.Status != CommitmentStatus.Open || c.DueDate == null || c.DueDate >= today);
+        }
 
         return await query
             .OrderBy(c => c.DueDate == null ? 1 : 0)

--- a/src/MentalMetal.Infrastructure/Repositories/CommitmentRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/CommitmentRepository.cs
@@ -1,0 +1,50 @@
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace MentalMetal.Infrastructure.Repositories;
+
+public sealed class CommitmentRepository(MentalMetalDbContext dbContext) : ICommitmentRepository
+{
+    public async Task<Commitment?> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Commitments.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+
+    public async Task<IReadOnlyList<Commitment>> GetAllAsync(
+        Guid userId,
+        CommitmentDirection? directionFilter,
+        CommitmentStatus? statusFilter,
+        Guid? personIdFilter,
+        Guid? initiativeIdFilter,
+        bool? overdueFilter,
+        CancellationToken cancellationToken)
+    {
+        var query = dbContext.Commitments.AsNoTracking().Where(c => c.UserId == userId);
+
+        if (directionFilter is not null)
+            query = query.Where(c => c.Direction == directionFilter.Value);
+
+        if (statusFilter is not null)
+            query = query.Where(c => c.Status == statusFilter.Value);
+
+        if (personIdFilter is not null)
+            query = query.Where(c => c.PersonId == personIdFilter.Value);
+
+        if (initiativeIdFilter is not null)
+            query = query.Where(c => c.InitiativeId == initiativeIdFilter.Value);
+
+        if (overdueFilter == true)
+        {
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            query = query.Where(c => c.Status == CommitmentStatus.Open && c.DueDate != null && c.DueDate < today);
+        }
+
+        return await query
+            .OrderBy(c => c.DueDate == null ? 1 : 0)
+            .ThenBy(c => c.DueDate)
+            .ThenByDescending(c => c.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Commitment commitment, CancellationToken cancellationToken) =>
+        await dbContext.Commitments.AddAsync(commitment, cancellationToken);
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/app.routes.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.routes.ts
@@ -11,6 +11,8 @@ export const routes: Routes = [
   { path: 'people/:id', loadComponent: () => import('./pages/people/person-detail/person-detail.component').then(m => m.PersonDetailComponent), canActivate: [authGuard], data: { title: 'Person Detail' } },
   { path: 'initiatives', loadComponent: () => import('./pages/initiatives/initiatives-list/initiatives-list.component').then(m => m.InitiativesListComponent), canActivate: [authGuard], data: { title: 'Initiatives' } },
   { path: 'initiatives/:id', loadComponent: () => import('./pages/initiatives/initiative-detail/initiative-detail.component').then(m => m.InitiativeDetailComponent), canActivate: [authGuard], data: { title: 'Initiative Detail' } },
+  { path: 'commitments', loadComponent: () => import('./pages/commitments/commitments-list/commitments-list.component').then(m => m.CommitmentsListComponent), canActivate: [authGuard], data: { title: 'Commitments' } },
+  { path: 'commitments/:id', loadComponent: () => import('./pages/commitments/commitment-detail/commitment-detail.component').then(m => m.CommitmentDetailComponent), canActivate: [authGuard], data: { title: 'Commitment Detail' } },
   { path: 'queue', loadComponent: () => import('./pages/placeholder.page').then(m => m.PlaceholderPage), canActivate: [authGuard], data: { title: 'My Queue' } },
   { path: 'settings', loadComponent: () => import('./pages/settings/settings.page').then(m => m.SettingsPage), canActivate: [authGuard], data: { title: 'Settings' } },
   { path: '**', redirectTo: 'dashboard' },

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
@@ -125,6 +125,9 @@ export class CommitmentDetailComponent implements OnInit {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.loadCommitment(id);
+    } else {
+      this.loading.set(false);
+      this.router.navigate(['/commitments']);
     }
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
@@ -1,0 +1,237 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { CommitmentsService } from '../../../shared/services/commitments.service';
+import { PeopleService } from '../../../shared/services/people.service';
+import { InitiativesService } from '../../../shared/services/initiatives.service';
+import { Commitment, CommitmentDirection, CommitmentStatus } from '../../../shared/models/commitment.model';
+import { CommitmentDialogComponent } from '../commitment-dialog/commitment-dialog.component';
+
+@Component({
+  selector: 'app-commitment-detail',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, ButtonModule, TagModule, ToastModule, CommitmentDialogComponent],
+  providers: [MessageService],
+  styles: [`
+    .detail-row {
+      border-color: var(--p-surface-200);
+    }
+  `],
+  template: `
+    <p-toast />
+
+    @if (loading()) {
+      <div class="flex justify-center p-8">
+        <i class="pi pi-spinner pi-spin text-2xl"></i>
+      </div>
+    } @else if (commitment()) {
+      <div class="max-w-2xl mx-auto flex flex-col gap-8">
+        <!-- Header -->
+        <div class="flex items-center gap-4">
+          <p-button icon="pi pi-arrow-left" [text]="true" (onClick)="goBack()" />
+          <h1 class="text-2xl font-bold flex-1">{{ commitment()!.description }}</h1>
+          <p-tag [value]="formatDirection(commitment()!.direction)" [severity]="directionSeverity(commitment()!.direction)" />
+          <p-tag [value]="formatStatus(commitment()!.status)" [severity]="statusSeverity(commitment()!.status)" />
+          @if (commitment()!.isOverdue) {
+            <p-tag value="Overdue" severity="danger" />
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex gap-2">
+          @if (commitment()!.status === 'Open') {
+            <p-button label="Complete" icon="pi pi-check" severity="success" (onClick)="onComplete()" />
+            <p-button label="Cancel" icon="pi pi-times" severity="danger" [outlined]="true" (onClick)="onCancel()" />
+          } @else {
+            <p-button label="Reopen" icon="pi pi-replay" severity="info" (onClick)="onReopen()" />
+          }
+          <p-button label="Edit" icon="pi pi-pencil" [outlined]="true" (onClick)="openEditDialog()" />
+        </div>
+
+        <!-- Details -->
+        <section class="flex flex-col gap-4">
+          <h2 class="text-xl font-semibold">Details</h2>
+          <div class="flex flex-col gap-3">
+            <div class="flex gap-4 py-2 border-b detail-row">
+              <span class="text-sm font-medium text-muted-color w-32">Person</span>
+              <span class="text-sm">{{ personName() }}</span>
+            </div>
+            <div class="flex gap-4 py-2 border-b detail-row">
+              <span class="text-sm font-medium text-muted-color w-32">Direction</span>
+              <span class="text-sm">{{ formatDirection(commitment()!.direction) }}</span>
+            </div>
+            <div class="flex gap-4 py-2 border-b detail-row">
+              <span class="text-sm font-medium text-muted-color w-32">Due Date</span>
+              <span class="text-sm">{{ commitment()!.dueDate || 'Not set' }}</span>
+            </div>
+            @if (commitment()!.initiativeId) {
+              <div class="flex gap-4 py-2 border-b detail-row">
+                <span class="text-sm font-medium text-muted-color w-32">Initiative</span>
+                <span class="text-sm">{{ initiativeName() }}</span>
+              </div>
+            }
+            @if (commitment()!.notes) {
+              <div class="flex gap-4 py-2 border-b detail-row">
+                <span class="text-sm font-medium text-muted-color w-32">Notes</span>
+                <span class="text-sm whitespace-pre-wrap">{{ commitment()!.notes }}</span>
+              </div>
+            }
+            @if (commitment()!.completedAt) {
+              <div class="flex gap-4 py-2 border-b detail-row">
+                <span class="text-sm font-medium text-muted-color w-32">Completed At</span>
+                <span class="text-sm">{{ commitment()!.completedAt | date:'medium' }}</span>
+              </div>
+            }
+            <div class="flex gap-4 py-2 border-b detail-row">
+              <span class="text-sm font-medium text-muted-color w-32">Created</span>
+              <span class="text-sm">{{ commitment()!.createdAt | date:'medium' }}</span>
+            </div>
+            <div class="flex gap-4 py-2">
+              <span class="text-sm font-medium text-muted-color w-32">Updated</span>
+              <span class="text-sm">{{ commitment()!.updatedAt | date:'medium' }}</span>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <app-commitment-dialog
+        [(visible)]="showEditDialog"
+        [editCommitment]="commitment()!"
+        (updated)="onUpdated($event)"
+      />
+    }
+  `,
+})
+export class CommitmentDetailComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly commitmentsService = inject(CommitmentsService);
+  private readonly peopleService = inject(PeopleService);
+  private readonly initiativesService = inject(InitiativesService);
+  private readonly messageService = inject(MessageService);
+
+  readonly commitment = signal<Commitment | null>(null);
+  readonly loading = signal(true);
+  readonly showEditDialog = signal(false);
+  readonly personName = signal('Loading...');
+  readonly initiativeName = signal('');
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.loadCommitment(id);
+    }
+  }
+
+  protected goBack(): void {
+    this.router.navigate(['/commitments']);
+  }
+
+  protected openEditDialog(): void {
+    this.showEditDialog.set(true);
+  }
+
+  protected onUpdated(updated: Commitment): void {
+    this.commitment.set(updated);
+    this.messageService.add({ severity: 'success', summary: 'Commitment updated' });
+  }
+
+  protected onComplete(): void {
+    const c = this.commitment();
+    if (!c) return;
+    this.commitmentsService.complete(c.id).subscribe({
+      next: (updated) => {
+        this.commitment.set(updated);
+        this.messageService.add({ severity: 'success', summary: 'Commitment completed' });
+      },
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to complete' }),
+    });
+  }
+
+  protected onCancel(): void {
+    const c = this.commitment();
+    if (!c) return;
+    this.commitmentsService.cancel(c.id).subscribe({
+      next: (updated) => {
+        this.commitment.set(updated);
+        this.messageService.add({ severity: 'success', summary: 'Commitment cancelled' });
+      },
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to cancel' }),
+    });
+  }
+
+  protected onReopen(): void {
+    const c = this.commitment();
+    if (!c) return;
+    this.commitmentsService.reopen(c.id).subscribe({
+      next: (updated) => {
+        this.commitment.set(updated);
+        this.messageService.add({ severity: 'success', summary: 'Commitment reopened' });
+      },
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to reopen' }),
+    });
+  }
+
+  protected formatDirection(direction: CommitmentDirection): string {
+    switch (direction) {
+      case 'MineToThem': return 'I owe them';
+      case 'TheirsToMe': return 'They owe me';
+    }
+  }
+
+  protected directionSeverity(direction: CommitmentDirection): 'info' | 'warn' {
+    switch (direction) {
+      case 'MineToThem': return 'warn';
+      case 'TheirsToMe': return 'info';
+    }
+  }
+
+  protected formatStatus(status: CommitmentStatus): string {
+    return status;
+  }
+
+  protected statusSeverity(status: CommitmentStatus): 'info' | 'success' | 'secondary' {
+    switch (status) {
+      case 'Open': return 'info';
+      case 'Completed': return 'success';
+      case 'Cancelled': return 'secondary';
+    }
+  }
+
+  private loadCommitment(id: string): void {
+    this.loading.set(true);
+    this.commitmentsService.get(id).subscribe({
+      next: (commitment) => {
+        this.commitment.set(commitment);
+        this.loadPersonName(commitment.personId);
+        if (commitment.initiativeId) {
+          this.loadInitiativeName(commitment.initiativeId);
+        }
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.router.navigate(['/commitments']);
+      },
+    });
+  }
+
+  private loadPersonName(personId: string): void {
+    this.peopleService.get(personId).subscribe({
+      next: (person) => this.personName.set(person.name),
+      error: () => this.personName.set('Unknown'),
+    });
+  }
+
+  private loadInitiativeName(initiativeId: string): void {
+    this.initiativesService.get(initiativeId).subscribe({
+      next: (initiative) => this.initiativeName.set(initiative.title),
+      error: () => this.initiativeName.set('Unknown'),
+    });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
@@ -74,21 +74,19 @@ import { Initiative } from '../../../shared/models/initiative.model';
           />
         </div>
 
-        @if (!editCommitment()) {
-          <div class="flex flex-col gap-2">
-            <label for="commitmentInitiative" class="text-sm font-medium text-muted-color">Initiative (optional)</label>
-            <p-select
-              id="commitmentInitiative"
-              [options]="initiativeOptions()"
-              [(ngModel)]="selectedInitiativeId"
-              placeholder="Select initiative"
-              [filter]="true"
-              filterBy="label"
-              [showClear]="true"
-              class="w-full"
-            />
-          </div>
-        }
+        <div class="flex flex-col gap-2">
+          <label for="commitmentInitiative" class="text-sm font-medium text-muted-color">Initiative (optional)</label>
+          <p-select
+            id="commitmentInitiative"
+            [options]="initiativeOptions()"
+            [(ngModel)]="selectedInitiativeId"
+            placeholder="Select initiative"
+            [filter]="true"
+            filterBy="label"
+            [showClear]="true"
+            class="w-full"
+          />
+        </div>
 
         <div class="flex flex-col gap-2">
           <label for="commitmentNotes" class="text-sm font-medium text-muted-color">Notes (optional)</label>
@@ -146,6 +144,7 @@ export class CommitmentDialogComponent implements OnInit {
         this.description = edit.description;
         this.notes = edit.notes ?? '';
         this.dueDate = edit.dueDate ? new Date(edit.dueDate + 'T00:00:00') : null;
+        this.selectedInitiativeId = edit.initiativeId;
       }
     });
   }
@@ -176,28 +175,36 @@ export class CommitmentDialogComponent implements OnInit {
         description: this.description.trim(),
         notes: this.notes.trim() || null,
       }).subscribe({
-        next: (commitment) => {
-          // Also update due date if it changed
-          const newDueDateStr = this.dueDate
-            ? `${this.dueDate.getFullYear()}-${String(this.dueDate.getMonth() + 1).padStart(2, '0')}-${String(this.dueDate.getDate()).padStart(2, '0')}`
-            : null;
-          if (newDueDateStr !== edit.dueDate) {
+        next: (latest) => {
+          // Chain due date update if changed
+          const newDueDateStr = this.formatDateStr(this.dueDate);
+          const dueDateChanged = newDueDateStr !== edit.dueDate;
+          const initiativeChanged = this.selectedInitiativeId !== edit.initiativeId && this.selectedInitiativeId;
+
+          const afterDueDate = (current: Commitment) => {
+            if (initiativeChanged) {
+              this.commitmentsService.linkInitiative(edit.id, this.selectedInitiativeId!).subscribe({
+                next: (updated) => this.finishEdit(updated),
+                error: () => {
+                  this.messageService.add({ severity: 'error', summary: 'Failed to link initiative' });
+                  this.finishEdit(current);
+                },
+              });
+            } else {
+              this.finishEdit(current);
+            }
+          };
+
+          if (dueDateChanged) {
             this.commitmentsService.updateDueDate(edit.id, { dueDate: newDueDateStr }).subscribe({
-              next: (updated) => {
-                this.submitting.set(false);
-                this.updated.emit(updated);
-                this.visible.set(false);
-              },
+              next: (updated) => afterDueDate(updated),
               error: () => {
-                this.submitting.set(false);
-                this.updated.emit(commitment);
-                this.visible.set(false);
+                this.messageService.add({ severity: 'error', summary: 'Failed to update due date' });
+                afterDueDate(latest);
               },
             });
           } else {
-            this.submitting.set(false);
-            this.updated.emit(commitment);
-            this.visible.set(false);
+            afterDueDate(latest);
           }
         },
         error: () => {
@@ -206,9 +213,7 @@ export class CommitmentDialogComponent implements OnInit {
         },
       });
     } else {
-      const dueDateStr = this.dueDate
-        ? `${this.dueDate.getFullYear()}-${String(this.dueDate.getMonth() + 1).padStart(2, '0')}-${String(this.dueDate.getDate()).padStart(2, '0')}`
-        : undefined;
+      const dueDateStr = this.formatDateStr(this.dueDate) ?? undefined;
 
       this.commitmentsService.create({
         description: this.description.trim(),
@@ -230,6 +235,17 @@ export class CommitmentDialogComponent implements OnInit {
         },
       });
     }
+  }
+
+  private finishEdit(commitment: Commitment): void {
+    this.submitting.set(false);
+    this.updated.emit(commitment);
+    this.visible.set(false);
+  }
+
+  private formatDateStr(date: Date | null): string | null {
+    if (!date) return null;
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
   }
 
   private resetForm(): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, model, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, model, OnInit, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { DatePickerModule } from 'primeng/datepicker';
@@ -138,6 +138,18 @@ export class CommitmentDialogComponent implements OnInit {
     { label: 'They owe me', value: 'TheirsToMe' as CommitmentDirection },
   ];
 
+  constructor() {
+    // Populate form fields when edit commitment changes
+    effect(() => {
+      const edit = this.editCommitment();
+      if (edit && this.visible()) {
+        this.description = edit.description;
+        this.notes = edit.notes ?? '';
+        this.dueDate = edit.dueDate ? new Date(edit.dueDate + 'T00:00:00') : null;
+      }
+    });
+  }
+
   ngOnInit(): void {
     this.loadPeople();
     this.loadInitiatives();
@@ -159,14 +171,34 @@ export class CommitmentDialogComponent implements OnInit {
 
     const edit = this.editCommitment();
     if (edit) {
+      // Update description and notes
       this.commitmentsService.update(edit.id, {
         description: this.description.trim(),
         notes: this.notes.trim() || null,
       }).subscribe({
         next: (commitment) => {
-          this.submitting.set(false);
-          this.updated.emit(commitment);
-          this.visible.set(false);
+          // Also update due date if it changed
+          const newDueDateStr = this.dueDate
+            ? `${this.dueDate.getFullYear()}-${String(this.dueDate.getMonth() + 1).padStart(2, '0')}-${String(this.dueDate.getDate()).padStart(2, '0')}`
+            : null;
+          if (newDueDateStr !== edit.dueDate) {
+            this.commitmentsService.updateDueDate(edit.id, { dueDate: newDueDateStr }).subscribe({
+              next: (updated) => {
+                this.submitting.set(false);
+                this.updated.emit(updated);
+                this.visible.set(false);
+              },
+              error: () => {
+                this.submitting.set(false);
+                this.updated.emit(commitment);
+                this.visible.set(false);
+              },
+            });
+          } else {
+            this.submitting.set(false);
+            this.updated.emit(commitment);
+            this.visible.set(false);
+          }
         },
         error: () => {
           this.submitting.set(false);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-dialog/commitment-dialog.component.ts
@@ -1,0 +1,233 @@
+import { ChangeDetectionStrategy, Component, inject, model, OnInit, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { DatePickerModule } from 'primeng/datepicker';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { SelectModule } from 'primeng/select';
+import { TextareaModule } from 'primeng/textarea';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { CommitmentsService } from '../../../shared/services/commitments.service';
+import { Commitment, CommitmentDirection } from '../../../shared/models/commitment.model';
+import { PeopleService } from '../../../shared/services/people.service';
+import { InitiativesService } from '../../../shared/services/initiatives.service';
+import { Person } from '../../../shared/models/person.model';
+import { Initiative } from '../../../shared/models/initiative.model';
+
+@Component({
+  selector: 'app-commitment-dialog',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, ButtonModule, DatePickerModule, DialogModule, InputTextModule, SelectModule, TextareaModule, ToastModule],
+  providers: [MessageService],
+  template: `
+    <p-toast />
+    <p-dialog
+      [header]="editCommitment() ? 'Edit Commitment' : 'New Commitment'"
+      [visible]="visible()"
+      (visibleChange)="visible.set($event)"
+      [modal]="true"
+      [style]="{ width: '36rem' }"
+    >
+      <div class="flex flex-col gap-4 pt-4">
+        <div class="flex flex-col gap-2">
+          <label for="commitmentDesc" class="text-sm font-medium text-muted-color">Description *</label>
+          <textarea pTextarea id="commitmentDesc" [(ngModel)]="description" [rows]="3" class="w-full" placeholder="What is the commitment?"></textarea>
+        </div>
+
+        @if (!editCommitment()) {
+          <div class="flex flex-col gap-2">
+            <label for="commitmentDirection" class="text-sm font-medium text-muted-color">Direction *</label>
+            <p-select
+              id="commitmentDirection"
+              [options]="directionOptions"
+              [(ngModel)]="selectedDirection"
+              placeholder="Select direction"
+              class="w-full"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label for="commitmentPerson" class="text-sm font-medium text-muted-color">Person *</label>
+            <p-select
+              id="commitmentPerson"
+              [options]="personOptions()"
+              [(ngModel)]="selectedPersonId"
+              placeholder="Select person"
+              [filter]="true"
+              filterBy="label"
+              class="w-full"
+            />
+          </div>
+        }
+
+        <div class="flex flex-col gap-2">
+          <label for="commitmentDueDate" class="text-sm font-medium text-muted-color">Due Date (optional)</label>
+          <p-datepicker
+            id="commitmentDueDate"
+            [(ngModel)]="dueDate"
+            [showIcon]="true"
+            dateFormat="yy-mm-dd"
+            placeholder="Select due date"
+            class="w-full"
+          />
+        </div>
+
+        @if (!editCommitment()) {
+          <div class="flex flex-col gap-2">
+            <label for="commitmentInitiative" class="text-sm font-medium text-muted-color">Initiative (optional)</label>
+            <p-select
+              id="commitmentInitiative"
+              [options]="initiativeOptions()"
+              [(ngModel)]="selectedInitiativeId"
+              placeholder="Select initiative"
+              [filter]="true"
+              filterBy="label"
+              [showClear]="true"
+              class="w-full"
+            />
+          </div>
+        }
+
+        <div class="flex flex-col gap-2">
+          <label for="commitmentNotes" class="text-sm font-medium text-muted-color">Notes (optional)</label>
+          <textarea pTextarea id="commitmentNotes" [(ngModel)]="notes" [rows]="2" class="w-full" placeholder="Any additional context..."></textarea>
+        </div>
+      </div>
+
+      <ng-template #footer>
+        <div class="flex justify-end gap-2">
+          <p-button label="Cancel" severity="secondary" (onClick)="visible.set(false)" />
+          <p-button
+            [label]="editCommitment() ? 'Save' : 'Create'"
+            icon="pi pi-check"
+            (onClick)="onSubmit()"
+            [loading]="submitting()"
+            [disabled]="!isValid()"
+          />
+        </div>
+      </ng-template>
+    </p-dialog>
+  `,
+})
+export class CommitmentDialogComponent implements OnInit {
+  private readonly commitmentsService = inject(CommitmentsService);
+  private readonly peopleService = inject(PeopleService);
+  private readonly initiativesService = inject(InitiativesService);
+  private readonly messageService = inject(MessageService);
+
+  readonly visible = model(false);
+  readonly editCommitment = model<Commitment | null>(null);
+  readonly created = output<Commitment>();
+  readonly updated = output<Commitment>();
+
+  protected readonly submitting = signal(false);
+  protected readonly personOptions = signal<{ label: string; value: string }[]>([]);
+  protected readonly initiativeOptions = signal<{ label: string; value: string }[]>([]);
+
+  protected description = '';
+  protected selectedDirection: CommitmentDirection | null = null;
+  protected selectedPersonId: string | null = null;
+  protected selectedInitiativeId: string | null = null;
+  protected dueDate: Date | null = null;
+  protected notes = '';
+
+  protected readonly directionOptions = [
+    { label: 'I owe them', value: 'MineToThem' as CommitmentDirection },
+    { label: 'They owe me', value: 'TheirsToMe' as CommitmentDirection },
+  ];
+
+  ngOnInit(): void {
+    this.loadPeople();
+    this.loadInitiatives();
+  }
+
+  protected isValid(): boolean {
+    if (this.editCommitment()) {
+      return this.description.trim().length > 0;
+    }
+    return this.description.trim().length > 0
+      && this.selectedDirection !== null
+      && this.selectedPersonId !== null;
+  }
+
+  protected onSubmit(): void {
+    if (!this.isValid()) return;
+
+    this.submitting.set(true);
+
+    const edit = this.editCommitment();
+    if (edit) {
+      this.commitmentsService.update(edit.id, {
+        description: this.description.trim(),
+        notes: this.notes.trim() || null,
+      }).subscribe({
+        next: (commitment) => {
+          this.submitting.set(false);
+          this.updated.emit(commitment);
+          this.visible.set(false);
+        },
+        error: () => {
+          this.submitting.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Failed to update commitment' });
+        },
+      });
+    } else {
+      const dueDateStr = this.dueDate
+        ? `${this.dueDate.getFullYear()}-${String(this.dueDate.getMonth() + 1).padStart(2, '0')}-${String(this.dueDate.getDate()).padStart(2, '0')}`
+        : undefined;
+
+      this.commitmentsService.create({
+        description: this.description.trim(),
+        direction: this.selectedDirection!,
+        personId: this.selectedPersonId!,
+        ...(dueDateStr && { dueDate: dueDateStr }),
+        ...(this.selectedInitiativeId && { initiativeId: this.selectedInitiativeId }),
+        ...(this.notes.trim() && { notes: this.notes.trim() }),
+      }).subscribe({
+        next: (commitment) => {
+          this.submitting.set(false);
+          this.created.emit(commitment);
+          this.resetForm();
+          this.visible.set(false);
+        },
+        error: () => {
+          this.submitting.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Failed to create commitment' });
+        },
+      });
+    }
+  }
+
+  private resetForm(): void {
+    this.description = '';
+    this.selectedDirection = null;
+    this.selectedPersonId = null;
+    this.selectedInitiativeId = null;
+    this.dueDate = null;
+    this.notes = '';
+  }
+
+  private loadPeople(): void {
+    this.peopleService.list().subscribe({
+      next: (people: Person[]) => {
+        this.personOptions.set(
+          people
+            .filter(p => !p.isArchived)
+            .map(p => ({ label: p.name, value: p.id })),
+        );
+      },
+    });
+  }
+
+  private loadInitiatives(): void {
+    this.initiativesService.list().subscribe({
+      next: (initiatives: Initiative[]) => {
+        this.initiativeOptions.set(
+          initiatives.map(i => ({ label: i.title, value: i.id })),
+        );
+      },
+    });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
@@ -7,6 +7,7 @@ import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
 import { MessageService } from 'primeng/api';
 import { CommitmentsService } from '../../../shared/services/commitments.service';
 import { Commitment, CommitmentDirection, CommitmentStatus } from '../../../shared/models/commitment.model';
@@ -18,9 +19,10 @@ import { CommitmentDialogComponent } from '../commitment-dialog/commitment-dialo
   selector: 'app-commitments-list',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ToastModule, CommitmentDialogComponent],
+  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ToastModule, TooltipModule, CommitmentDialogComponent],
   providers: [MessageService],
   template: `
+    <p-toast />
     <div class="flex flex-col gap-6">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-bold">Commitments</h1>

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
@@ -1,0 +1,252 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { SelectModule } from 'primeng/select';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { CommitmentsService } from '../../../shared/services/commitments.service';
+import { Commitment, CommitmentDirection, CommitmentStatus } from '../../../shared/models/commitment.model';
+import { PeopleService } from '../../../shared/services/people.service';
+import { Person } from '../../../shared/models/person.model';
+import { CommitmentDialogComponent } from '../commitment-dialog/commitment-dialog.component';
+
+@Component({
+  selector: 'app-commitments-list',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ToastModule, CommitmentDialogComponent],
+  providers: [MessageService],
+  template: `
+    <div class="flex flex-col gap-6">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold">Commitments</h1>
+        <p-button label="New Commitment" icon="pi pi-plus" (onClick)="showCreateDialog.set(true)" />
+      </div>
+
+      <div class="flex items-center gap-4 flex-wrap">
+        <p-select
+          [options]="directionFilterOptions"
+          [(ngModel)]="selectedDirection"
+          (ngModelChange)="onFilterChange()"
+          placeholder="All Directions"
+          [showClear]="true"
+          class="w-48"
+        />
+        <p-select
+          [options]="statusFilterOptions"
+          [(ngModel)]="selectedStatus"
+          (ngModelChange)="onFilterChange()"
+          placeholder="All Statuses"
+          [showClear]="true"
+          class="w-48"
+        />
+        <p-select
+          [options]="overdueFilterOptions"
+          [(ngModel)]="selectedOverdue"
+          (ngModelChange)="onFilterChange()"
+          placeholder="All"
+          [showClear]="true"
+          class="w-48"
+        />
+      </div>
+
+      @if (loading()) {
+        <div class="flex justify-center p-8">
+          <i class="pi pi-spinner pi-spin text-2xl"></i>
+        </div>
+      } @else if (commitments().length === 0) {
+        <div class="flex flex-col items-center gap-4 p-12">
+          <i class="pi pi-check-square text-4xl text-muted-color"></i>
+          <p class="text-muted-color">No commitments found. Create your first commitment to start tracking promises.</p>
+        </div>
+      } @else {
+        <p-table
+          [value]="commitments()"
+          [rows]="20"
+          [paginator]="commitments().length > 20"
+          [rowHover]="true"
+          styleClass="p-datatable-sm"
+        >
+          <ng-template #header>
+            <tr>
+              <th>Direction</th>
+              <th>Description</th>
+              <th>Person</th>
+              <th>Status</th>
+              <th>Due Date</th>
+              <th>Actions</th>
+            </tr>
+          </ng-template>
+          <ng-template #body let-commitment>
+            <tr class="cursor-pointer" (click)="onRowClick(commitment)">
+              <td>
+                <p-tag [value]="formatDirection(commitment.direction)" [severity]="directionSeverity(commitment.direction)" />
+              </td>
+              <td class="font-medium">
+                {{ commitment.description.length > 60 ? commitment.description.substring(0, 60) + '...' : commitment.description }}
+              </td>
+              <td class="text-muted-color text-sm">{{ personName(commitment.personId) }}</td>
+              <td>
+                <p-tag [value]="formatStatus(commitment.status)" [severity]="statusSeverity(commitment.status)" />
+                @if (commitment.isOverdue) {
+                  <p-tag value="Overdue" severity="danger" class="ml-1" />
+                }
+              </td>
+              <td class="text-muted-color text-sm">
+                @if (commitment.dueDate) {
+                  {{ commitment.dueDate }}
+                } @else {
+                  -
+                }
+              </td>
+              <td>
+                <div class="flex gap-1" (click)="$event.stopPropagation()">
+                  @if (commitment.status === 'Open') {
+                    <p-button icon="pi pi-check" severity="success" [text]="true" size="small" pTooltip="Complete" (onClick)="onComplete(commitment)" />
+                    <p-button icon="pi pi-times" severity="danger" [text]="true" size="small" pTooltip="Cancel" (onClick)="onCancel(commitment)" />
+                  } @else {
+                    <p-button icon="pi pi-replay" severity="info" [text]="true" size="small" pTooltip="Reopen" (onClick)="onReopen(commitment)" />
+                  }
+                </div>
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+      }
+
+      <app-commitment-dialog
+        [(visible)]="showCreateDialog"
+        (created)="onCommitmentCreated($event)"
+      />
+    </div>
+  `,
+})
+export class CommitmentsListComponent implements OnInit {
+  private readonly commitmentsService = inject(CommitmentsService);
+  private readonly peopleService = inject(PeopleService);
+  private readonly messageService = inject(MessageService);
+  private readonly router = inject(Router);
+
+  readonly commitments = signal<Commitment[]>([]);
+  readonly loading = signal(true);
+  readonly showCreateDialog = signal(false);
+  private readonly peopleMap = signal<Map<string, string>>(new Map());
+
+  protected selectedDirection: CommitmentDirection | null = null;
+  protected selectedStatus: CommitmentStatus | null = null;
+  protected selectedOverdue: boolean | null = null;
+
+  protected readonly directionFilterOptions = [
+    { label: 'I owe them', value: 'MineToThem' as CommitmentDirection },
+    { label: 'They owe me', value: 'TheirsToMe' as CommitmentDirection },
+  ];
+
+  protected readonly statusFilterOptions = [
+    { label: 'Open', value: 'Open' as CommitmentStatus },
+    { label: 'Completed', value: 'Completed' as CommitmentStatus },
+    { label: 'Cancelled', value: 'Cancelled' as CommitmentStatus },
+  ];
+
+  protected readonly overdueFilterOptions = [
+    { label: 'Overdue only', value: true },
+  ];
+
+  ngOnInit(): void {
+    this.loadPeople();
+    this.loadCommitments();
+  }
+
+  protected onFilterChange(): void {
+    this.loadCommitments();
+  }
+
+  protected onRowClick(commitment: Commitment): void {
+    this.router.navigate(['/commitments', commitment.id]);
+  }
+
+  protected onCommitmentCreated(_commitment: Commitment): void {
+    this.loadCommitments();
+  }
+
+  protected personName(personId: string): string {
+    return this.peopleMap().get(personId) ?? 'Unknown';
+  }
+
+  protected formatDirection(direction: CommitmentDirection): string {
+    switch (direction) {
+      case 'MineToThem': return 'I owe them';
+      case 'TheirsToMe': return 'They owe me';
+    }
+  }
+
+  protected directionSeverity(direction: CommitmentDirection): 'info' | 'warn' {
+    switch (direction) {
+      case 'MineToThem': return 'warn';
+      case 'TheirsToMe': return 'info';
+    }
+  }
+
+  protected formatStatus(status: CommitmentStatus): string {
+    return status;
+  }
+
+  protected statusSeverity(status: CommitmentStatus): 'info' | 'success' | 'secondary' {
+    switch (status) {
+      case 'Open': return 'info';
+      case 'Completed': return 'success';
+      case 'Cancelled': return 'secondary';
+    }
+  }
+
+  protected onComplete(commitment: Commitment): void {
+    this.commitmentsService.complete(commitment.id).subscribe({
+      next: () => this.loadCommitments(),
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to complete commitment' }),
+    });
+  }
+
+  protected onCancel(commitment: Commitment): void {
+    this.commitmentsService.cancel(commitment.id).subscribe({
+      next: () => this.loadCommitments(),
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to cancel commitment' }),
+    });
+  }
+
+  protected onReopen(commitment: Commitment): void {
+    this.commitmentsService.reopen(commitment.id).subscribe({
+      next: () => this.loadCommitments(),
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to reopen commitment' }),
+    });
+  }
+
+  private loadCommitments(): void {
+    this.loading.set(true);
+    this.commitmentsService.list(
+      this.selectedDirection ?? undefined,
+      this.selectedStatus ?? undefined,
+      undefined,
+      undefined,
+      this.selectedOverdue ?? undefined,
+    ).subscribe({
+      next: (commitments) => {
+        this.commitments.set(commitments);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  private loadPeople(): void {
+    this.peopleService.list(undefined, true).subscribe({
+      next: (people: Person[]) => {
+        const map = new Map<string, string>();
+        people.forEach(p => map.set(p.id, p.name));
+        this.peopleMap.set(map);
+      },
+    });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DatePipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
@@ -19,7 +18,7 @@ import { CommitmentDialogComponent } from '../commitment-dialog/commitment-dialo
   selector: 'app-commitments-list',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ToastModule, TooltipModule, CommitmentDialogComponent],
+  imports: [FormsModule, ButtonModule, SelectModule, TableModule, TagModule, ToastModule, TooltipModule, CommitmentDialogComponent],
   providers: [MessageService],
   template: `
     <p-toast />

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -68,6 +68,12 @@ import { ThemeService } from '../services/theme.service';
         <i class="pi pi-flag"></i>
         <span>Initiatives</span>
       </a>
+      <a routerLink="/commitments" routerLinkActive="font-semibold sidebar-link-active"
+         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
+         (click)="navClick.emit()">
+        <i class="pi pi-check-square"></i>
+        <span>Commitments</span>
+      </a>
       <a routerLink="/queue" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
          (click)="navClick.emit()">

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/commitment.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/commitment.model.ts
@@ -1,0 +1,51 @@
+export type CommitmentDirection = 'MineToThem' | 'TheirsToMe';
+
+export type CommitmentStatus = 'Open' | 'Completed' | 'Cancelled';
+
+export interface Commitment {
+  id: string;
+  userId: string;
+  description: string;
+  direction: CommitmentDirection;
+  personId: string;
+  initiativeId: string | null;
+  sourceCaptureId: string | null;
+  dueDate: string | null;
+  status: CommitmentStatus;
+  completedAt: string | null;
+  notes: string | null;
+  isOverdue: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCommitmentRequest {
+  description: string;
+  direction: CommitmentDirection;
+  personId: string;
+  dueDate?: string;
+  initiativeId?: string;
+  sourceCaptureId?: string;
+  notes?: string;
+}
+
+export interface UpdateCommitmentRequest {
+  description: string;
+  notes: string | null;
+}
+
+export interface CompleteCommitmentRequest {
+  notes?: string;
+}
+
+export interface CancelCommitmentRequest {
+  reason?: string;
+}
+
+export interface UpdateDueDateRequest {
+  dueDate: string | null;
+}
+
+export interface LinkInitiativeRequest {
+  initiativeId: string;
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/commitments.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/commitments.service.ts
@@ -1,0 +1,77 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  CancelCommitmentRequest,
+  Commitment,
+  CommitmentDirection,
+  CommitmentStatus,
+  CompleteCommitmentRequest,
+  CreateCommitmentRequest,
+  UpdateCommitmentRequest,
+  UpdateDueDateRequest,
+} from '../models/commitment.model';
+
+@Injectable({ providedIn: 'root' })
+export class CommitmentsService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/commitments';
+
+  list(
+    direction?: CommitmentDirection,
+    status?: CommitmentStatus,
+    personId?: string,
+    initiativeId?: string,
+    overdue?: boolean,
+  ): Observable<Commitment[]> {
+    let params = new HttpParams();
+    if (direction) {
+      params = params.set('direction', direction);
+    }
+    if (status) {
+      params = params.set('status', status);
+    }
+    if (personId) {
+      params = params.set('personId', personId);
+    }
+    if (initiativeId) {
+      params = params.set('initiativeId', initiativeId);
+    }
+    if (overdue !== undefined) {
+      params = params.set('overdue', overdue.toString());
+    }
+    return this.http.get<Commitment[]>(this.baseUrl, { params });
+  }
+
+  get(id: string): Observable<Commitment> {
+    return this.http.get<Commitment>(`${this.baseUrl}/${id}`);
+  }
+
+  create(request: CreateCommitmentRequest): Observable<Commitment> {
+    return this.http.post<Commitment>(this.baseUrl, request);
+  }
+
+  update(id: string, request: UpdateCommitmentRequest): Observable<Commitment> {
+    return this.http.put<Commitment>(`${this.baseUrl}/${id}`, request);
+  }
+
+  complete(id: string, request?: CompleteCommitmentRequest): Observable<Commitment> {
+    return this.http.post<Commitment>(`${this.baseUrl}/${id}/complete`, request ?? {});
+  }
+
+  cancel(id: string, request?: CancelCommitmentRequest): Observable<Commitment> {
+    return this.http.post<Commitment>(`${this.baseUrl}/${id}/cancel`, request ?? {});
+  }
+
+  reopen(id: string): Observable<Commitment> {
+    return this.http.post<Commitment>(`${this.baseUrl}/${id}/reopen`, {});
+  }
+
+  updateDueDate(id: string, request: UpdateDueDateRequest): Observable<Commitment> {
+    return this.http.put<Commitment>(`${this.baseUrl}/${id}/due-date`, request);
+  }
+
+  linkInitiative(id: string, initiativeId: string): Observable<Commitment> {
+    return this.http.post<Commitment>(`${this.baseUrl}/${id}/link-initiative`, { initiativeId });
+  }
+}

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -732,7 +732,7 @@ app.MapPost("/api/captures/{id:guid}/link-person", async (
 
 app.MapPost("/api/captures/{id:guid}/link-initiative", async (
     Guid id,
-    MentalMetal.Application.Captures.LinkInitiativeRequest request,
+    LinkInitiativeRequest request,
     LinkCaptureToInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {
@@ -766,7 +766,7 @@ app.MapPost("/api/captures/{id:guid}/unlink-person", async (
 
 app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
     Guid id,
-    MentalMetal.Application.Captures.LinkInitiativeRequest request,
+    LinkInitiativeRequest request,
     UnlinkCaptureFromInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {
@@ -923,7 +923,7 @@ app.MapPut("/api/commitments/{id:guid}/due-date", async (
 
 app.MapPost("/api/commitments/{id:guid}/link-initiative", async (
     Guid id,
-    MentalMetal.Application.Commitments.LinkInitiativeRequest request,
+    LinkCommitmentToInitiativeRequest request,
     LinkCommitmentToInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -732,7 +732,7 @@ app.MapPost("/api/captures/{id:guid}/link-person", async (
 
 app.MapPost("/api/captures/{id:guid}/link-initiative", async (
     Guid id,
-    LinkInitiativeRequest request,
+    MentalMetal.Application.Captures.LinkInitiativeRequest request,
     LinkCaptureToInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {
@@ -766,7 +766,7 @@ app.MapPost("/api/captures/{id:guid}/unlink-person", async (
 
 app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
     Guid id,
-    LinkInitiativeRequest request,
+    MentalMetal.Application.Captures.LinkInitiativeRequest request,
     UnlinkCaptureFromInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -2,11 +2,13 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Json.Serialization;
 using MentalMetal.Application.Captures;
+using MentalMetal.Application.Commitments;
 using MentalMetal.Application.Common.Ai;
 using MentalMetal.Application.Initiatives;
 using MentalMetal.Application.People;
 using MentalMetal.Application.Users;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.People;
 using MentalMetal.Infrastructure;
@@ -766,6 +768,163 @@ app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
     Guid id,
     LinkInitiativeRequest request,
     UnlinkCaptureFromInitiativeHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+}).RequireAuthorization();
+
+// --- Commitment Endpoints ---
+
+app.MapPost("/api/commitments", async (
+    CreateCommitmentRequest request,
+    CreateCommitmentHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(request, cancellationToken);
+        return Results.Created($"/api/commitments/{response.Id}", response);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapGet("/api/commitments", async (
+    CommitmentDirection? direction,
+    CommitmentStatus? status,
+    Guid? personId,
+    Guid? initiativeId,
+    bool? overdue,
+    GetUserCommitmentsHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var list = await handler.HandleAsync(direction, status, personId, initiativeId, overdue, cancellationToken);
+    return Results.Ok(list);
+}).RequireAuthorization();
+
+app.MapGet("/api/commitments/{id:guid}", async (
+    Guid id,
+    GetCommitmentByIdHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var response = await handler.HandleAsync(id, cancellationToken);
+    return response is not null ? Results.Ok(response) : Results.NotFound();
+}).RequireAuthorization();
+
+app.MapPut("/api/commitments/{id:guid}", async (
+    Guid id,
+    UpdateCommitmentRequest request,
+    UpdateCommitmentHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/commitments/{id:guid}/complete", async (
+    Guid id,
+    CompleteCommitmentRequest request,
+    CompleteCommitmentHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/commitments/{id:guid}/cancel", async (
+    Guid id,
+    CancelCommitmentRequest request,
+    CancelCommitmentHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/commitments/{id:guid}/reopen", async (
+    Guid id,
+    ReopenCommitmentHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPut("/api/commitments/{id:guid}/due-date", async (
+    Guid id,
+    UpdateDueDateRequest request,
+    UpdateCommitmentDueDateHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/commitments/{id:guid}/link-initiative", async (
+    Guid id,
+    MentalMetal.Application.Commitments.LinkInitiativeRequest request,
+    LinkCommitmentToInitiativeHandler handler,
     CancellationToken cancellationToken) =>
 {
     try

--- a/tests/MentalMetal.Domain.Tests/Commitments/CommitmentTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Commitments/CommitmentTests.cs
@@ -1,0 +1,382 @@
+using MentalMetal.Domain.Commitments;
+
+namespace MentalMetal.Domain.Tests.Commitments;
+
+public class CommitmentTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid PersonId = Guid.NewGuid();
+
+    // 2.1 Test Commitment creation with valid inputs and domain event
+    [Fact]
+    public void Create_ValidInputs_CreatesCommitmentWithCorrectState()
+    {
+        var commitment = Commitment.Create(UserId, "Send Q3 roadmap draft", CommitmentDirection.MineToThem, PersonId);
+
+        Assert.NotEqual(Guid.Empty, commitment.Id);
+        Assert.Equal(UserId, commitment.UserId);
+        Assert.Equal("Send Q3 roadmap draft", commitment.Description);
+        Assert.Equal(CommitmentDirection.MineToThem, commitment.Direction);
+        Assert.Equal(PersonId, commitment.PersonId);
+        Assert.Equal(CommitmentStatus.Open, commitment.Status);
+        Assert.Null(commitment.InitiativeId);
+        Assert.Null(commitment.SourceCaptureId);
+        Assert.Null(commitment.DueDate);
+        Assert.Null(commitment.CompletedAt);
+        Assert.Null(commitment.Notes);
+
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        var created = Assert.IsType<CommitmentCreated>(domainEvent);
+        Assert.Equal(commitment.Id, created.CommitmentId);
+        Assert.Equal(UserId, created.UserId);
+        Assert.Equal(CommitmentDirection.MineToThem, created.Direction);
+        Assert.Equal(PersonId, created.PersonId);
+    }
+
+    [Fact]
+    public void Create_WithOptionalFields_SetsAllFields()
+    {
+        var initiativeId = Guid.NewGuid();
+        var captureId = Guid.NewGuid();
+        var dueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7));
+
+        var commitment = Commitment.Create(
+            UserId, "Deliver design doc", CommitmentDirection.TheirsToMe, PersonId,
+            dueDate, initiativeId, captureId);
+
+        Assert.Equal(CommitmentDirection.TheirsToMe, commitment.Direction);
+        Assert.Equal(dueDate, commitment.DueDate);
+        Assert.Equal(initiativeId, commitment.InitiativeId);
+        Assert.Equal(captureId, commitment.SourceCaptureId);
+    }
+
+    // 2.2 Test creation rejects empty description and missing personId
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Create_EmptyDescription_Throws(string? description)
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            Commitment.Create(UserId, description!, CommitmentDirection.MineToThem, PersonId));
+    }
+
+    [Fact]
+    public void Create_EmptyPersonId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, Guid.Empty));
+    }
+
+    // 2.3 Test status transitions: Open->Completed, Open->Cancelled, Completed->Open, Cancelled->Open
+    [Fact]
+    public void Complete_FromOpen_TransitionsToCompleted()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.ClearDomainEvents();
+
+        commitment.Complete();
+
+        Assert.Equal(CommitmentStatus.Completed, commitment.Status);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentCompleted>(domainEvent);
+    }
+
+    [Fact]
+    public void Cancel_FromOpen_TransitionsToCancelled()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.ClearDomainEvents();
+
+        commitment.Cancel();
+
+        Assert.Equal(CommitmentStatus.Cancelled, commitment.Status);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentCancelled>(domainEvent);
+    }
+
+    [Fact]
+    public void Reopen_FromCompleted_TransitionsToOpen()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Complete();
+        commitment.ClearDomainEvents();
+
+        commitment.Reopen();
+
+        Assert.Equal(CommitmentStatus.Open, commitment.Status);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentReopened>(domainEvent);
+    }
+
+    [Fact]
+    public void Reopen_FromCancelled_TransitionsToOpen()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Cancel();
+        commitment.ClearDomainEvents();
+
+        commitment.Reopen();
+
+        Assert.Equal(CommitmentStatus.Open, commitment.Status);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentReopened>(domainEvent);
+    }
+
+    // 2.4 Test invalid status transitions throw domain exception
+    [Fact]
+    public void Complete_FromCompleted_Throws()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Complete();
+
+        Assert.Throws<InvalidOperationException>(() => commitment.Complete());
+    }
+
+    [Fact]
+    public void Complete_FromCancelled_Throws()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Cancel();
+
+        Assert.Throws<InvalidOperationException>(() => commitment.Complete());
+    }
+
+    [Fact]
+    public void Cancel_FromCancelled_Throws()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Cancel();
+
+        Assert.Throws<InvalidOperationException>(() => commitment.Cancel());
+    }
+
+    [Fact]
+    public void Cancel_FromCompleted_Throws()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Complete();
+
+        Assert.Throws<InvalidOperationException>(() => commitment.Cancel());
+    }
+
+    [Fact]
+    public void Reopen_FromOpen_Throws()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        Assert.Throws<InvalidOperationException>(() => commitment.Reopen());
+    }
+
+    // 2.5 Test CompletedAt is set on completion and cleared on reopen
+    [Fact]
+    public void Complete_SetsCompletedAt()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        commitment.Complete();
+
+        Assert.NotNull(commitment.CompletedAt);
+    }
+
+    [Fact]
+    public void Reopen_ClearsCompletedAt()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.Complete();
+        Assert.NotNull(commitment.CompletedAt);
+
+        commitment.Reopen();
+
+        Assert.Null(commitment.CompletedAt);
+    }
+
+    // 2.6 Test IsOverdue computation for all status/date combinations
+    [Fact]
+    public void IsOverdue_OpenWithPastDueDate_ReturnsTrue()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)));
+
+        Assert.True(commitment.IsOverdue);
+    }
+
+    [Fact]
+    public void IsOverdue_OpenWithFutureDueDate_ReturnsFalse()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)));
+
+        Assert.False(commitment.IsOverdue);
+    }
+
+    [Fact]
+    public void IsOverdue_OpenWithNoDueDate_ReturnsFalse()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        Assert.False(commitment.IsOverdue);
+    }
+
+    [Fact]
+    public void IsOverdue_CompletedWithPastDueDate_ReturnsFalse()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)));
+        commitment.Complete();
+
+        Assert.False(commitment.IsOverdue);
+    }
+
+    [Fact]
+    public void IsOverdue_CancelledWithPastDueDate_ReturnsFalse()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)));
+        commitment.Cancel();
+
+        Assert.False(commitment.IsOverdue);
+    }
+
+    // 2.7 Test MarkOverdue raises event only when conditions met
+    [Fact]
+    public void MarkOverdue_WhenOverdue_RaisesEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)));
+        commitment.ClearDomainEvents();
+
+        commitment.MarkOverdue();
+
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentBecameOverdue>(domainEvent);
+    }
+
+    [Fact]
+    public void MarkOverdue_WhenNotOverdue_DoesNotRaiseEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)));
+        commitment.ClearDomainEvents();
+
+        commitment.MarkOverdue();
+
+        Assert.Empty(commitment.DomainEvents);
+    }
+
+    [Fact]
+    public void MarkOverdue_WhenCompleted_DoesNotRaiseEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)));
+        commitment.Complete();
+        commitment.ClearDomainEvents();
+
+        commitment.MarkOverdue();
+
+        Assert.Empty(commitment.DomainEvents);
+    }
+
+    // 2.8 Test UpdateDueDate and UpdateDescription
+    [Fact]
+    public void UpdateDueDate_SetsNewDateAndRaisesEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.ClearDomainEvents();
+        var newDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(14));
+
+        commitment.UpdateDueDate(newDate);
+
+        Assert.Equal(newDate, commitment.DueDate);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        var changed = Assert.IsType<CommitmentDueDateChanged>(domainEvent);
+        Assert.Equal(newDate, changed.NewDueDate);
+    }
+
+    [Fact]
+    public void UpdateDueDate_ClearsDateAndRaisesEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)));
+        commitment.ClearDomainEvents();
+
+        commitment.UpdateDueDate(null);
+
+        Assert.Null(commitment.DueDate);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        var changed = Assert.IsType<CommitmentDueDateChanged>(domainEvent);
+        Assert.Null(changed.NewDueDate);
+    }
+
+    [Fact]
+    public void UpdateDescription_SetsNewDescriptionAndRaisesEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Old description", CommitmentDirection.MineToThem, PersonId);
+        commitment.ClearDomainEvents();
+
+        commitment.UpdateDescription("New description");
+
+        Assert.Equal("New description", commitment.Description);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        Assert.IsType<CommitmentDescriptionUpdated>(domainEvent);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void UpdateDescription_EmptyDescription_Throws(string? description)
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        Assert.ThrowsAny<ArgumentException>(() => commitment.UpdateDescription(description!));
+    }
+
+    [Fact]
+    public void LinkToInitiative_SetsInitiativeIdAndRaisesEvent()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+        commitment.ClearDomainEvents();
+        var initiativeId = Guid.NewGuid();
+
+        commitment.LinkToInitiative(initiativeId);
+
+        Assert.Equal(initiativeId, commitment.InitiativeId);
+        var domainEvent = Assert.Single(commitment.DomainEvents);
+        var linked = Assert.IsType<CommitmentLinkedToInitiative>(domainEvent);
+        Assert.Equal(initiativeId, linked.InitiativeId);
+    }
+
+    [Fact]
+    public void LinkToInitiative_SameInitiative_IsIdempotent()
+    {
+        var initiativeId = Guid.NewGuid();
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId,
+            initiativeId: initiativeId);
+        commitment.ClearDomainEvents();
+
+        commitment.LinkToInitiative(initiativeId);
+
+        Assert.Empty(commitment.DomainEvents);
+    }
+
+    [Fact]
+    public void Complete_WithNotes_AppendsNotes()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        commitment.Complete("Delivered in leadership sync");
+
+        Assert.Equal("Delivered in leadership sync", commitment.Notes);
+    }
+
+    [Fact]
+    public void Cancel_WithReason_AppendsReason()
+    {
+        var commitment = Commitment.Create(UserId, "Test", CommitmentDirection.MineToThem, PersonId);
+
+        commitment.Cancel("No longer relevant after reorg");
+
+        Assert.Equal("No longer relevant after reorg", commitment.Notes);
+    }
+}

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/commitments.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/commitments.spec.ts
@@ -1,0 +1,174 @@
+import { test as authTest, API_BASE } from './fixtures/auth.fixture';
+import { expect } from '@playwright/test';
+
+authTest.describe('Commitments', () => {
+  // 8.1 E2E test: create a commitment and verify it appears in the list
+  authTest('Create a commitment and verify it appears in the list', async ({ authenticatedPage, testUser }) => {
+    await authenticatedPage.goto('/dashboard');
+    await expect(authenticatedPage).toHaveURL(/\/dashboard/);
+
+    const token = await authenticatedPage.evaluate(() => localStorage.getItem('access_token'));
+
+    // Create a person first (PersonId is required)
+    const personResponse = await authenticatedPage.request.post(`${API_BASE}/api/people`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { name: 'Sarah Commitment Test', type: 'Stakeholder' },
+    });
+    expect(personResponse.status()).toBe(201);
+    const person = await personResponse.json();
+
+    // Create a commitment
+    const createResponse = await authenticatedPage.request.post(`${API_BASE}/api/commitments`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: {
+        description: 'Send Q3 roadmap draft',
+        direction: 'MineToThem',
+        personId: person.id,
+      },
+    });
+
+    expect(createResponse.status()).toBe(201);
+    const created = await createResponse.json();
+    expect(created.id).toBeTruthy();
+    expect(created.description).toBe('Send Q3 roadmap draft');
+    expect(created.direction).toBe('MineToThem');
+    expect(created.status).toBe('Open');
+    expect(created.personId).toBe(person.id);
+    expect(created.isOverdue).toBe(false);
+
+    // List commitments and verify the new one appears
+    const listResponse = await authenticatedPage.request.get(`${API_BASE}/api/commitments`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(listResponse.ok()).toBeTruthy();
+    const commitments = await listResponse.json();
+    expect(commitments.some((c: { id: string }) => c.id === created.id)).toBeTruthy();
+  });
+
+  // 8.2 E2E test: complete and reopen a commitment
+  authTest('Complete and reopen a commitment', async ({ authenticatedPage, testUser }) => {
+    await authenticatedPage.goto('/dashboard');
+    await expect(authenticatedPage).toHaveURL(/\/dashboard/);
+
+    const token = await authenticatedPage.evaluate(() => localStorage.getItem('access_token'));
+
+    // Create a person
+    const personResponse = await authenticatedPage.request.post(`${API_BASE}/api/people`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { name: 'Bob Commitment Test', type: 'DirectReport' },
+    });
+    expect(personResponse.status()).toBe(201);
+    const person = await personResponse.json();
+
+    // Create a commitment
+    const createResponse = await authenticatedPage.request.post(`${API_BASE}/api/commitments`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: {
+        description: 'Deliver design doc',
+        direction: 'TheirsToMe',
+        personId: person.id,
+        dueDate: '2026-05-01',
+      },
+    });
+    expect(createResponse.status()).toBe(201);
+    const created = await createResponse.json();
+
+    // Complete the commitment
+    const completeResponse = await authenticatedPage.request.post(
+      `${API_BASE}/api/commitments/${created.id}/complete`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { notes: 'Delivered in leadership sync' },
+      },
+    );
+    expect(completeResponse.ok()).toBeTruthy();
+    const completed = await completeResponse.json();
+    expect(completed.status).toBe('Completed');
+    expect(completed.completedAt).toBeTruthy();
+    expect(completed.notes).toContain('Delivered in leadership sync');
+
+    // Verify cannot complete again (409 Conflict)
+    const doubleComplete = await authenticatedPage.request.post(
+      `${API_BASE}/api/commitments/${created.id}/complete`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {},
+      },
+    );
+    expect(doubleComplete.status()).toBe(409);
+
+    // Reopen the commitment
+    const reopenResponse = await authenticatedPage.request.post(
+      `${API_BASE}/api/commitments/${created.id}/reopen`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {},
+      },
+    );
+    expect(reopenResponse.ok()).toBeTruthy();
+    const reopened = await reopenResponse.json();
+    expect(reopened.status).toBe('Open');
+    expect(reopened.completedAt).toBeNull();
+  });
+
+  // 8.3 E2E test: user isolation — commitments are scoped per user
+  authTest('User isolation — commitments are scoped per user', async ({ browser }) => {
+    const context1 = await browser.newContext();
+    const page1 = await context1.newPage();
+    const context2 = await browser.newContext();
+    const page2 = await context2.newPage();
+
+    // Login as user 1
+    const login1 = await page1.request.post(`${API_BASE}/api/auth/test-login`, {
+      data: { email: 'commitment-isolation-user1@test.local', name: 'User One' },
+    });
+    expect(login1.ok()).toBeTruthy();
+    const token1 = (await login1.json()).accessToken;
+
+    // Login as user 2
+    const login2 = await page2.request.post(`${API_BASE}/api/auth/test-login`, {
+      data: { email: 'commitment-isolation-user2@test.local', name: 'User Two' },
+    });
+    expect(login2.ok()).toBeTruthy();
+    const token2 = (await login2.json()).accessToken;
+
+    // User 1 creates a person
+    const personResponse = await page1.request.post(`${API_BASE}/api/people`, {
+      headers: { Authorization: `Bearer ${token1}` },
+      data: { name: 'Isolation Person', type: 'Stakeholder' },
+    });
+    expect(personResponse.status()).toBe(201);
+    const person = await personResponse.json();
+
+    // User 1 creates a commitment
+    const createResponse = await page1.request.post(`${API_BASE}/api/commitments`, {
+      headers: { Authorization: `Bearer ${token1}` },
+      data: {
+        description: 'User 1 private commitment',
+        direction: 'MineToThem',
+        personId: person.id,
+      },
+    });
+    expect(createResponse.status()).toBe(201);
+    const user1Commitment = await createResponse.json();
+
+    // User 2 lists commitments — should NOT see user 1's commitment
+    const listResponse = await page2.request.get(`${API_BASE}/api/commitments`, {
+      headers: { Authorization: `Bearer ${token2}` },
+    });
+    expect(listResponse.ok()).toBeTruthy();
+    const user2Commitments = await listResponse.json();
+    expect(user2Commitments.every((c: { id: string }) => c.id !== user1Commitment.id)).toBeTruthy();
+
+    // User 2 tries to get user 1's commitment directly — should get 404
+    const getResponse = await page2.request.get(
+      `${API_BASE}/api/commitments/${user1Commitment.id}`,
+      { headers: { Authorization: `Bearer ${token2}` } },
+    );
+    expect(getResponse.status()).toBe(404);
+
+    await context1.close();
+    await context2.close();
+  });
+});


### PR DESCRIPTION
## Summary

Implement the commitment-tracking Tier 2A feature, adding bidirectional promise tracking between users and people. Commitments support direction (MineToThem/TheirsToMe), a status lifecycle (Open -> Completed/Cancelled, with Reopen), overdue detection via DueDate, and links to Person (required), Initiative (optional), and Capture (optional).

**Change**: [commitment-tracking](openspec/changes/commitment-tracking/)

## Changes

- **Domain**: `Commitment` aggregate root with rich behaviour (factory method, status transitions, overdue detection), `CommitmentDirection` and `CommitmentStatus` enums, 8 domain event types, `ICommitmentRepository` interface
- **Infrastructure**: EF Core `CommitmentConfiguration`, `CommitmentRepository` with direction/status/person/initiative/overdue filtering, `AddCommitments` migration, query filter for user isolation
- **Application**: 9 vertical slice CQRS handlers (Create, GetById, GetAll, Update, Complete, Cancel, Reopen, UpdateDueDate, LinkToInitiative) with DTOs
- **Web API**: 9 minimal API endpoints under `/api/commitments` with proper error handling (400, 404, 409)
- **Frontend**: Commitment list page with direction/status/overdue filters, create/edit dialog with person and initiative selectors, detail view with status actions, sidebar navigation, Angular routes
- **Tests**: 30 domain unit tests covering creation, validation, status transitions, overdue computation, and all domain methods; 3 E2E test specs

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (202 domain + 25 application tests)
- [x] `ng test --watch=false` passes (14 frontend tests)
- [ ] E2E tests pass (requires Docker stack)
- [ ] Create a commitment via API and verify it appears in the list
- [ ] Complete/cancel/reopen a commitment and verify status transitions
- [ ] Verify user isolation (commitments scoped per user)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Commitment tracking functionality allowing users to create, update, complete, cancel, and reopen commitments
  * Users can filter commitments by direction, status, person, and overdue status
  * Support for setting due dates, linking commitments to initiatives, and adding notes
  * New Commitments page in the app with list and detail views for managing commitments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->