### PR TITLE
feat: Implement capture-ai-extraction (Tier 2B)

### DIFF
--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -10,13 +10,42 @@ public sealed record LinkPersonRequest(Guid PersonId);
 
 public sealed record LinkInitiativeRequest(Guid InitiativeId);
 
+public sealed record AiExtractionResponse(
+    string Summary,
+    List<ExtractedCommitmentResponse> Commitments,
+    List<ExtractedDelegationResponse> Delegations,
+    List<ExtractedObservationResponse> Observations,
+    List<string> Decisions,
+    List<string> RisksIdentified,
+    List<string> SuggestedPersonLinks,
+    List<string> SuggestedInitiativeLinks,
+    decimal ConfidenceScore)
+{
+    public static AiExtractionResponse? From(AiExtraction? extraction) =>
+        extraction is null ? null : new(
+            extraction.Summary,
+            extraction.Commitments.Select(c => new ExtractedCommitmentResponse(c.Description, c.Direction, c.PersonHint, c.DueDate)).ToList(),
+            extraction.Delegations.Select(d => new ExtractedDelegationResponse(d.Description, d.PersonHint, d.DueDate)).ToList(),
+            extraction.Observations.Select(o => new ExtractedObservationResponse(o.Description, o.PersonHint, o.Tag)).ToList(),
+            extraction.Decisions.ToList(),
+            extraction.RisksIdentified.ToList(),
+            extraction.SuggestedPersonLinks.ToList(),
+            extraction.SuggestedInitiativeLinks.ToList(),
+            extraction.ConfidenceScore);
+}
+
+public sealed record ExtractedCommitmentResponse(string Description, string Direction, string? PersonHint, string? DueDate);
+public sealed record ExtractedDelegationResponse(string Description, string? PersonHint, string? DueDate);
+public sealed record ExtractedObservationResponse(string Description, string? PersonHint, string? Tag);
+
 public sealed record CaptureResponse(
     Guid Id,
     Guid UserId,
     string RawContent,
     CaptureType CaptureType,
     ProcessingStatus ProcessingStatus,
-    string? AiExtraction,
+    AiExtractionResponse? AiExtraction,
+    string? FailureReason,
     List<Guid> LinkedPersonIds,
     List<Guid> LinkedInitiativeIds,
     List<Guid> SpawnedCommitmentIds,
@@ -34,7 +63,8 @@ public sealed record CaptureResponse(
         capture.RawContent,
         capture.CaptureType,
         capture.ProcessingStatus,
-        capture.AiExtraction,
+        AiExtractionResponse.From(capture.AiExtraction),
+        capture.FailureReason,
         capture.LinkedPersonIds.ToList(),
         capture.LinkedInitiativeIds.ToList(),
         capture.SpawnedCommitmentIds.ToList(),

--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -24,7 +24,7 @@ public sealed record AiExtractionResponse(
     public static AiExtractionResponse? From(AiExtraction? extraction) =>
         extraction is null ? null : new(
             extraction.Summary,
-            extraction.Commitments.Select(c => new ExtractedCommitmentResponse(c.Description, c.Direction, c.PersonHint, c.DueDate)).ToList(),
+            extraction.Commitments.Select(c => new ExtractedCommitmentResponse(c.Description, c.Direction.ToString(), c.PersonHint, c.DueDate)).ToList(),
             extraction.Delegations.Select(d => new ExtractedDelegationResponse(d.Description, d.PersonHint, d.DueDate)).ToList(),
             extraction.Observations.Select(o => new ExtractedObservationResponse(o.Description, o.PersonHint, o.Tag)).ToList(),
             extraction.Decisions.ToList(),
@@ -44,6 +44,7 @@ public sealed record CaptureResponse(
     string RawContent,
     CaptureType CaptureType,
     ProcessingStatus ProcessingStatus,
+    ExtractionStatus ExtractionStatus,
     AiExtractionResponse? AiExtraction,
     string? FailureReason,
     List<Guid> LinkedPersonIds,
@@ -63,6 +64,7 @@ public sealed record CaptureResponse(
         capture.RawContent,
         capture.CaptureType,
         capture.ProcessingStatus,
+        capture.ExtractionStatus,
         AiExtractionResponse.From(capture.AiExtraction),
         capture.FailureReason,
         capture.LinkedPersonIds.ToList(),

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -1,0 +1,124 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Delegations;
+using MentalMetal.Domain.People;
+using MentalMetal.Domain.Initiatives;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Captures;
+
+public sealed class ConfirmExtractionHandler(
+    ICaptureRepository captureRepository,
+    ICommitmentRepository commitmentRepository,
+    IDelegationRepository delegationRepository,
+    IPersonRepository personRepository,
+    IInitiativeRepository initiativeRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
+            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+
+        capture.ConfirmExtraction();
+
+        var extraction = capture.AiExtraction!;
+        var userId = currentUserService.UserId;
+
+        // Load all people and initiatives for matching
+        var people = await personRepository.GetAllAsync(userId, null, false, cancellationToken);
+        var initiatives = await initiativeRepository.GetAllAsync(userId, null, cancellationToken);
+
+        // Spawn commitments
+        foreach (var ec in extraction.Commitments)
+        {
+            var personId = MatchPerson(ec.PersonHint, people);
+            if (personId == Guid.Empty) continue; // Skip if no person match — PersonId is required
+
+            var direction = ec.Direction == "MineToThem"
+                ? CommitmentDirection.MineToThem
+                : CommitmentDirection.TheirsToMe;
+
+            DateOnly? dueDate = DateOnly.TryParse(ec.DueDate, out var d) ? d : null;
+
+            var commitment = Commitment.Create(userId, ec.Description, direction, personId, dueDate,
+                sourceCaptureId: capture.Id);
+            await commitmentRepository.AddAsync(commitment, cancellationToken);
+            capture.RecordSpawnedCommitment(commitment.Id);
+        }
+
+        // Spawn delegations
+        foreach (var ed in extraction.Delegations)
+        {
+            var personId = MatchPerson(ed.PersonHint, people);
+            if (personId == Guid.Empty) continue; // Skip if no person match — DelegatePersonId is required
+
+            DateOnly? dueDate = DateOnly.TryParse(ed.DueDate, out var d) ? d : null;
+
+            var delegation = Delegation.Create(userId, ed.Description, personId, dueDate,
+                sourceCaptureId: capture.Id);
+            await delegationRepository.AddAsync(delegation, cancellationToken);
+            capture.RecordSpawnedDelegation(delegation.Id);
+        }
+
+        // Auto-link matched people
+        foreach (var personHint in extraction.SuggestedPersonLinks)
+        {
+            var personId = MatchPerson(personHint, people);
+            if (personId != Guid.Empty)
+                capture.LinkToPerson(personId);
+        }
+
+        // Auto-link matched initiatives
+        foreach (var initiativeHint in extraction.SuggestedInitiativeLinks)
+        {
+            var initiativeId = MatchInitiative(initiativeHint, initiatives);
+            if (initiativeId != Guid.Empty)
+                capture.LinkToInitiative(initiativeId);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CaptureResponse.From(capture);
+    }
+
+    private static Guid MatchPerson(string? hint, IReadOnlyList<Person> people)
+    {
+        if (string.IsNullOrWhiteSpace(hint)) return Guid.Empty;
+
+        var normalizedHint = hint.Trim().ToLower();
+
+        // Exact match first
+        var exact = people.FirstOrDefault(p => p.Name.ToLower() == normalizedHint);
+        if (exact is not null) return exact.Id;
+
+        // Contains match (e.g., "Sarah" matches "Sarah Chen")
+        var partial = people.FirstOrDefault(p =>
+            p.Name.ToLower().Contains(normalizedHint) ||
+            normalizedHint.Contains(p.Name.ToLower()));
+        if (partial is not null) return partial.Id;
+
+        // First name match
+        var firstName = people.FirstOrDefault(p =>
+            p.Name.ToLower().Split(' ')[0] == normalizedHint);
+
+        return firstName?.Id ?? Guid.Empty;
+    }
+
+    private static Guid MatchInitiative(string? hint, IReadOnlyList<Initiative> initiatives)
+    {
+        if (string.IsNullOrWhiteSpace(hint)) return Guid.Empty;
+
+        var normalizedHint = hint.Trim().ToLower();
+
+        var exact = initiatives.FirstOrDefault(i => i.Title.ToLower() == normalizedHint);
+        if (exact is not null) return exact.Id;
+
+        var partial = initiatives.FirstOrDefault(i =>
+            i.Title.ToLower().Contains(normalizedHint) ||
+            normalizedHint.Contains(i.Title.ToLower()));
+
+        return partial?.Id ?? Guid.Empty;
+    }
+}

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Captures;
 using MentalMetal.Domain.Commitments;
@@ -22,6 +23,10 @@ public sealed class ConfirmExtractionHandler(
         var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
             ?? throw new InvalidOperationException($"Capture not found: {captureId}");
 
+        // Idempotency: if entities already spawned, return current state
+        if (capture.SpawnedCommitmentIds.Count > 0 || capture.SpawnedDelegationIds.Count > 0)
+            return CaptureResponse.From(capture);
+
         capture.ConfirmExtraction();
 
         var extraction = capture.AiExtraction!;
@@ -41,7 +46,7 @@ public sealed class ConfirmExtractionHandler(
                 ? CommitmentDirection.MineToThem
                 : CommitmentDirection.TheirsToMe;
 
-            DateOnly? dueDate = DateOnly.TryParse(ec.DueDate, out var d) ? d : null;
+            DateOnly? dueDate = ParseIsoDate(ec.DueDate);
 
             var commitment = Commitment.Create(userId, ec.Description, direction, personId, dueDate,
                 sourceCaptureId: capture.Id);
@@ -55,7 +60,7 @@ public sealed class ConfirmExtractionHandler(
             var personId = MatchPerson(ed.PersonHint, people);
             if (personId == Guid.Empty) continue; // Skip if no person match — DelegatePersonId is required
 
-            DateOnly? dueDate = DateOnly.TryParse(ed.DueDate, out var d) ? d : null;
+            DateOnly? dueDate = ParseIsoDate(ed.DueDate);
 
             var delegation = Delegation.Create(userId, ed.Description, personId, dueDate,
                 sourceCaptureId: capture.Id);
@@ -82,6 +87,10 @@ public sealed class ConfirmExtractionHandler(
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return CaptureResponse.From(capture);
     }
+
+    private static DateOnly? ParseIsoDate(string? value) =>
+        DateOnly.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var d)
+            ? d : null;
 
     private static Guid MatchPerson(string? hint, IReadOnlyList<Person> people)
     {

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -23,10 +23,6 @@ public sealed class ConfirmExtractionHandler(
         var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
             ?? throw new InvalidOperationException($"Capture not found: {captureId}");
 
-        // Idempotency: if entities already spawned, return current state
-        if (capture.SpawnedCommitmentIds.Count > 0 || capture.SpawnedDelegationIds.Count > 0)
-            return CaptureResponse.From(capture);
-
         capture.ConfirmExtraction();
 
         var extraction = capture.AiExtraction!;
@@ -42,7 +38,7 @@ public sealed class ConfirmExtractionHandler(
             var personId = MatchPerson(ec.PersonHint, people);
             if (personId == Guid.Empty) continue; // Skip if no person match — PersonId is required
 
-            var direction = ec.Direction == "MineToThem"
+            var direction = ec.Direction == ExtractionDirection.MineToThem
                 ? CommitmentDirection.MineToThem
                 : CommitmentDirection.TheirsToMe;
 

--- a/src/MentalMetal.Application/Captures/DiscardExtraction.cs
+++ b/src/MentalMetal.Application/Captures/DiscardExtraction.cs
@@ -1,0 +1,19 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+namespace MentalMetal.Application.Captures;
+
+public sealed class DiscardExtractionHandler(
+    ICaptureRepository captureRepository,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
+            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+
+        capture.DiscardExtraction();
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CaptureResponse.From(capture);
+    }
+}

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -33,6 +33,10 @@ public sealed class ProcessCaptureHandler(
         {
             capture.FailProcessing(ex.Message);
         }
+        catch (System.Text.Json.JsonException ex)
+        {
+            capture.FailProcessing($"Failed to parse AI response: {ex.Message}");
+        }
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return CaptureResponse.From(capture);
@@ -85,7 +89,7 @@ public sealed class ProcessCaptureHandler(
 
     internal static AiExtraction ParseExtraction(string jsonContent)
     {
-        var json = System.Text.Json.JsonDocument.Parse(jsonContent);
+        using var json = System.Text.Json.JsonDocument.Parse(jsonContent);
         var root = json.RootElement;
 
         return new AiExtraction
@@ -115,7 +119,7 @@ public sealed class ProcessCaptureHandler(
             SuggestedPersonLinks = ParseStringArray(root, "suggestedPersonLinks"),
             SuggestedInitiativeLinks = ParseStringArray(root, "suggestedInitiativeLinks"),
             ConfidenceScore = root.TryGetProperty("confidenceScore", out var cs)
-                ? cs.GetDecimal()
+                ? Math.Clamp(cs.GetDecimal(), 0m, 1m)
                 : 0m,
         };
     }

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -1,0 +1,150 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Captures;
+namespace MentalMetal.Application.Captures;
+
+public sealed class ProcessCaptureHandler(
+    ICaptureRepository captureRepository,
+    IAiCompletionService aiCompletionService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
+            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+
+        capture.BeginProcessing();
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            var systemPrompt = BuildSystemPrompt();
+            var request = new AiCompletionRequest(systemPrompt, capture.RawContent, Temperature: 0.2f);
+            var result = await aiCompletionService.CompleteAsync(request, cancellationToken);
+
+            var extraction = ParseExtraction(result.Content);
+            capture.CompleteProcessing(extraction);
+        }
+        catch (TasteLimitExceededException)
+        {
+            capture.FailProcessing("Daily AI limit reached");
+        }
+        catch (AiProviderException ex)
+        {
+            capture.FailProcessing(ex.Message);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CaptureResponse.From(capture);
+    }
+
+    private static string BuildSystemPrompt() => """
+        You are an AI assistant that extracts structured data from raw notes, transcripts, and meeting content.
+        Analyze the provided content and extract the following in JSON format:
+
+        {
+          "summary": "A concise summary of the content (1-3 sentences)",
+          "commitments": [
+            {
+              "description": "What was committed to",
+              "direction": "MineToThem" or "TheirsToMe",
+              "personHint": "Name of the person involved (if mentioned)",
+              "dueDate": "Due date if mentioned (ISO format YYYY-MM-DD or null)"
+            }
+          ],
+          "delegations": [
+            {
+              "description": "What was delegated",
+              "personHint": "Name of the person delegated to",
+              "dueDate": "Due date if mentioned (ISO format YYYY-MM-DD or null)"
+            }
+          ],
+          "observations": [
+            {
+              "description": "Notable observation about a person",
+              "personHint": "Name of the person observed",
+              "tag": "Category tag (e.g., 'strength', 'growth-area', 'feedback', 'career')"
+            }
+          ],
+          "decisions": ["Decision 1", "Decision 2"],
+          "risksIdentified": ["Risk 1", "Risk 2"],
+          "suggestedPersonLinks": ["Person name 1", "Person name 2"],
+          "suggestedInitiativeLinks": ["Initiative name 1"],
+          "confidenceScore": 0.85
+        }
+
+        Rules:
+        - Only extract items explicitly stated or strongly implied in the content.
+        - For commitments, determine the direction: "MineToThem" if the user committed to doing something for someone, "TheirsToMe" if someone committed to doing something for the user.
+        - For delegations, these are tasks the user assigned to someone else.
+        - Observations are notable characteristics, behaviors, or feedback about people.
+        - The confidence score (0.0-1.0) reflects how confident you are in the overall extraction quality.
+        - Return empty arrays for categories with no relevant items.
+        - Respond with ONLY the JSON object, no additional text.
+        """;
+
+    internal static AiExtraction ParseExtraction(string jsonContent)
+    {
+        var json = System.Text.Json.JsonDocument.Parse(jsonContent);
+        var root = json.RootElement;
+
+        return new AiExtraction
+        {
+            Summary = root.GetProperty("summary").GetString() ?? "",
+            Commitments = ParseArray(root, "commitments", e => new ExtractedCommitment
+            {
+                Description = e.GetProperty("description").GetString() ?? "",
+                Direction = e.GetProperty("direction").GetString() ?? "TheirsToMe",
+                PersonHint = GetOptionalString(e, "personHint"),
+                DueDate = GetOptionalString(e, "dueDate"),
+            }),
+            Delegations = ParseArray(root, "delegations", e => new ExtractedDelegation
+            {
+                Description = e.GetProperty("description").GetString() ?? "",
+                PersonHint = GetOptionalString(e, "personHint"),
+                DueDate = GetOptionalString(e, "dueDate"),
+            }),
+            Observations = ParseArray(root, "observations", e => new ExtractedObservation
+            {
+                Description = e.GetProperty("description").GetString() ?? "",
+                PersonHint = GetOptionalString(e, "personHint"),
+                Tag = GetOptionalString(e, "tag"),
+            }),
+            Decisions = ParseStringArray(root, "decisions"),
+            RisksIdentified = ParseStringArray(root, "risksIdentified"),
+            SuggestedPersonLinks = ParseStringArray(root, "suggestedPersonLinks"),
+            SuggestedInitiativeLinks = ParseStringArray(root, "suggestedInitiativeLinks"),
+            ConfidenceScore = root.TryGetProperty("confidenceScore", out var cs)
+                ? cs.GetDecimal()
+                : 0m,
+        };
+    }
+
+    private static List<T> ParseArray<T>(
+        System.Text.Json.JsonElement root, string propertyName, Func<System.Text.Json.JsonElement, T> mapper)
+    {
+        if (!root.TryGetProperty(propertyName, out var arr) || arr.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return [];
+
+        return arr.EnumerateArray().Select(mapper).ToList();
+    }
+
+    private static List<string> ParseStringArray(System.Text.Json.JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var arr) || arr.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return [];
+
+        return arr.EnumerateArray()
+            .Select(e => e.GetString() ?? "")
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+    }
+
+    private static string? GetOptionalString(System.Text.Json.JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var prop))
+            return null;
+
+        return prop.ValueKind == System.Text.Json.JsonValueKind.Null ? null : prop.GetString();
+    }
+}

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -102,7 +102,7 @@ public sealed class ProcessCaptureHandler(
             Commitments = ParseArray(root, "commitments", e => new ExtractedCommitment
             {
                 Description = e.GetProperty("description").GetString() ?? "",
-                Direction = e.GetProperty("direction").GetString() ?? "TheirsToMe",
+                Direction = ParseDirection(GetOptionalString(e, "direction")),
                 PersonHint = GetOptionalString(e, "personHint"),
                 DueDate = GetOptionalString(e, "dueDate"),
             }),
@@ -147,6 +147,11 @@ public sealed class ProcessCaptureHandler(
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .ToList();
     }
+
+    private static ExtractionDirection ParseDirection(string? value) =>
+        string.Equals(value, "MineToThem", StringComparison.OrdinalIgnoreCase)
+            ? ExtractionDirection.MineToThem
+            : ExtractionDirection.TheirsToMe;
 
     private static string? GetOptionalString(System.Text.Json.JsonElement element, string propertyName)
     {

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -37,6 +37,10 @@ public sealed class ProcessCaptureHandler(
         {
             capture.FailProcessing($"Failed to parse AI response: {ex.Message}");
         }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            capture.FailProcessing($"Unexpected error: {ex.Message}");
+        }
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return CaptureResponse.From(capture);
@@ -51,7 +55,7 @@ public sealed class ProcessCaptureHandler(
           "commitments": [
             {
               "description": "What was committed to",
-              "direction": "MineToThem" or "TheirsToMe",
+              "direction": "MineToThem",
               "personHint": "Name of the person involved (if mentioned)",
               "dueDate": "Due date if mentioned (ISO format YYYY-MM-DD or null)"
             }
@@ -79,7 +83,7 @@ public sealed class ProcessCaptureHandler(
 
         Rules:
         - Only extract items explicitly stated or strongly implied in the content.
-        - For commitments, determine the direction: "MineToThem" if the user committed to doing something for someone, "TheirsToMe" if someone committed to doing something for the user.
+        - For commitments, set direction to exactly "MineToThem" if the user committed to doing something for someone, or "TheirsToMe" if someone committed to doing something for the user.
         - For delegations, these are tasks the user assigned to someone else.
         - Observations are notable characteristics, behaviors, or feedback about people.
         - The confidence score (0.0-1.0) reflects how confident you are in the overall extraction quality.

--- a/src/MentalMetal.Application/Captures/RetryProcessing.cs
+++ b/src/MentalMetal.Application/Captures/RetryProcessing.cs
@@ -1,0 +1,19 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+namespace MentalMetal.Application.Captures;
+
+public sealed class RetryProcessingHandler(
+    ICaptureRepository captureRepository,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
+            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+
+        capture.RetryProcessing();
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return CaptureResponse.From(capture);
+    }
+}

--- a/src/MentalMetal.Domain/Captures/AiExtraction.cs
+++ b/src/MentalMetal.Domain/Captures/AiExtraction.cs
@@ -16,7 +16,7 @@ public sealed record AiExtraction
 public sealed record ExtractedCommitment
 {
     public required string Description { get; init; }
-    public required string Direction { get; init; } // "MineToThem" or "TheirsToMe"
+    public required ExtractionDirection Direction { get; init; }
     public string? PersonHint { get; init; }
     public string? DueDate { get; init; }
 }
@@ -33,4 +33,10 @@ public sealed record ExtractedObservation
     public required string Description { get; init; }
     public string? PersonHint { get; init; }
     public string? Tag { get; init; }
+}
+
+public enum ExtractionDirection
+{
+    MineToThem,
+    TheirsToMe
 }

--- a/src/MentalMetal.Domain/Captures/AiExtraction.cs
+++ b/src/MentalMetal.Domain/Captures/AiExtraction.cs
@@ -1,0 +1,36 @@
+namespace MentalMetal.Domain.Captures;
+
+public sealed record AiExtraction
+{
+    public required string Summary { get; init; }
+    public IReadOnlyList<ExtractedCommitment> Commitments { get; init; } = [];
+    public IReadOnlyList<ExtractedDelegation> Delegations { get; init; } = [];
+    public IReadOnlyList<ExtractedObservation> Observations { get; init; } = [];
+    public IReadOnlyList<string> Decisions { get; init; } = [];
+    public IReadOnlyList<string> RisksIdentified { get; init; } = [];
+    public IReadOnlyList<string> SuggestedPersonLinks { get; init; } = [];
+    public IReadOnlyList<string> SuggestedInitiativeLinks { get; init; } = [];
+    public decimal ConfidenceScore { get; init; }
+}
+
+public sealed record ExtractedCommitment
+{
+    public required string Description { get; init; }
+    public required string Direction { get; init; } // "MineToThem" or "TheirsToMe"
+    public string? PersonHint { get; init; }
+    public string? DueDate { get; init; }
+}
+
+public sealed record ExtractedDelegation
+{
+    public required string Description { get; init; }
+    public string? PersonHint { get; init; }
+    public string? DueDate { get; init; }
+}
+
+public sealed record ExtractedObservation
+{
+    public required string Description { get; init; }
+    public string? PersonHint { get; init; }
+    public string? Tag { get; init; }
+}

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -15,6 +15,7 @@ public sealed class Capture : AggregateRoot, IUserScoped
     public CaptureType CaptureType { get; private set; }
     public ProcessingStatus ProcessingStatus { get; private set; }
     public AiExtraction? AiExtraction { get; private set; }
+    public ExtractionStatus ExtractionStatus { get; private set; }
     public string? FailureReason { get; private set; }
     public IReadOnlyList<Guid> LinkedPersonIds => _linkedPersonIds;
     public IReadOnlyList<Guid> LinkedInitiativeIds => _linkedInitiativeIds;
@@ -75,6 +76,7 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
         ProcessingStatus = ProcessingStatus.Processed;
         AiExtraction = extraction;
+        ExtractionStatus = ExtractionStatus.Pending;
         FailureReason = null;
         ProcessedAt = DateTimeOffset.UtcNow;
         UpdatedAt = DateTimeOffset.UtcNow;
@@ -104,6 +106,7 @@ public sealed class Capture : AggregateRoot, IUserScoped
         ProcessingStatus = ProcessingStatus.Raw;
         FailureReason = null;
         AiExtraction = null;
+        ExtractionStatus = ExtractionStatus.None;
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new CaptureRetryRequested(Id));
@@ -118,6 +121,12 @@ public sealed class Capture : AggregateRoot, IUserScoped
         if (AiExtraction is null)
             throw new InvalidOperationException("No extraction to confirm.");
 
+        if (ExtractionStatus == ExtractionStatus.Confirmed)
+            throw new InvalidOperationException("Extraction already confirmed.");
+
+        ExtractionStatus = ExtractionStatus.Confirmed;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
         RaiseDomainEvent(new CaptureExtractionConfirmed(Id));
     }
 
@@ -127,6 +136,11 @@ public sealed class Capture : AggregateRoot, IUserScoped
             throw new InvalidOperationException(
                 $"Cannot discard extraction from '{ProcessingStatus}' status. Must be 'Processed'.");
 
+        if (ExtractionStatus != ExtractionStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot discard extraction with status '{ExtractionStatus}'. Must be 'Pending'.");
+
+        ExtractionStatus = ExtractionStatus.Discarded;
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new CaptureExtractionDiscarded(Id));

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -14,7 +14,8 @@ public sealed class Capture : AggregateRoot, IUserScoped
     public string RawContent { get; private set; } = null!;
     public CaptureType CaptureType { get; private set; }
     public ProcessingStatus ProcessingStatus { get; private set; }
-    public string? AiExtraction { get; private set; }
+    public AiExtraction? AiExtraction { get; private set; }
+    public string? FailureReason { get; private set; }
     public IReadOnlyList<Guid> LinkedPersonIds => _linkedPersonIds;
     public IReadOnlyList<Guid> LinkedInitiativeIds => _linkedInitiativeIds;
     public IReadOnlyList<Guid> SpawnedCommitmentIds => _spawnedCommitmentIds;
@@ -64,14 +65,17 @@ public sealed class Capture : AggregateRoot, IUserScoped
         RaiseDomainEvent(new CaptureProcessingStarted(Id));
     }
 
-    public void CompleteProcessing(string? extraction = null)
+    public void CompleteProcessing(AiExtraction extraction)
     {
+        ArgumentNullException.ThrowIfNull(extraction, nameof(extraction));
+
         if (ProcessingStatus != ProcessingStatus.Processing)
             throw new InvalidOperationException(
                 $"Cannot complete processing from '{ProcessingStatus}' status. Must be 'Processing'.");
 
         ProcessingStatus = ProcessingStatus.Processed;
         AiExtraction = extraction;
+        FailureReason = null;
         ProcessedAt = DateTimeOffset.UtcNow;
         UpdatedAt = DateTimeOffset.UtcNow;
 
@@ -85,6 +89,7 @@ public sealed class Capture : AggregateRoot, IUserScoped
                 $"Cannot fail processing from '{ProcessingStatus}' status. Must be 'Processing'.");
 
         ProcessingStatus = ProcessingStatus.Failed;
+        FailureReason = reason;
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new CaptureProcessingFailed(Id, reason));
@@ -97,9 +102,34 @@ public sealed class Capture : AggregateRoot, IUserScoped
                 $"Cannot retry processing from '{ProcessingStatus}' status. Must be 'Failed'.");
 
         ProcessingStatus = ProcessingStatus.Raw;
+        FailureReason = null;
+        AiExtraction = null;
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new CaptureRetryRequested(Id));
+    }
+
+    public void ConfirmExtraction()
+    {
+        if (ProcessingStatus != ProcessingStatus.Processed)
+            throw new InvalidOperationException(
+                $"Cannot confirm extraction from '{ProcessingStatus}' status. Must be 'Processed'.");
+
+        if (AiExtraction is null)
+            throw new InvalidOperationException("No extraction to confirm.");
+
+        RaiseDomainEvent(new CaptureExtractionConfirmed(Id));
+    }
+
+    public void DiscardExtraction()
+    {
+        if (ProcessingStatus != ProcessingStatus.Processed)
+            throw new InvalidOperationException(
+                $"Cannot discard extraction from '{ProcessingStatus}' status. Must be 'Processed'.");
+
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CaptureExtractionDiscarded(Id));
     }
 
     public void LinkToPerson(Guid personId)

--- a/src/MentalMetal.Domain/Captures/CaptureEvents.cs
+++ b/src/MentalMetal.Domain/Captures/CaptureEvents.cs
@@ -51,3 +51,13 @@ public sealed record CaptureMetadataUpdated(Guid CaptureId) : IDomainEvent
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record CaptureExtractionConfirmed(Guid CaptureId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CaptureExtractionDiscarded(Guid CaptureId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Domain/Captures/ExtractionStatus.cs
+++ b/src/MentalMetal.Domain/Captures/ExtractionStatus.cs
@@ -1,0 +1,9 @@
+namespace MentalMetal.Domain.Captures;
+
+public enum ExtractionStatus
+{
+    None,
+    Pending,
+    Confirmed,
+    Discarded
+}

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -138,6 +138,10 @@ public static class DependencyInjection
         services.AddScoped<LinkCaptureToInitiativeHandler>();
         services.AddScoped<UnlinkCaptureFromPersonHandler>();
         services.AddScoped<UnlinkCaptureFromInitiativeHandler>();
+        services.AddScoped<ProcessCaptureHandler>();
+        services.AddScoped<RetryProcessingHandler>();
+        services.AddScoped<ConfirmExtractionHandler>();
+        services.AddScoped<DiscardExtractionHandler>();
 
         return services;
     }

--- a/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413031942_AddAiExtractionJsonAndFailureReason")]
+    partial class AddAiExtractionJsonAndFailureReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
@@ -10,6 +10,9 @@ namespace MentalMetal.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Clear any existing non-JSON text values before converting to jsonb
+            migrationBuilder.Sql("""UPDATE "Captures" SET "AiExtraction" = NULL WHERE "AiExtraction" IS NOT NULL""");
+
             migrationBuilder.AlterColumn<string>(
                 name: "AiExtraction",
                 table: "Captures",

--- a/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAiExtractionJsonAndFailureReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "AiExtraction",
+                table: "Captures",
+                type: "jsonb",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FailureReason",
+                table: "Captures",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FailureReason",
+                table: "Captures");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AiExtraction",
+                table: "Captures",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "jsonb",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Migrations/20260413053932_AddExtractionStatus.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413053932_AddExtractionStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413053932_AddExtractionStatus")]
+    partial class AddExtractionStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260413053932_AddExtractionStatus.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413053932_AddExtractionStatus.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExtractionStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExtractionStatus",
+                table: "Captures",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "None");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExtractionStatus",
+                table: "Captures");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
@@ -33,6 +33,12 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
             extraction.OwnsMany(e => e.Observations);
         });
 
+        builder.Property(c => c.ExtractionStatus)
+            .HasConversion<string>()
+            .IsRequired()
+            .HasMaxLength(20)
+            .HasDefaultValue(ExtractionStatus.None);
+
         builder.Property(c => c.FailureReason)
             .HasMaxLength(2000);
 

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
@@ -25,7 +25,16 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
             .IsRequired()
             .HasMaxLength(20);
 
-        builder.Property(c => c.AiExtraction);
+        builder.OwnsOne(c => c.AiExtraction, extraction =>
+        {
+            extraction.ToJson();
+            extraction.OwnsMany(e => e.Commitments);
+            extraction.OwnsMany(e => e.Delegations);
+            extraction.OwnsMany(e => e.Observations);
+        });
+
+        builder.Property(c => c.FailureReason)
+            .HasMaxLength(2000);
 
         builder.Property(c => c.Title)
             .HasMaxLength(500);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -7,6 +7,8 @@ import { InputTextModule } from 'primeng/inputtext';
 import { TagModule } from 'primeng/tag';
 import { ChipModule } from 'primeng/chip';
 import { ToastModule } from 'primeng/toast';
+import { PanelModule } from 'primeng/panel';
+import { DividerModule } from 'primeng/divider';
 import { AutoCompleteModule, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
 import { MessageService } from 'primeng/api';
 import { CapturesService } from '../../../shared/services/captures.service';
@@ -28,12 +30,21 @@ import { Initiative } from '../../../shared/models/initiative.model';
     TagModule,
     ChipModule,
     ToastModule,
+    PanelModule,
+    DividerModule,
     AutoCompleteModule,
   ],
   styles: [`
     .content-block {
       border-color: var(--p-surface-200);
       background-color: var(--p-surface-50);
+    }
+    .extraction-section {
+      border-color: var(--p-surface-200);
+      background-color: var(--p-surface-50);
+    }
+    .extraction-item {
+      border-color: var(--p-surface-100);
     }
   `],
   providers: [MessageService],
@@ -51,7 +62,13 @@ import { Initiative } from '../../../shared/models/initiative.model';
           <p-button icon="pi pi-arrow-left" [text]="true" (onClick)="goBack()" />
           <h1 class="text-2xl font-bold flex-1">{{ capture()!.title || 'Untitled Capture' }}</h1>
           <p-tag [value]="formatType(capture()!.captureType)" [severity]="typeSeverity(capture()!.captureType)" />
-          <p-tag [value]="formatStatus(capture()!.processingStatus)" [severity]="statusSeverity(capture()!.processingStatus)" />
+          @if (capture()!.processingStatus === 'Processing') {
+            <p-tag severity="warn">
+              <i class="pi pi-spinner pi-spin mr-1"></i> Processing
+            </p-tag>
+          } @else {
+            <p-tag [value]="formatStatus(capture()!.processingStatus)" [severity]="statusSeverity(capture()!.processingStatus)" />
+          }
         </div>
 
         <!-- Timestamps -->
@@ -65,11 +82,201 @@ import { Initiative } from '../../../shared/models/initiative.model';
           }
         </div>
 
+        <!-- Action Buttons -->
+        @if (capture()!.processingStatus === 'Raw') {
+          <div>
+            <p-button
+              label="Process with AI"
+              icon="pi pi-sparkles"
+              (onClick)="processCapture()"
+              [loading]="processing()"
+            />
+          </div>
+        }
+        @if (capture()!.processingStatus === 'Failed') {
+          <div class="flex items-center gap-4 p-4 rounded-md border border-red-200 bg-red-50">
+            <i class="pi pi-exclamation-triangle text-red-500"></i>
+            <div class="flex-1">
+              <p class="font-medium text-red-700">Processing Failed</p>
+              @if (capture()!.failureReason) {
+                <p class="text-sm text-red-600">{{ capture()!.failureReason }}</p>
+              }
+            </div>
+            <p-button
+              label="Retry"
+              icon="pi pi-refresh"
+              severity="warn"
+              (onClick)="retryProcessing()"
+              [loading]="retrying()"
+            />
+          </div>
+        }
+
         <!-- Raw Content -->
         <section class="flex flex-col gap-4">
           <h2 class="text-xl font-semibold">Content</h2>
           <div class="p-4 rounded-md border content-block whitespace-pre-wrap text-sm">{{ capture()!.rawContent }}</div>
         </section>
+
+        <!-- AI Extraction Review Panel -->
+        @if (capture()!.processingStatus === 'Processed' && capture()!.aiExtraction) {
+          <section class="flex flex-col gap-4">
+            <div class="flex items-center justify-between">
+              <h2 class="text-xl font-semibold">AI Extraction</h2>
+              <p-tag
+                [value]="'Confidence: ' + (capture()!.aiExtraction!.confidenceScore * 100).toFixed(0) + '%'"
+                severity="info"
+              />
+            </div>
+
+            @if (extractionConfirmed()) {
+              <div class="flex items-center gap-2 p-3 rounded-md bg-green-50 border border-green-200">
+                <i class="pi pi-check-circle text-green-600"></i>
+                <span class="text-green-700 font-medium">Entities created</span>
+              </div>
+            } @else if (extractionDiscarded()) {
+              <div class="flex items-center gap-2 p-3 rounded-md bg-yellow-50 border border-yellow-200">
+                <i class="pi pi-info-circle text-yellow-600"></i>
+                <span class="text-yellow-700 font-medium">Extraction discarded</span>
+              </div>
+            } @else {
+              <div class="flex gap-2">
+                <p-button
+                  label="Confirm & Create"
+                  icon="pi pi-check"
+                  (onClick)="confirmExtraction()"
+                  [loading]="confirming()"
+                />
+                <p-button
+                  label="Discard"
+                  icon="pi pi-times"
+                  severity="secondary"
+                  [outlined]="true"
+                  (onClick)="discardExtraction()"
+                  [loading]="discarding()"
+                />
+              </div>
+            }
+
+            <!-- Summary -->
+            <div class="p-4 rounded-md border extraction-section">
+              <h3 class="font-semibold mb-2">Summary</h3>
+              <p class="text-sm">{{ capture()!.aiExtraction!.summary }}</p>
+            </div>
+
+            <!-- Commitments -->
+            @if (capture()!.aiExtraction!.commitments.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Commitments ({{ capture()!.aiExtraction!.commitments.length }})</h3>
+                @for (c of capture()!.aiExtraction!.commitments; track $index) {
+                  <div class="p-3 mb-2 rounded border extraction-item flex items-start gap-3">
+                    <p-tag [value]="c.direction === 'MineToThem' ? 'Mine → Them' : 'Theirs → Me'" [severity]="c.direction === 'MineToThem' ? 'warn' : 'info'" />
+                    <div class="flex-1">
+                      <p class="text-sm font-medium">{{ c.description }}</p>
+                      <div class="flex gap-3 mt-1 text-xs text-muted-color">
+                        @if (c.personHint) {
+                          <span><i class="pi pi-user mr-1"></i>{{ c.personHint }}</span>
+                        }
+                        @if (c.dueDate) {
+                          <span><i class="pi pi-calendar mr-1"></i>{{ c.dueDate }}</span>
+                        }
+                      </div>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Delegations -->
+            @if (capture()!.aiExtraction!.delegations.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Delegations ({{ capture()!.aiExtraction!.delegations.length }})</h3>
+                @for (d of capture()!.aiExtraction!.delegations; track $index) {
+                  <div class="p-3 mb-2 rounded border extraction-item">
+                    <p class="text-sm font-medium">{{ d.description }}</p>
+                    <div class="flex gap-3 mt-1 text-xs text-muted-color">
+                      @if (d.personHint) {
+                        <span><i class="pi pi-user mr-1"></i>{{ d.personHint }}</span>
+                      }
+                      @if (d.dueDate) {
+                        <span><i class="pi pi-calendar mr-1"></i>{{ d.dueDate }}</span>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Observations -->
+            @if (capture()!.aiExtraction!.observations.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Observations ({{ capture()!.aiExtraction!.observations.length }})</h3>
+                @for (o of capture()!.aiExtraction!.observations; track $index) {
+                  <div class="p-3 mb-2 rounded border extraction-item flex items-start gap-3">
+                    @if (o.tag) {
+                      <p-tag [value]="o.tag" severity="secondary" />
+                    }
+                    <div class="flex-1">
+                      <p class="text-sm font-medium">{{ o.description }}</p>
+                      @if (o.personHint) {
+                        <span class="text-xs text-muted-color"><i class="pi pi-user mr-1"></i>{{ o.personHint }}</span>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Decisions -->
+            @if (capture()!.aiExtraction!.decisions.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Decisions ({{ capture()!.aiExtraction!.decisions.length }})</h3>
+                @for (d of capture()!.aiExtraction!.decisions; track $index) {
+                  <div class="p-2 mb-1 text-sm flex items-start gap-2">
+                    <i class="pi pi-check-square text-muted-color mt-0.5"></i>
+                    <span>{{ d }}</span>
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Risks -->
+            @if (capture()!.aiExtraction!.risksIdentified.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Risks ({{ capture()!.aiExtraction!.risksIdentified.length }})</h3>
+                @for (r of capture()!.aiExtraction!.risksIdentified; track $index) {
+                  <div class="p-2 mb-1 text-sm flex items-start gap-2">
+                    <i class="pi pi-exclamation-triangle text-yellow-500 mt-0.5"></i>
+                    <span>{{ r }}</span>
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Suggested Links -->
+            @if (capture()!.aiExtraction!.suggestedPersonLinks.length > 0 || capture()!.aiExtraction!.suggestedInitiativeLinks.length > 0) {
+              <div class="p-4 rounded-md border extraction-section">
+                <h3 class="font-semibold mb-2">Suggested Links</h3>
+                @if (capture()!.aiExtraction!.suggestedPersonLinks.length > 0) {
+                  <div class="flex flex-wrap gap-2 mb-2">
+                    <span class="text-sm text-muted-color mr-2">People:</span>
+                    @for (p of capture()!.aiExtraction!.suggestedPersonLinks; track $index) {
+                      <p-tag [value]="p" severity="info" />
+                    }
+                  </div>
+                }
+                @if (capture()!.aiExtraction!.suggestedInitiativeLinks.length > 0) {
+                  <div class="flex flex-wrap gap-2">
+                    <span class="text-sm text-muted-color mr-2">Initiatives:</span>
+                    @for (i of capture()!.aiExtraction!.suggestedInitiativeLinks; track $index) {
+                      <p-tag [value]="i" severity="success" />
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </section>
+        }
 
         <!-- Metadata Section -->
         <section class="flex flex-col gap-4">
@@ -186,6 +393,12 @@ export class CaptureDetailComponent implements OnInit {
   readonly savingMetadata = signal(false);
   readonly linkingPerson = signal(false);
   readonly linkingInitiative = signal(false);
+  readonly processing = signal(false);
+  readonly retrying = signal(false);
+  readonly confirming = signal(false);
+  readonly discarding = signal(false);
+  readonly extractionConfirmed = signal(false);
+  readonly extractionDiscarded = signal(false);
   readonly linkedPeople = signal<Person[]>([]);
   readonly linkedInitiatives = signal<Initiative[]>([]);
   readonly peopleSuggestions = signal<Person[]>([]);
@@ -211,6 +424,88 @@ export class CaptureDetailComponent implements OnInit {
     const c = this.capture();
     if (!c) return false;
     return this.editTitle !== (c.title ?? '') || this.editSource !== (c.source ?? '');
+  }
+
+  protected processCapture(): void {
+    const c = this.capture();
+    if (!c) return;
+
+    this.processing.set(true);
+    this.capturesService.process(c.id).subscribe({
+      next: (updated) => {
+        this.capture.set(updated);
+        this.processing.set(false);
+        if (updated.processingStatus === 'Processed') {
+          this.messageService.add({ severity: 'success', summary: 'Processing complete' });
+        } else if (updated.processingStatus === 'Failed') {
+          this.messageService.add({ severity: 'error', summary: 'Processing failed', detail: updated.failureReason ?? undefined });
+        } else {
+          this.messageService.add({ severity: 'info', summary: 'Processing started' });
+        }
+      },
+      error: () => {
+        this.processing.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to start processing' });
+      },
+    });
+  }
+
+  protected retryProcessing(): void {
+    const c = this.capture();
+    if (!c) return;
+
+    this.retrying.set(true);
+    this.capturesService.retry(c.id).subscribe({
+      next: (updated) => {
+        this.capture.set(updated);
+        this.retrying.set(false);
+        this.messageService.add({ severity: 'success', summary: 'Ready for reprocessing' });
+      },
+      error: () => {
+        this.retrying.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to retry' });
+      },
+    });
+  }
+
+  protected confirmExtraction(): void {
+    const c = this.capture();
+    if (!c) return;
+
+    this.confirming.set(true);
+    this.capturesService.confirmExtraction(c.id).subscribe({
+      next: (updated) => {
+        this.capture.set(updated);
+        this.confirming.set(false);
+        this.extractionConfirmed.set(true);
+        this.loadLinkedPeople(updated.linkedPersonIds);
+        this.loadLinkedInitiatives(updated.linkedInitiativeIds);
+        this.messageService.add({ severity: 'success', summary: 'Entities created from extraction' });
+      },
+      error: () => {
+        this.confirming.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to confirm extraction' });
+      },
+    });
+  }
+
+  protected discardExtraction(): void {
+    const c = this.capture();
+    if (!c) return;
+
+    this.discarding.set(true);
+    this.capturesService.discardExtraction(c.id).subscribe({
+      next: (updated) => {
+        this.capture.set(updated);
+        this.discarding.set(false);
+        this.extractionDiscarded.set(true);
+        this.messageService.add({ severity: 'info', summary: 'Extraction discarded' });
+      },
+      error: () => {
+        this.discarding.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to discard extraction' });
+      },
+    });
   }
 
   protected saveMetadata(): void {
@@ -385,6 +680,10 @@ export class CaptureDetailComponent implements OnInit {
         this.editSource = capture.source ?? '';
         this.loadLinkedPeople(capture.linkedPersonIds);
         this.loadLinkedInitiatives(capture.linkedInitiativeIds);
+        // If already has spawned entities, show confirmed state
+        if (capture.spawnedCommitmentIds.length > 0 || capture.spawnedDelegationIds.length > 0) {
+          this.extractionConfirmed.set(true);
+        }
         this.loading.set(false);
       },
       error: () => {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -149,12 +149,12 @@ import { Initiative } from '../../../shared/models/initiative.model';
               />
             </div>
 
-            @if (extractionConfirmed()) {
+            @if (capture()!.extractionStatus === 'Confirmed') {
               <div class="flex items-center gap-2 p-3 rounded-md border success-banner">
                 <i class="pi pi-check-circle success-icon"></i>
                 <span class="success-text font-medium">Entities created</span>
               </div>
-            } @else if (extractionDiscarded()) {
+            } @else if (capture()!.extractionStatus === 'Discarded') {
               <div class="flex items-center gap-2 p-3 rounded-md border warn-banner">
                 <i class="pi pi-info-circle warn-icon"></i>
                 <span class="warn-text font-medium">Extraction discarded</span>
@@ -417,8 +417,6 @@ export class CaptureDetailComponent implements OnInit {
   readonly retrying = signal(false);
   readonly confirming = signal(false);
   readonly discarding = signal(false);
-  readonly extractionConfirmed = signal(false);
-  readonly extractionDiscarded = signal(false);
   readonly linkedPeople = signal<Person[]>([]);
   readonly linkedInitiatives = signal<Initiative[]>([]);
   readonly peopleSuggestions = signal<Person[]>([]);
@@ -497,8 +495,6 @@ export class CaptureDetailComponent implements OnInit {
       next: (updated) => {
         this.capture.set(updated);
         this.confirming.set(false);
-        this.extractionConfirmed.set(true);
-        this.extractionDiscarded.set(false);
         this.loadLinkedPeople(updated.linkedPersonIds);
         this.loadLinkedInitiatives(updated.linkedInitiativeIds);
         this.messageService.add({ severity: 'success', summary: 'Entities created from extraction' });
@@ -519,8 +515,6 @@ export class CaptureDetailComponent implements OnInit {
       next: (updated) => {
         this.capture.set(updated);
         this.discarding.set(false);
-        this.extractionDiscarded.set(true);
-        this.extractionConfirmed.set(false);
         this.messageService.add({ severity: 'info', summary: 'Extraction discarded' });
       },
       error: () => {
@@ -695,8 +689,6 @@ export class CaptureDetailComponent implements OnInit {
 
   private loadCapture(id: string): void {
     this.loading.set(true);
-    this.extractionConfirmed.set(false);
-    this.extractionDiscarded.set(false);
     this.capturesService.get(id).subscribe({
       next: (capture) => {
         this.capture.set(capture);
@@ -704,10 +696,6 @@ export class CaptureDetailComponent implements OnInit {
         this.editSource = capture.source ?? '';
         this.loadLinkedPeople(capture.linkedPersonIds);
         this.loadLinkedInitiatives(capture.linkedInitiativeIds);
-        // If already has spawned entities, show confirmed state
-        if (capture.spawnedCommitmentIds.length > 0 || capture.spawnedDelegationIds.length > 0) {
-          this.extractionConfirmed.set(true);
-        }
         this.loading.set(false);
       },
       error: () => {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -498,6 +498,7 @@ export class CaptureDetailComponent implements OnInit {
         this.capture.set(updated);
         this.confirming.set(false);
         this.extractionConfirmed.set(true);
+        this.extractionDiscarded.set(false);
         this.loadLinkedPeople(updated.linkedPersonIds);
         this.loadLinkedInitiatives(updated.linkedInitiativeIds);
         this.messageService.add({ severity: 'success', summary: 'Entities created from extraction' });
@@ -519,6 +520,7 @@ export class CaptureDetailComponent implements OnInit {
         this.capture.set(updated);
         this.discarding.set(false);
         this.extractionDiscarded.set(true);
+        this.extractionConfirmed.set(false);
         this.messageService.add({ severity: 'info', summary: 'Extraction discarded' });
       },
       error: () => {
@@ -693,6 +695,8 @@ export class CaptureDetailComponent implements OnInit {
 
   private loadCapture(id: string): void {
     this.loading.set(true);
+    this.extractionConfirmed.set(false);
+    this.extractionDiscarded.set(false);
     this.capturesService.get(id).subscribe({
       next: (capture) => {
         this.capture.set(capture);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -46,6 +46,26 @@ import { Initiative } from '../../../shared/models/initiative.model';
     .extraction-item {
       border-color: var(--p-surface-100);
     }
+    .error-banner {
+      border-color: var(--p-red-200);
+      background-color: var(--p-red-50);
+    }
+    .error-icon { color: var(--p-red-500); }
+    .error-title { color: var(--p-red-700); }
+    .error-detail { color: var(--p-red-600); }
+    .success-banner {
+      background-color: var(--p-green-50);
+      border-color: var(--p-green-200);
+    }
+    .success-icon { color: var(--p-green-600); }
+    .success-text { color: var(--p-green-700); }
+    .warn-banner {
+      background-color: var(--p-yellow-50);
+      border-color: var(--p-yellow-200);
+    }
+    .warn-icon { color: var(--p-yellow-600); }
+    .warn-text { color: var(--p-yellow-700); }
+    .risk-icon { color: var(--p-yellow-500); }
   `],
   providers: [MessageService],
   template: `
@@ -94,12 +114,12 @@ import { Initiative } from '../../../shared/models/initiative.model';
           </div>
         }
         @if (capture()!.processingStatus === 'Failed') {
-          <div class="flex items-center gap-4 p-4 rounded-md border border-red-200 bg-red-50">
-            <i class="pi pi-exclamation-triangle text-red-500"></i>
+          <div class="flex items-center gap-4 p-4 rounded-md border error-banner">
+            <i class="pi pi-exclamation-triangle error-icon"></i>
             <div class="flex-1">
-              <p class="font-medium text-red-700">Processing Failed</p>
+              <p class="font-medium error-title">Processing Failed</p>
               @if (capture()!.failureReason) {
-                <p class="text-sm text-red-600">{{ capture()!.failureReason }}</p>
+                <p class="text-sm error-detail">{{ capture()!.failureReason }}</p>
               }
             </div>
             <p-button
@@ -130,14 +150,14 @@ import { Initiative } from '../../../shared/models/initiative.model';
             </div>
 
             @if (extractionConfirmed()) {
-              <div class="flex items-center gap-2 p-3 rounded-md bg-green-50 border border-green-200">
-                <i class="pi pi-check-circle text-green-600"></i>
-                <span class="text-green-700 font-medium">Entities created</span>
+              <div class="flex items-center gap-2 p-3 rounded-md border success-banner">
+                <i class="pi pi-check-circle success-icon"></i>
+                <span class="success-text font-medium">Entities created</span>
               </div>
             } @else if (extractionDiscarded()) {
-              <div class="flex items-center gap-2 p-3 rounded-md bg-yellow-50 border border-yellow-200">
-                <i class="pi pi-info-circle text-yellow-600"></i>
-                <span class="text-yellow-700 font-medium">Extraction discarded</span>
+              <div class="flex items-center gap-2 p-3 rounded-md border warn-banner">
+                <i class="pi pi-info-circle warn-icon"></i>
+                <span class="warn-text font-medium">Extraction discarded</span>
               </div>
             } @else {
               <div class="flex gap-2">
@@ -246,7 +266,7 @@ import { Initiative } from '../../../shared/models/initiative.model';
                 <h3 class="font-semibold mb-2">Risks ({{ capture()!.aiExtraction!.risksIdentified.length }})</h3>
                 @for (r of capture()!.aiExtraction!.risksIdentified; track $index) {
                   <div class="p-2 mb-1 text-sm flex items-start gap-2">
-                    <i class="pi pi-exclamation-triangle text-yellow-500 mt-0.5"></i>
+                    <i class="pi pi-exclamation-triangle risk-icon mt-0.5"></i>
                     <span>{{ r }}</span>
                   </div>
                 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
@@ -73,7 +73,13 @@ import { QuickCaptureDialogComponent } from '../quick-capture-dialog/quick-captu
                 <p-tag [value]="formatType(capture.captureType)" [severity]="typeSeverity(capture.captureType)" />
               </td>
               <td>
-                <p-tag [value]="formatStatus(capture.processingStatus)" [severity]="statusSeverity(capture.processingStatus)" />
+                @if (capture.processingStatus === 'Processing') {
+                  <p-tag severity="warn">
+                    <i class="pi pi-spinner pi-spin mr-1"></i> Processing
+                  </p-tag>
+                } @else {
+                  <p-tag [value]="formatStatus(capture.processingStatus)" [severity]="statusSeverity(capture.processingStatus)" />
+                }
               </td>
               <td class="text-muted-color text-sm">{{ capture.capturedAt | date:'short' }}</td>
             </tr>

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -2,6 +2,8 @@ export type CaptureType = 'QuickNote' | 'Transcript' | 'MeetingNotes';
 
 export type ProcessingStatus = 'Raw' | 'Processing' | 'Processed' | 'Failed';
 
+export type ExtractionStatus = 'None' | 'Pending' | 'Confirmed' | 'Discarded';
+
 export interface ExtractedCommitment {
   description: string;
   direction: 'MineToThem' | 'TheirsToMe';
@@ -39,6 +41,7 @@ export interface Capture {
   rawContent: string;
   captureType: CaptureType;
   processingStatus: ProcessingStatus;
+  extractionStatus: ExtractionStatus;
   aiExtraction: AiExtraction | null;
   failureReason: string | null;
   linkedPersonIds: string[];

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -2,13 +2,45 @@ export type CaptureType = 'QuickNote' | 'Transcript' | 'MeetingNotes';
 
 export type ProcessingStatus = 'Raw' | 'Processing' | 'Processed' | 'Failed';
 
+export interface ExtractedCommitment {
+  description: string;
+  direction: 'MineToThem' | 'TheirsToMe';
+  personHint: string | null;
+  dueDate: string | null;
+}
+
+export interface ExtractedDelegation {
+  description: string;
+  personHint: string | null;
+  dueDate: string | null;
+}
+
+export interface ExtractedObservation {
+  description: string;
+  personHint: string | null;
+  tag: string | null;
+}
+
+export interface AiExtraction {
+  summary: string;
+  commitments: ExtractedCommitment[];
+  delegations: ExtractedDelegation[];
+  observations: ExtractedObservation[];
+  decisions: string[];
+  risksIdentified: string[];
+  suggestedPersonLinks: string[];
+  suggestedInitiativeLinks: string[];
+  confidenceScore: number;
+}
+
 export interface Capture {
   id: string;
   userId: string;
   rawContent: string;
   captureType: CaptureType;
   processingStatus: ProcessingStatus;
-  aiExtraction: string | null;
+  aiExtraction: AiExtraction | null;
+  failureReason: string | null;
   linkedPersonIds: string[];
   linkedInitiativeIds: string[];
   spawnedCommitmentIds: string[];

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
@@ -37,6 +37,22 @@ export class CapturesService {
     return this.http.put<Capture>(`${this.baseUrl}/${id}`, request);
   }
 
+  process(id: string): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/process`, {});
+  }
+
+  retry(id: string): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/retry`, {});
+  }
+
+  confirmExtraction(id: string): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/confirm-extraction`, {});
+  }
+
+  discardExtraction(id: string): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/discard-extraction`, {});
+  }
+
   linkPerson(id: string, personId: string): Observable<Capture> {
     return this.http.post<Capture>(`${this.baseUrl}/${id}/link-person`, { personId });
   }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -837,7 +837,9 @@ app.MapPost("/api/captures/{id:guid}/confirm-extraction", async (
     {
         return Results.NotFound();
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot confirm"))
+    catch (InvalidOperationException ex) when (
+        ex.Message.Contains("Cannot confirm") ||
+        ex.Message.Contains("No extraction to confirm"))
     {
         return Results.Conflict(new { error = ex.Message });
     }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -859,7 +859,9 @@ app.MapPost("/api/captures/{id:guid}/discard-extraction", async (
     {
         return Results.NotFound();
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot discard"))
+    catch (InvalidOperationException ex) when (
+        ex.Message.Contains("Cannot discard") ||
+        ex.Message.Contains("Extraction already confirmed"))
     {
         return Results.Conflict(new { error = ex.Message });
     }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -783,6 +783,86 @@ app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
     }
 }).RequireAuthorization();
 
+app.MapPost("/api/captures/{id:guid}/process", async (
+    Guid id,
+    ProcessCaptureHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, cancellationToken);
+        return Results.Accepted(null, response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot begin processing"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/captures/{id:guid}/retry", async (
+    Guid id,
+    RetryProcessingHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot retry"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/captures/{id:guid}/confirm-extraction", async (
+    Guid id,
+    ConfirmExtractionHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot confirm"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/captures/{id:guid}/discard-extraction", async (
+    Guid id,
+    DiscardExtractionHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot discard"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
 // --- Commitment Endpoints ---
 
 app.MapPost("/api/commitments", async (

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -352,4 +352,124 @@ public class CaptureTests
         Assert.Single(capture.SpawnedObservationIds);
         Assert.Contains(observationId, capture.SpawnedObservationIds);
     }
+
+    // ConfirmExtraction tests
+    [Fact]
+    public void ConfirmExtraction_FromProcessed_SetsConfirmedAndRaisesEvent()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ClearDomainEvents();
+
+        capture.ConfirmExtraction();
+
+        Assert.Equal(ExtractionStatus.Confirmed, capture.ExtractionStatus);
+        var domainEvent = Assert.Single(capture.DomainEvents);
+        Assert.IsType<CaptureExtractionConfirmed>(domainEvent);
+    }
+
+    [Fact]
+    public void ConfirmExtraction_FromRaw_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<InvalidOperationException>(() => capture.ConfirmExtraction());
+    }
+
+    [Fact]
+    public void ConfirmExtraction_AlreadyConfirmed_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ConfirmExtraction();
+
+        Assert.Throws<InvalidOperationException>(() => capture.ConfirmExtraction());
+    }
+
+    [Fact]
+    public void ConfirmExtraction_NullExtraction_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        // Manually transition to Processed without extraction not possible via public API
+        // This tests the guard at domain level
+        Assert.Throws<InvalidOperationException>(() => capture.ConfirmExtraction());
+    }
+
+    // DiscardExtraction tests
+    [Fact]
+    public void DiscardExtraction_FromProcessedPending_SetsDiscardedAndRaisesEvent()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ClearDomainEvents();
+
+        capture.DiscardExtraction();
+
+        Assert.Equal(ExtractionStatus.Discarded, capture.ExtractionStatus);
+        Assert.NotNull(capture.AiExtraction); // retained for reference
+        var domainEvent = Assert.Single(capture.DomainEvents);
+        Assert.IsType<CaptureExtractionDiscarded>(domainEvent);
+    }
+
+    [Fact]
+    public void DiscardExtraction_FromRaw_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<InvalidOperationException>(() => capture.DiscardExtraction());
+    }
+
+    [Fact]
+    public void DiscardExtraction_AlreadyConfirmed_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ConfirmExtraction();
+
+        Assert.Throws<InvalidOperationException>(() => capture.DiscardExtraction());
+    }
+
+    [Fact]
+    public void DiscardExtraction_AlreadyDiscarded_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.DiscardExtraction();
+
+        Assert.Throws<InvalidOperationException>(() => capture.DiscardExtraction());
+    }
+
+    // ExtractionStatus lifecycle
+    [Fact]
+    public void ExtractionStatus_FullLifecycle()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        Assert.Equal(ExtractionStatus.None, capture.ExtractionStatus);
+
+        capture.BeginProcessing();
+        Assert.Equal(ExtractionStatus.None, capture.ExtractionStatus);
+
+        capture.CompleteProcessing(CreateTestExtraction());
+        Assert.Equal(ExtractionStatus.Pending, capture.ExtractionStatus);
+
+        capture.ConfirmExtraction();
+        Assert.Equal(ExtractionStatus.Confirmed, capture.ExtractionStatus);
+    }
+
+    [Fact]
+    public void RetryProcessing_ResetsExtractionStatus()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.FailProcessing("error");
+        capture.RetryProcessing();
+
+        Assert.Equal(ExtractionStatus.None, capture.ExtractionStatus);
+    }
 }

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -6,6 +6,11 @@ public class CaptureTests
 {
     private static readonly Guid UserId = Guid.NewGuid();
 
+    private static AiExtraction CreateTestExtraction(string summary = "Test summary") => new()
+    {
+        Summary = summary,
+    };
+
     // 2.1 Test Capture creation with valid inputs and domain event
     [Fact]
     public void Create_ValidInputs_CreatesCaptureWithCorrectState()
@@ -73,10 +78,11 @@ public class CaptureTests
         capture.BeginProcessing();
         capture.ClearDomainEvents();
 
-        capture.CompleteProcessing("extracted data");
+        var extraction = CreateTestExtraction("extracted data");
+        capture.CompleteProcessing(extraction);
 
         Assert.Equal(ProcessingStatus.Processed, capture.ProcessingStatus);
-        Assert.Equal("extracted data", capture.AiExtraction);
+        Assert.Equal(extraction, capture.AiExtraction);
         Assert.NotNull(capture.ProcessedAt);
         var domainEvent = Assert.Single(capture.DomainEvents);
         Assert.IsType<CaptureProcessed>(domainEvent);
@@ -127,7 +133,7 @@ public class CaptureTests
     {
         var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
         capture.BeginProcessing();
-        capture.CompleteProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
 
         Assert.Throws<InvalidOperationException>(() => capture.BeginProcessing());
     }
@@ -137,7 +143,7 @@ public class CaptureTests
     {
         var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
 
-        Assert.Throws<InvalidOperationException>(() => capture.CompleteProcessing());
+        Assert.Throws<InvalidOperationException>(() => capture.CompleteProcessing(CreateTestExtraction()));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements the capture-ai-extraction feature — an AI-powered pipeline that processes raw captures (quick notes, transcripts, meeting notes) to extract structured data: commitments, delegations, observations, decisions, risks, and suggested person/initiative links. Users can review extraction results and confirm to spawn entities, or discard.

**Spec**: [capture-ai-extraction](openspec/specs/capture-ai-extraction/spec.md)

## Changes

- **Domain:** Added `AiExtraction` value object (with `ExtractedCommitment`, `ExtractedDelegation`, `ExtractedObservation` nested records). Updated `Capture` aggregate: structured `AiExtraction` property (replaces plain string), `FailureReason`, `ConfirmExtraction()`, `DiscardExtraction()` methods, and two new domain events.
- **Application:** Created 4 new handlers: `ProcessCaptureHandler` (orchestrates AI extraction pipeline via `IAiCompletionService`), `RetryProcessingHandler`, `ConfirmExtractionHandler` (spawns Commitment/Delegation entities with fuzzy person/initiative matching), `DiscardExtractionHandler`. Updated DTOs for structured extraction response.
- **Infrastructure:** Updated EF Core `CaptureConfiguration` for JSON column storage (`OwnsOne` + `ToJson()`). Created migration `AddAiExtractionJsonAndFailureReason`. Registered 4 new handlers in DI.
- **API:** Added 4 endpoints: `POST /api/captures/{id}/process`, `/retry`, `/confirm-extraction`, `/discard-extraction` with appropriate HTTP status codes (202, 409, 404).
- **Frontend:** Updated TypeScript models and `CapturesService` with new API methods. Capture detail view now has: "Process with AI" button (Raw status), animated spinner (Processing), error banner + Retry (Failed), full extraction review panel with organized sections (Processed) — Confirm & Create / Discard actions. List view shows animated spinner for Processing status.

## Test Plan

- [ ] `dotnet build` succeeds (0 errors)
- [ ] `ng test --watch=false` passes (14/14)
- [ ] Create a Raw capture → click "Process with AI" → verify extraction appears
- [ ] Review extraction panel shows commitments, delegations, observations, decisions, risks
- [ ] Click "Confirm & Create" → verify spawned entities appear with correct SourceCaptureId
- [ ] Click "Discard" → verify no entities spawned, extraction retained for reference
- [ ] Retry flow: failed capture → Retry → reprocess
- [ ] Person matching: extraction person hints match existing people by name similarity
- [ ] Auto-linking: suggested person/initiative links automatically applied on confirm

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI extraction now returns structured insights (summary, typed items, suggested links) with a confidence score and explicit extraction status/failure reason.
  * UI adds “Process with AI”, a review panel with details/confidence, and actions to Confirm (which can create commitments/delegations) or Discard an extraction; Retry shown on failure.
  * Server endpoints added to process, retry, confirm, and discard extractions; DB migrations persist structured extraction JSON and status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->