### PR TITLE
fix: Address critical review feedback from merged PRs

### DIFF
--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -38,7 +38,7 @@ public sealed record ExtractedCommitmentResponse(string Description, string Dire
 public sealed record ExtractedDelegationResponse(string Description, string? PersonHint, string? DueDate);
 public sealed record ExtractedObservationResponse(string Description, string? PersonHint, string? Tag);
 
-public sealed record ConfirmExtractionResponse(CaptureResponse Capture, List<string> Warnings);
+public sealed record ConfirmExtractionResponse(CaptureResponse Capture, IReadOnlyList<string> Warnings);
 
 public sealed record CaptureResponse(
     Guid Id,

--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -38,6 +38,8 @@ public sealed record ExtractedCommitmentResponse(string Description, string Dire
 public sealed record ExtractedDelegationResponse(string Description, string? PersonHint, string? DueDate);
 public sealed record ExtractedObservationResponse(string Description, string? PersonHint, string? Tag);
 
+public sealed record ConfirmExtractionResponse(CaptureResponse Capture, List<string> Warnings);
+
 public sealed record CaptureResponse(
     Guid Id,
     Guid UserId,

--- a/src/MentalMetal.Application/Captures/CaptureOwnershipExtensions.cs
+++ b/src/MentalMetal.Application/Captures/CaptureOwnershipExtensions.cs
@@ -1,0 +1,18 @@
+using MentalMetal.Domain.Captures;
+
+namespace MentalMetal.Application.Captures;
+
+internal static class CaptureOwnershipExtensions
+{
+    /// <summary>
+    /// Returns the capture if it exists and belongs to the given user,
+    /// otherwise throws InvalidOperationException (treated as not-found by endpoints).
+    /// </summary>
+    public static Capture EnsureOwned(this Capture? capture, Guid userId, Guid captureId)
+    {
+        if (capture is null || capture.UserId != userId)
+            throw new InvalidOperationException($"Capture not found: {captureId}");
+
+        return capture;
+    }
+}

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -18,15 +18,18 @@ public sealed class ConfirmExtractionHandler(
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
-    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    public async Task<ConfirmExtractionResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
-            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+
+        if (capture is null || capture.UserId != currentUserService.UserId)
+            throw new InvalidOperationException($"Capture not found: {captureId}");
 
         capture.ConfirmExtraction();
 
         var extraction = capture.AiExtraction!;
         var userId = currentUserService.UserId;
+        var warnings = new List<string>();
 
         // Load all people and initiatives for matching
         var people = await personRepository.GetAllAsync(userId, null, false, cancellationToken);
@@ -36,7 +39,11 @@ public sealed class ConfirmExtractionHandler(
         foreach (var ec in extraction.Commitments)
         {
             var personId = MatchPerson(ec.PersonHint, people);
-            if (personId == Guid.Empty) continue; // Skip if no person match — PersonId is required
+            if (personId == Guid.Empty)
+            {
+                warnings.Add($"Commitment skipped — no matching person for \"{ec.PersonHint ?? "(none)"}\": {ec.Description}");
+                continue;
+            }
 
             var direction = ec.Direction == ExtractionDirection.MineToThem
                 ? CommitmentDirection.MineToThem
@@ -54,7 +61,11 @@ public sealed class ConfirmExtractionHandler(
         foreach (var ed in extraction.Delegations)
         {
             var personId = MatchPerson(ed.PersonHint, people);
-            if (personId == Guid.Empty) continue; // Skip if no person match — DelegatePersonId is required
+            if (personId == Guid.Empty)
+            {
+                warnings.Add($"Delegation skipped — no matching person for \"{ed.PersonHint ?? "(none)"}\": {ed.Description}");
+                continue;
+            }
 
             DateOnly? dueDate = ParseIsoDate(ed.DueDate);
 
@@ -81,7 +92,7 @@ public sealed class ConfirmExtractionHandler(
         }
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return CaptureResponse.From(capture);
+        return new ConfirmExtractionResponse(CaptureResponse.From(capture), warnings);
     }
 
     private static DateOnly? ParseIsoDate(string? value) =>

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -92,7 +92,7 @@ public sealed class ConfirmExtractionHandler(
         }
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return new ConfirmExtractionResponse(CaptureResponse.From(capture), warnings);
+        return new ConfirmExtractionResponse(CaptureResponse.From(capture), warnings.AsReadOnly());
     }
 
     private static DateOnly? ParseIsoDate(string? value) =>

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -39,7 +39,8 @@ public sealed class ConfirmExtractionHandler(
             var personId = MatchPerson(ec.PersonHint, people);
             if (personId == Guid.Empty)
             {
-                warnings.Add($"Commitment skipped — no matching person for \"{ec.PersonHint ?? "(none)"}\": {ec.Description}");
+                var hint = string.IsNullOrWhiteSpace(ec.PersonHint) ? "(none)" : ec.PersonHint;
+                warnings.Add($"Commitment skipped — no matching person for \"{hint}\": {ec.Description}");
                 continue;
             }
 
@@ -61,7 +62,8 @@ public sealed class ConfirmExtractionHandler(
             var personId = MatchPerson(ed.PersonHint, people);
             if (personId == Guid.Empty)
             {
-                warnings.Add($"Delegation skipped — no matching person for \"{ed.PersonHint ?? "(none)"}\": {ed.Description}");
+                var hint = string.IsNullOrWhiteSpace(ed.PersonHint) ? "(none)" : ed.PersonHint;
+                warnings.Add($"Delegation skipped — no matching person for \"{hint}\": {ed.Description}");
                 continue;
             }
 

--- a/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
+++ b/src/MentalMetal.Application/Captures/ConfirmExtraction.cs
@@ -20,10 +20,8 @@ public sealed class ConfirmExtractionHandler(
 {
     public async Task<ConfirmExtractionResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
-
-        if (capture is null || capture.UserId != currentUserService.UserId)
-            throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(currentUserService.UserId, captureId);
 
         capture.ConfirmExtraction();
 

--- a/src/MentalMetal.Application/Captures/DiscardExtraction.cs
+++ b/src/MentalMetal.Application/Captures/DiscardExtraction.cs
@@ -10,10 +10,8 @@ public sealed class DiscardExtractionHandler(
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
-
-        if (capture is null || capture.UserId != currentUserService.UserId)
-            throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(currentUserService.UserId, captureId);
 
         capture.DiscardExtraction();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Captures/DiscardExtraction.cs
+++ b/src/MentalMetal.Application/Captures/DiscardExtraction.cs
@@ -1,15 +1,19 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
 namespace MentalMetal.Application.Captures;
 
 public sealed class DiscardExtractionHandler(
     ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
-            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+
+        if (capture is null || capture.UserId != currentUserService.UserId)
+            throw new InvalidOperationException($"Capture not found: {captureId}");
 
         capture.DiscardExtraction();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -12,10 +12,8 @@ public sealed class ProcessCaptureHandler(
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
-
-        if (capture is null || capture.UserId != currentUserService.UserId)
-            throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(currentUserService.UserId, captureId);
 
         capture.BeginProcessing();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -1,17 +1,21 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Application.Common.Ai;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
 namespace MentalMetal.Application.Captures;
 
 public sealed class ProcessCaptureHandler(
     ICaptureRepository captureRepository,
     IAiCompletionService aiCompletionService,
+    ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
-            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+
+        if (capture is null || capture.UserId != currentUserService.UserId)
+            throw new InvalidOperationException($"Capture not found: {captureId}");
 
         capture.BeginProcessing();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Captures/RetryProcessing.cs
+++ b/src/MentalMetal.Application/Captures/RetryProcessing.cs
@@ -1,15 +1,19 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
 namespace MentalMetal.Application.Captures;
 
 public sealed class RetryProcessingHandler(
     ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken)
-            ?? throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+
+        if (capture is null || capture.UserId != currentUserService.UserId)
+            throw new InvalidOperationException($"Capture not found: {captureId}");
 
         capture.RetryProcessing();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Captures/RetryProcessing.cs
+++ b/src/MentalMetal.Application/Captures/RetryProcessing.cs
@@ -10,10 +10,8 @@ public sealed class RetryProcessingHandler(
 {
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
-
-        if (capture is null || capture.UserId != currentUserService.UserId)
-            throw new InvalidOperationException($"Capture not found: {captureId}");
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(currentUserService.UserId, captureId);
 
         capture.RetryProcessing();
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/MentalMetal.Application/Users/ValidateAiProvider.cs
+++ b/src/MentalMetal.Application/Users/ValidateAiProvider.cs
@@ -12,6 +12,9 @@ public sealed class ValidateAiProviderHandler(IAiProviderValidator providerValid
             || !Enum.IsDefined(provider))
             return new ValidateAiProviderResponse(false, null, $"Unsupported provider: {request.Provider}");
 
+        if (string.IsNullOrWhiteSpace(request.ApiKey))
+            return new ValidateAiProviderResponse(false, null, "API key is required.");
+
         try
         {
             var model = await providerValidator.ValidateAsync(

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -34,12 +34,9 @@ public sealed class AnthropicAdapter : IAiProviderAdapter
                 cancellationToken: cancellationToken);
 
             var text = "";
-            if (response.Content.Count > 0)
-            {
-                var firstBlock = response.Content[0];
-                if (firstBlock.IsText)
-                    text = firstBlock.Text.Text;
-            }
+            var firstBlock = response.Content.FirstOrDefault();
+            if (firstBlock is not null && firstBlock.IsText)
+                text = firstBlock.Text.Text;
 
             return new AiCompletionResult(
                 Content: text,

--- a/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/OpenAiAdapter.cs
@@ -31,9 +31,10 @@ public sealed class OpenAiAdapter : IAiProviderAdapter
         {
             var response = await client.CompleteChatAsync(messages, options, cancellationToken);
 
-            var content = response.Value.Content.Count > 0
-                ? response.Value.Content[0].Text
-                : "";
+            var firstPart = response.Value.Content.Count > 0
+                ? response.Value.Content[0]
+                : null;
+            var content = firstPart?.Text ?? "";
 
             return new AiCompletionResult(
                 Content: content,

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -492,11 +492,16 @@ export class CaptureDetailComponent implements OnInit {
 
     this.confirming.set(true);
     this.capturesService.confirmExtraction(c.id).subscribe({
-      next: (updated) => {
-        this.capture.set(updated);
+      next: (result) => {
+        this.capture.set(result.capture);
         this.confirming.set(false);
-        this.loadLinkedPeople(updated.linkedPersonIds);
-        this.loadLinkedInitiatives(updated.linkedInitiativeIds);
+        this.loadLinkedPeople(result.capture.linkedPersonIds);
+        this.loadLinkedInitiatives(result.capture.linkedInitiativeIds);
+        if (result.warnings.length > 0) {
+          for (const warning of result.warnings) {
+            this.messageService.add({ severity: 'warn', summary: 'Skipped item', detail: warning, life: 8000 });
+          }
+        }
         this.messageService.add({ severity: 'success', summary: 'Entities created from extraction' });
       },
       error: () => {

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -75,3 +75,8 @@ export interface LinkPersonRequest {
 export interface LinkInitiativeRequest {
   initiativeId: string;
 }
+
+export interface ConfirmExtractionResponse {
+  capture: Capture;
+  warnings: string[];
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import {
   Capture,
   CaptureType,
+  ConfirmExtractionResponse,
   CreateCaptureRequest,
   ProcessingStatus,
   UpdateCaptureMetadataRequest,
@@ -45,8 +46,8 @@ export class CapturesService {
     return this.http.post<Capture>(`${this.baseUrl}/${id}/retry`, {});
   }
 
-  confirmExtraction(id: string): Observable<Capture> {
-    return this.http.post<Capture>(`${this.baseUrl}/${id}/confirm-extraction`, {});
+  confirmExtraction(id: string): Observable<ConfirmExtractionResponse> {
+    return this.http.post<ConfirmExtractionResponse>(`${this.baseUrl}/${id}/confirm-extraction`, {});
   }
 
   discardExtraction(id: string): Observable<Capture> {

--- a/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/ValidateAiProviderTests.cs
@@ -52,4 +52,17 @@ public class ValidateAiProviderTests
         Assert.False(result.Success);
         Assert.Contains("Unsupported provider", result.Error);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BlankApiKey_ReturnsFailure(string? apiKey)
+    {
+        var request = new ValidateAiProviderRequest("Anthropic", apiKey!, "model");
+        var result = await _handler.HandleAsync(request, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal("API key is required.", result.Error);
+    }
 }


### PR DESCRIPTION
## Summary

Addresses critical security, data-integrity, and null-safety issues flagged in review comments on merged PRs #68, #49, #48, and #59.

## Changes

- **Ownership checks (PR #68)**: `ProcessCapture`, `RetryProcessing`, `DiscardExtraction`, and `ConfirmExtraction` handlers now verify `capture.UserId == currentUser.UserId`, treating non-owned captures as not-found
- **Silently dropped items (PR #68)**: `ConfirmExtraction` now returns a `ConfirmExtractionResponse` with a `Warnings` list when commitments/delegations are skipped due to unmatched person hints; frontend displays these as toast notifications
- **ApiKey validation (PR #48)**: `ValidateAiProvider` now guards against null/whitespace API keys before calling the provider
- **Null safety (PR #49)**: `AnthropicAdapter` uses `FirstOrDefault()` instead of index access on `response.Content`; `OpenAiAdapter` guards against empty `Content` list

### Already addressed in prior commits (verified, no changes needed)

- PR #68: Broad exception catch in ProcessCapture, culture-invariant date parsing, idempotent confirm guard, JsonDocument disposal
- PR #49: TasteBudgetService uses ExecuteSqlInterpolatedAsync (auto-persisted), GoogleAdapter uses IHttpClientFactory, GetRemainingAsync clamps to 0, Google API key sent via header
- PR #59: HTTP verb mismatches already corrected, IsArchived guards already present
- PR #48: Enum.IsDefined checks, ConfigureAiProvider ApiKey guard, safe error messages in ValidateAiProvider

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (269 tests)
- [x] `ng test --watch=false` passes (14 tests)
- [ ] Verify non-owned capture returns 404 for process/retry/discard/confirm
- [ ] Verify confirm extraction with unmatched person hints returns warnings
- [ ] Verify ValidateAiProvider with blank API key returns error

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce user ownership checks on capture processing endpoints, improve AI adapter null-safety, and surface extraction confirmation warnings to the client.

New Features:
- Return a structured ConfirmExtractionResponse including capture data and human-readable warnings when extracted commitments or delegations are skipped.

Bug Fixes:
- Guard capture processing, retry, discard, and confirm handlers so that only the owning user can operate on a capture, treating non-owned or missing captures as not found.
- Prevent null or empty API keys from being validated by ValidateAiProvider, returning a clear error instead.
- Harden Anthropic and OpenAI adapter response handling to safely deal with empty or missing content blocks.

Enhancements:
- Expose extraction confirmation warnings in the Angular client and display them as toast notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extraction confirmation now returns and displays per-entry warnings for unmatched items.

* **Bug Fixes**
  * Captures are strictly validated to ensure only the owner can access them.
  * AI provider validation now requires a non-empty API key and surfaces a clear error when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->