### PR TITLE
fix: Address correctness bugs from PR reviews

### DIFF
--- a/src/MentalMetal.Application/Initiatives/AddMilestone.cs
+++ b/src/MentalMetal.Application/Initiatives/AddMilestone.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class AddMilestoneHandler(
         Guid initiativeId, MilestoneRequest request, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.AddMilestone(request.Title, request.TargetDate, request.Description);
 

--- a/src/MentalMetal.Application/Initiatives/ChangeInitiativeStatus.cs
+++ b/src/MentalMetal.Application/Initiatives/ChangeInitiativeStatus.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class ChangeInitiativeStatusHandler(
         Guid initiativeId, ChangeStatusRequest request, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.ChangeStatus(request.NewStatus);
 

--- a/src/MentalMetal.Application/Initiatives/CompleteMilestone.cs
+++ b/src/MentalMetal.Application/Initiatives/CompleteMilestone.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class CompleteMilestoneHandler(
         Guid initiativeId, Guid milestoneId, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.CompleteMilestone(milestoneId);
 

--- a/src/MentalMetal.Application/Initiatives/LinkPerson.cs
+++ b/src/MentalMetal.Application/Initiatives/LinkPerson.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.People;
 using MentalMetal.Domain.Users;
@@ -15,15 +16,15 @@ public sealed class LinkPersonHandler(
         Guid initiativeId, LinkPersonRequest request, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         var person = await personRepository.GetByIdAsync(request.PersonId, cancellationToken);
 
         if (person is null || person.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Person not found.");
+            throw new NotFoundException("Person", request.PersonId);
 
         initiative.LinkPerson(request.PersonId);
 

--- a/src/MentalMetal.Application/Initiatives/RemoveMilestone.cs
+++ b/src/MentalMetal.Application/Initiatives/RemoveMilestone.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class RemoveMilestoneHandler(
         Guid initiativeId, Guid milestoneId, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.RemoveMilestone(milestoneId);
 

--- a/src/MentalMetal.Application/Initiatives/UnlinkPerson.cs
+++ b/src/MentalMetal.Application/Initiatives/UnlinkPerson.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class UnlinkPersonHandler(
         Guid initiativeId, Guid personId, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.UnlinkPerson(personId);
 

--- a/src/MentalMetal.Application/Initiatives/UpdateInitiativeTitle.cs
+++ b/src/MentalMetal.Application/Initiatives/UpdateInitiativeTitle.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class UpdateInitiativeTitleHandler(
         Guid initiativeId, UpdateTitleRequest request, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.UpdateTitle(request.Title);
 

--- a/src/MentalMetal.Application/Initiatives/UpdateMilestone.cs
+++ b/src/MentalMetal.Application/Initiatives/UpdateMilestone.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Common;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Users;
 
@@ -13,10 +14,10 @@ public sealed class UpdateMilestoneHandler(
         Guid initiativeId, Guid milestoneId, MilestoneRequest request, CancellationToken cancellationToken)
     {
         var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken)
-            ?? throw new InvalidOperationException("Initiative not found.");
+            ?? throw new NotFoundException("Initiative", initiativeId);
 
         if (initiative.UserId != currentUserService.UserId)
-            throw new InvalidOperationException("Initiative not found.");
+            throw new NotFoundException("Initiative", initiativeId);
 
         initiative.UpdateMilestone(milestoneId, request.Title, request.TargetDate, request.Description);
 

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -34,6 +34,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(rawContent, nameof(rawContent));
 
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId is required.", nameof(userId));
+
         var now = DateTimeOffset.UtcNow;
 
         var capture = new Capture
@@ -148,6 +151,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void LinkToPerson(Guid personId)
     {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
         if (_linkedPersonIds.Contains(personId))
             return;
 
@@ -159,6 +165,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void UnlinkFromPerson(Guid personId)
     {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
         if (!_linkedPersonIds.Remove(personId))
             return; // idempotent
 
@@ -169,6 +178,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void LinkToInitiative(Guid initiativeId)
     {
+        if (initiativeId == Guid.Empty)
+            throw new ArgumentException("InitiativeId is required.", nameof(initiativeId));
+
         if (_linkedInitiativeIds.Contains(initiativeId))
             return;
 
@@ -180,6 +192,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void UnlinkFromInitiative(Guid initiativeId)
     {
+        if (initiativeId == Guid.Empty)
+            throw new ArgumentException("InitiativeId is required.", nameof(initiativeId));
+
         if (!_linkedInitiativeIds.Remove(initiativeId))
             return; // idempotent
 
@@ -199,6 +214,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void RecordSpawnedCommitment(Guid commitmentId)
     {
+        if (commitmentId == Guid.Empty)
+            throw new ArgumentException("CommitmentId is required.", nameof(commitmentId));
+
         if (_spawnedCommitmentIds.Contains(commitmentId))
             return;
 
@@ -208,6 +226,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void RecordSpawnedDelegation(Guid delegationId)
     {
+        if (delegationId == Guid.Empty)
+            throw new ArgumentException("DelegationId is required.", nameof(delegationId));
+
         if (_spawnedDelegationIds.Contains(delegationId))
             return;
 
@@ -217,6 +238,9 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
     public void RecordSpawnedObservation(Guid observationId)
     {
+        if (observationId == Guid.Empty)
+            throw new ArgumentException("ObservationId is required.", nameof(observationId));
+
         if (_spawnedObservationIds.Contains(observationId))
             return;
 

--- a/src/MentalMetal.Domain/Common/NotFoundException.cs
+++ b/src/MentalMetal.Domain/Common/NotFoundException.cs
@@ -14,6 +14,9 @@ public sealed class NotFoundException : Exception
 
     public NotFoundException(string message) : base(message) { }
 
+    public NotFoundException(string message, Exception innerException)
+        : base(message, innerException) { }
+
     public string? EntityName { get; }
     public Guid? EntityId { get; }
 }

--- a/src/MentalMetal.Domain/Common/NotFoundException.cs
+++ b/src/MentalMetal.Domain/Common/NotFoundException.cs
@@ -1,0 +1,19 @@
+namespace MentalMetal.Domain.Common;
+
+/// <summary>
+/// Thrown when a requested aggregate or entity is not found.
+/// </summary>
+public sealed class NotFoundException : Exception
+{
+    public NotFoundException(string entityName, Guid id)
+        : base($"{entityName} '{id}' not found.")
+    {
+        EntityName = entityName;
+        EntityId = id;
+    }
+
+    public NotFoundException(string message) : base(message) { }
+
+    public string? EntityName { get; }
+    public Guid? EntityId { get; }
+}

--- a/src/MentalMetal.Domain/Initiatives/Initiative.cs
+++ b/src/MentalMetal.Domain/Initiatives/Initiative.cs
@@ -21,6 +21,9 @@ public sealed class Initiative : AggregateRoot, IUserScoped
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(title, nameof(title));
 
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId is required.", nameof(userId));
+
         var now = DateTimeOffset.UtcNow;
 
         var initiative = new Initiative
@@ -94,8 +97,7 @@ public sealed class Initiative : AggregateRoot, IUserScoped
         var existing = _milestones.FirstOrDefault(m => m.Id == milestoneId)
             ?? throw new ArgumentException($"Milestone '{milestoneId}' not found.");
 
-        _milestones.Remove(existing);
-        _milestones.Add(existing.WithUpdates(title, targetDate, description));
+        existing.ApplyUpdates(title, targetDate, description);
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new MilestoneSet(Id, milestoneId));
@@ -121,8 +123,7 @@ public sealed class Initiative : AggregateRoot, IUserScoped
         var existing = _milestones.FirstOrDefault(m => m.Id == milestoneId)
             ?? throw new ArgumentException($"Milestone '{milestoneId}' not found.");
 
-        _milestones.Remove(existing);
-        _milestones.Add(existing.Complete());
+        existing.Complete();
         UpdatedAt = DateTimeOffset.UtcNow;
 
         RaiseDomainEvent(new MilestoneCompleted(Id, milestoneId));

--- a/src/MentalMetal.Domain/Initiatives/Milestone.cs
+++ b/src/MentalMetal.Domain/Initiatives/Milestone.cs
@@ -26,7 +26,7 @@ public sealed class Milestone : ValueObject
         };
     }
 
-    public void Complete()
+    internal void Complete()
     {
         IsCompleted = true;
     }

--- a/src/MentalMetal.Domain/Initiatives/Milestone.cs
+++ b/src/MentalMetal.Domain/Initiatives/Milestone.cs
@@ -26,30 +26,18 @@ public sealed class Milestone : ValueObject
         };
     }
 
-    public Milestone Complete()
+    public void Complete()
     {
-        return new Milestone
-        {
-            Id = Id,
-            Title = Title,
-            TargetDate = TargetDate,
-            Description = Description,
-            IsCompleted = true
-        };
+        IsCompleted = true;
     }
 
-    internal Milestone WithUpdates(string title, DateOnly targetDate, string? description)
+    internal void ApplyUpdates(string title, DateOnly targetDate, string? description)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(title, nameof(title));
 
-        return new Milestone
-        {
-            Id = Id,
-            Title = title.Trim(),
-            TargetDate = targetDate,
-            Description = description?.Trim(),
-            IsCompleted = IsCompleted
-        };
+        Title = title.Trim();
+        TargetDate = targetDate;
+        Description = description?.Trim();
     }
 
     protected override IEnumerable<object?> GetEqualityComponents()

--- a/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AnthropicAdapter.cs
@@ -34,9 +34,12 @@ public sealed class AnthropicAdapter : IAiProviderAdapter
                 cancellationToken: cancellationToken);
 
             var text = "";
-            var firstBlock = response.Content.FirstOrDefault();
-            if (firstBlock is not null && firstBlock.IsText)
-                text = firstBlock.Text.Text;
+            if (response.Content.Count > 0)
+            {
+                var firstBlock = response.Content[0];
+                if (firstBlock.IsText)
+                    text = firstBlock.Text.Text;
+            }
 
             return new AiCompletionResult(
                 Content: text,

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -304,11 +304,11 @@ import { Initiative } from '../../../shared/models/initiative.model';
           <div class="flex items-end gap-4">
             <div class="flex flex-col gap-2 flex-1">
               <label for="title" class="text-sm font-medium text-muted-color">Title</label>
-              <input pInputText id="title" [(ngModel)]="editTitle" class="w-full" />
+              <input pInputText id="title" [ngModel]="editTitle()" (ngModelChange)="editTitle.set($event)" class="w-full" />
             </div>
             <div class="flex flex-col gap-2 flex-1">
               <label for="source" class="text-sm font-medium text-muted-color">Source</label>
-              <input pInputText id="source" [(ngModel)]="editSource" class="w-full" />
+              <input pInputText id="source" [ngModel]="editSource()" (ngModelChange)="editSource.set($event)" class="w-full" />
             </div>
             <p-button
               label="Save"
@@ -338,7 +338,8 @@ import { Initiative } from '../../../shared/models/initiative.model';
               <label for="linkPerson" class="text-sm font-medium text-muted-color">Add Person</label>
               <p-autoComplete
                 id="linkPerson"
-                [(ngModel)]="selectedPerson"
+                [ngModel]="selectedPerson()"
+                (ngModelChange)="selectedPerson.set($event)"
                 [suggestions]="peopleSuggestions()"
                 (completeMethod)="searchPeople($event)"
                 field="name"
@@ -353,7 +354,7 @@ import { Initiative } from '../../../shared/models/initiative.model';
               [outlined]="true"
               (onClick)="linkPerson()"
               [loading]="linkingPerson()"
-              [disabled]="!selectedPerson"
+              [disabled]="!selectedPerson()"
             />
           </div>
         </section>
@@ -377,7 +378,8 @@ import { Initiative } from '../../../shared/models/initiative.model';
               <label for="linkInitiative" class="text-sm font-medium text-muted-color">Add Initiative</label>
               <p-autoComplete
                 id="linkInitiative"
-                [(ngModel)]="selectedInitiative"
+                [ngModel]="selectedInitiative()"
+                (ngModelChange)="selectedInitiative.set($event)"
                 [suggestions]="initiativeSuggestions()"
                 (completeMethod)="searchInitiatives($event)"
                 field="title"
@@ -392,7 +394,7 @@ import { Initiative } from '../../../shared/models/initiative.model';
               [outlined]="true"
               (onClick)="linkInitiative()"
               [loading]="linkingInitiative()"
-              [disabled]="!selectedInitiative"
+              [disabled]="!selectedInitiative()"
             />
           </div>
         </section>
@@ -422,10 +424,10 @@ export class CaptureDetailComponent implements OnInit {
   readonly peopleSuggestions = signal<Person[]>([]);
   readonly initiativeSuggestions = signal<Initiative[]>([]);
 
-  protected editTitle = '';
-  protected editSource = '';
-  protected selectedPerson: Person | null = null;
-  protected selectedInitiative: Initiative | null = null;
+  readonly editTitle = signal('');
+  readonly editSource = signal('');
+  readonly selectedPerson = signal<Person | null>(null);
+  readonly selectedInitiative = signal<Initiative | null>(null);
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -441,7 +443,7 @@ export class CaptureDetailComponent implements OnInit {
   protected metadataChanged(): boolean {
     const c = this.capture();
     if (!c) return false;
-    return this.editTitle !== (c.title ?? '') || this.editSource !== (c.source ?? '');
+    return this.editTitle() !== (c.title ?? '') || this.editSource() !== (c.source ?? '');
   }
 
   protected processCapture(): void {
@@ -535,13 +537,13 @@ export class CaptureDetailComponent implements OnInit {
 
     this.savingMetadata.set(true);
     this.capturesService.updateMetadata(c.id, {
-      title: this.editTitle.trim() || null,
-      source: this.editSource.trim() || null,
+      title: this.editTitle().trim() || null,
+      source: this.editSource().trim() || null,
     }).subscribe({
       next: (updated) => {
         this.capture.set(updated);
-        this.editTitle = updated.title ?? '';
-        this.editSource = updated.source ?? '';
+        this.editTitle.set(updated.title ?? '');
+        this.editSource.set(updated.source ?? '');
         this.savingMetadata.set(false);
         this.messageService.add({ severity: 'success', summary: 'Metadata updated' });
       },
@@ -568,17 +570,17 @@ export class CaptureDetailComponent implements OnInit {
 
   protected linkPerson(): void {
     const c = this.capture();
-    if (!c || !this.selectedPerson) return;
+    if (!c || !this.selectedPerson()) return;
 
     this.linkingPerson.set(true);
-    const personToLink = this.selectedPerson;
+    const personToLink = this.selectedPerson()!;
     this.capturesService.linkPerson(c.id, personToLink.id).subscribe({
       next: (updated) => {
         this.capture.set(updated);
         this.linkedPeople.update((list) =>
           list.some((p) => p.id === personToLink.id) ? list : [...list, personToLink]
         );
-        this.selectedPerson = null;
+        this.selectedPerson.set(null);
         this.linkingPerson.set(false);
         this.messageService.add({ severity: 'success', summary: 'Person linked' });
       },
@@ -621,17 +623,17 @@ export class CaptureDetailComponent implements OnInit {
 
   protected linkInitiative(): void {
     const c = this.capture();
-    if (!c || !this.selectedInitiative) return;
+    if (!c || !this.selectedInitiative()) return;
 
     this.linkingInitiative.set(true);
-    const initiativeToLink = this.selectedInitiative;
+    const initiativeToLink = this.selectedInitiative()!;
     this.capturesService.linkInitiative(c.id, initiativeToLink.id).subscribe({
       next: (updated) => {
         this.capture.set(updated);
         this.linkedInitiatives.update((list) =>
           list.some((i) => i.id === initiativeToLink.id) ? list : [...list, initiativeToLink]
         );
-        this.selectedInitiative = null;
+        this.selectedInitiative.set(null);
         this.linkingInitiative.set(false);
         this.messageService.add({ severity: 'success', summary: 'Initiative linked' });
       },
@@ -697,8 +699,8 @@ export class CaptureDetailComponent implements OnInit {
     this.capturesService.get(id).subscribe({
       next: (capture) => {
         this.capture.set(capture);
-        this.editTitle = capture.title ?? '';
-        this.editSource = capture.source ?? '';
+        this.editTitle.set(capture.title ?? '');
+        this.editSource.set(capture.source ?? '');
         this.loadLinkedPeople(capture.linkedPersonIds);
         this.loadLinkedInitiatives(capture.linkedInitiativeIds);
         this.loading.set(false);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
@@ -25,16 +25,16 @@ import { QuickCaptureDialogComponent } from '../quick-capture-dialog/quick-captu
       <div class="flex items-center gap-4">
         <p-select
           [options]="typeFilterOptions"
-          [(ngModel)]="selectedType"
-          (ngModelChange)="onFilterChange()"
+          [ngModel]="selectedType()"
+          (ngModelChange)="selectedType.set($event); onFilterChange()"
           placeholder="All Types"
           [showClear]="true"
           class="w-48"
         />
         <p-select
           [options]="statusFilterOptions"
-          [(ngModel)]="selectedStatus"
-          (ngModelChange)="onFilterChange()"
+          [ngModel]="selectedStatus()"
+          (ngModelChange)="selectedStatus.set($event); onFilterChange()"
           placeholder="All Statuses"
           [showClear]="true"
           class="w-48"
@@ -101,8 +101,8 @@ export class CapturesListComponent implements OnInit {
   readonly captures = signal<Capture[]>([]);
   readonly loading = signal(true);
   readonly showCreateDialog = signal(false);
-  protected selectedType: CaptureType | null = null;
-  protected selectedStatus: ProcessingStatus | null = null;
+  readonly selectedType = signal<CaptureType | null>(null);
+  readonly selectedStatus = signal<ProcessingStatus | null>(null);
 
   protected readonly typeFilterOptions = [
     { label: 'Quick Note', value: 'QuickNote' as CaptureType },
@@ -173,7 +173,7 @@ export class CapturesListComponent implements OnInit {
 
   private loadCaptures(): void {
     this.loading.set(true);
-    this.capturesService.list(this.selectedType ?? undefined, this.selectedStatus ?? undefined).subscribe({
+    this.capturesService.list(this.selectedType() ?? undefined, this.selectedStatus() ?? undefined).subscribe({
       next: (captures) => {
         this.captures.set(captures);
         this.loading.set(false);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
@@ -238,6 +238,7 @@ export class CommitmentsListComponent implements OnInit {
         this.loading.set(false);
       },
       error: () => {
+        this.commitments.set([]);
         this.loading.set(false);
         this.messageService.add({ severity: 'error', summary: 'Failed to load commitments' });
       },

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitments-list/commitments-list.component.ts
@@ -31,24 +31,24 @@ import { CommitmentDialogComponent } from '../commitment-dialog/commitment-dialo
       <div class="flex items-center gap-4 flex-wrap">
         <p-select
           [options]="directionFilterOptions"
-          [(ngModel)]="selectedDirection"
-          (ngModelChange)="onFilterChange()"
+          [ngModel]="selectedDirection()"
+          (ngModelChange)="selectedDirection.set($event); onFilterChange()"
           placeholder="All Directions"
           [showClear]="true"
           class="w-48"
         />
         <p-select
           [options]="statusFilterOptions"
-          [(ngModel)]="selectedStatus"
-          (ngModelChange)="onFilterChange()"
+          [ngModel]="selectedStatus()"
+          (ngModelChange)="selectedStatus.set($event); onFilterChange()"
           placeholder="All Statuses"
           [showClear]="true"
           class="w-48"
         />
         <p-select
           [options]="overdueFilterOptions"
-          [(ngModel)]="selectedOverdue"
-          (ngModelChange)="onFilterChange()"
+          [ngModel]="selectedOverdue()"
+          (ngModelChange)="selectedOverdue.set($event); onFilterChange()"
           placeholder="All"
           [showClear]="true"
           class="w-48"
@@ -137,9 +137,9 @@ export class CommitmentsListComponent implements OnInit {
   readonly showCreateDialog = signal(false);
   private readonly peopleMap = signal<Map<string, string>>(new Map());
 
-  protected selectedDirection: CommitmentDirection | null = null;
-  protected selectedStatus: CommitmentStatus | null = null;
-  protected selectedOverdue: boolean | null = null;
+  readonly selectedDirection = signal<CommitmentDirection | null>(null);
+  readonly selectedStatus = signal<CommitmentStatus | null>(null);
+  readonly selectedOverdue = signal<boolean | null>(null);
 
   protected readonly directionFilterOptions = [
     { label: 'I owe them', value: 'MineToThem' as CommitmentDirection },
@@ -227,17 +227,20 @@ export class CommitmentsListComponent implements OnInit {
   private loadCommitments(): void {
     this.loading.set(true);
     this.commitmentsService.list(
-      this.selectedDirection ?? undefined,
-      this.selectedStatus ?? undefined,
+      this.selectedDirection() ?? undefined,
+      this.selectedStatus() ?? undefined,
       undefined,
       undefined,
-      this.selectedOverdue ?? undefined,
+      this.selectedOverdue() ?? undefined,
     ).subscribe({
       next: (commitments) => {
         this.commitments.set(commitments);
         this.loading.set(false);
       },
-      error: () => this.loading.set(false),
+      error: () => {
+        this.loading.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to load commitments' });
+      },
     });
   }
 
@@ -248,6 +251,7 @@ export class CommitmentsListComponent implements OnInit {
         people.forEach(p => map.set(p.id, p.name));
         this.peopleMap.set(map);
       },
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to load people' }),
     });
   }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/initiatives/initiative-detail/initiative-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/initiatives/initiative-detail/initiative-detail.component.ts
@@ -189,6 +189,8 @@ import { Person } from '../../../shared/models/person.model';
                 [suggestions]="peopleSuggestions()"
                 (completeMethod)="searchPeople($event)"
                 field="name"
+                [forceSelection]="true"
+                [minLength]="2"
                 placeholder="Search people..."
                 class="w-full"
               />

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/initiatives/initiatives-list/initiatives-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/initiatives/initiatives-list/initiatives-list.component.ts
@@ -24,8 +24,8 @@ import { CreateInitiativeDialogComponent } from '../create-initiative-dialog/cre
       <div class="flex items-center gap-4">
         <p-select
           [options]="statusFilterOptions"
-          [(ngModel)]="selectedStatus"
-          (ngModelChange)="onStatusFilterChange()"
+          [ngModel]="selectedStatus()"
+          (ngModelChange)="selectedStatus.set($event); onStatusFilterChange()"
           placeholder="All Statuses"
           [showClear]="true"
           class="w-48"
@@ -82,7 +82,7 @@ export class InitiativesListComponent implements OnInit {
   readonly initiatives = signal<Initiative[]>([]);
   readonly loading = signal(true);
   readonly showCreateDialog = signal(false);
-  protected selectedStatus: InitiativeStatus | null = null;
+  readonly selectedStatus = signal<InitiativeStatus | null>(null);
 
   protected readonly statusFilterOptions = [
     { label: 'Active', value: 'Active' as InitiativeStatus },
@@ -127,7 +127,7 @@ export class InitiativesListComponent implements OnInit {
 
   private loadInitiatives(): void {
     this.loading.set(true);
-    this.initiativesService.list(this.selectedStatus ?? undefined).subscribe({
+    this.initiativesService.list(this.selectedStatus() ?? undefined).subscribe({
       next: (initiatives) => {
         this.initiatives.set(initiatives);
         this.loading.set(false);

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -731,6 +731,10 @@ app.MapPost("/api/captures/{id:guid}/link-person", async (
     {
         return Results.NotFound();
     }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
 }).RequireAuthorization();
 
 app.MapPost("/api/captures/{id:guid}/link-initiative", async (
@@ -747,6 +751,10 @@ app.MapPost("/api/captures/{id:guid}/link-initiative", async (
     catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
     {
         return Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
     }
 }).RequireAuthorization();
 
@@ -765,6 +773,10 @@ app.MapPost("/api/captures/{id:guid}/unlink-person", async (
     {
         return Results.NotFound();
     }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
 }).RequireAuthorization();
 
 app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
@@ -781,6 +793,10 @@ app.MapPost("/api/captures/{id:guid}/unlink-initiative", async (
     catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
     {
         return Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
     }
 }).RequireAuthorization();
 

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -10,6 +10,7 @@ using MentalMetal.Application.People;
 using MentalMetal.Application.Users;
 using MentalMetal.Domain.Captures;
 using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.Common;
 using MentalMetal.Domain.Delegations;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.People;
@@ -503,7 +504,7 @@ app.MapPut("/api/initiatives/{id:guid}", async (
         var response = await handler.HandleAsync(id, request, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -524,7 +525,7 @@ app.MapPut("/api/initiatives/{id:guid}/status", async (
         var response = await handler.HandleAsync(id, request, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -545,7 +546,7 @@ app.MapPost("/api/initiatives/{id:guid}/milestones", async (
         var response = await handler.HandleAsync(id, request, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -567,7 +568,7 @@ app.MapPut("/api/initiatives/{id:guid}/milestones/{milestoneId:guid}", async (
         var response = await handler.HandleAsync(id, milestoneId, request, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -588,7 +589,7 @@ app.MapDelete("/api/initiatives/{id:guid}/milestones/{milestoneId:guid}", async 
         var response = await handler.HandleAsync(id, milestoneId, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -609,7 +610,7 @@ app.MapPost("/api/initiatives/{id:guid}/milestones/{milestoneId:guid}/complete",
         var response = await handler.HandleAsync(id, milestoneId, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -630,7 +631,7 @@ app.MapPost("/api/initiatives/{id:guid}/link-person", async (
         var response = await handler.HandleAsync(id, request, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }
@@ -651,7 +652,7 @@ app.MapDelete("/api/initiatives/{id:guid}/link-person/{personId:guid}", async (
         var response = await handler.HandleAsync(id, personId, cancellationToken);
         return Results.Ok(response);
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    catch (NotFoundException)
     {
         return Results.NotFound();
     }

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -472,4 +472,68 @@ public class CaptureTests
 
         Assert.Equal(ExtractionStatus.None, capture.ExtractionStatus);
     }
+
+    // Guid.Empty guard tests
+    [Fact]
+    public void Create_EmptyUserId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Capture.Create(Guid.Empty, "content", CaptureType.QuickNote));
+    }
+
+    [Fact]
+    public void LinkToPerson_EmptyPersonId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.LinkToPerson(Guid.Empty));
+    }
+
+    [Fact]
+    public void UnlinkFromPerson_EmptyPersonId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.UnlinkFromPerson(Guid.Empty));
+    }
+
+    [Fact]
+    public void LinkToInitiative_EmptyInitiativeId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.LinkToInitiative(Guid.Empty));
+    }
+
+    [Fact]
+    public void UnlinkFromInitiative_EmptyInitiativeId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.UnlinkFromInitiative(Guid.Empty));
+    }
+
+    [Fact]
+    public void RecordSpawnedCommitment_EmptyId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.RecordSpawnedCommitment(Guid.Empty));
+    }
+
+    [Fact]
+    public void RecordSpawnedDelegation_EmptyId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.RecordSpawnedDelegation(Guid.Empty));
+    }
+
+    [Fact]
+    public void RecordSpawnedObservation_EmptyId_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<ArgumentException>(() => capture.RecordSpawnedObservation(Guid.Empty));
+    }
 }

--- a/tests/MentalMetal.Domain.Tests/Initiatives/InitiativeTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Initiatives/InitiativeTests.cs
@@ -398,6 +398,13 @@ public class InitiativeTests
             initiative.UnlinkPerson(personId));
     }
 
+    [Fact]
+    public void Create_EmptyUserId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Initiative.Create(Guid.Empty, "Test"));
+    }
+
     private static Initiative CreateWithStatus(InitiativeStatus status)
     {
         var initiative = Initiative.Create(UserId, "Test");

--- a/tests/MentalMetal.Domain.Tests/Initiatives/InitiativeTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Initiatives/InitiativeTests.cs
@@ -399,6 +399,34 @@ public class InitiativeTests
     }
 
     [Fact]
+    public void UpdateMilestone_MutatesExistingInstance()
+    {
+        var initiative = Initiative.Create(UserId, "Test");
+        initiative.AddMilestone("Phase 1", new DateOnly(2026, 6, 1));
+        var original = initiative.Milestones[0];
+        var milestoneId = original.Id;
+
+        initiative.UpdateMilestone(milestoneId, "Phase 1 Updated", new DateOnly(2026, 7, 1));
+
+        Assert.Same(original, initiative.Milestones.First(m => m.Id == milestoneId));
+        Assert.Equal("Phase 1 Updated", original.Title);
+    }
+
+    [Fact]
+    public void CompleteMilestone_MutatesExistingInstance()
+    {
+        var initiative = Initiative.Create(UserId, "Test");
+        initiative.AddMilestone("Phase 1", new DateOnly(2026, 6, 1));
+        var original = initiative.Milestones[0];
+        var milestoneId = original.Id;
+
+        initiative.CompleteMilestone(milestoneId);
+
+        Assert.Same(original, initiative.Milestones.First(m => m.Id == milestoneId));
+        Assert.True(original.IsCompleted);
+    }
+
+    [Fact]
     public void Create_EmptyUserId_Throws()
     {
         Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
## Summary

Addresses unresolved review comments from merged PRs #60, #63, #64, and #65 — correctness bugs, EF tracking issues, zoneless violations, and UX gaps.

## Changes

### Backend
- **Guid.Empty guards** (PR #63): `Capture.Create`, `LinkToPerson`, `LinkToInitiative`, `UnlinkFromPerson`, `UnlinkFromInitiative`, `RecordSpawnedCommitment/Delegation/Observation` now reject `Guid.Empty`
- **Guid.Empty guard** (PR #60): `Initiative.Create` now rejects `Guid.Empty` userId
- **Typed NotFoundException** (PR #60): Replaced brittle `ex.Message.Contains("not found")` string matching in initiative endpoints with a typed `NotFoundException` class, caught directly in `Program.cs`
- **EF tracked entity mutation** (PR #60): `Initiative.UpdateMilestone` and `CompleteMilestone` now mutate the existing `Milestone` in-place instead of removing and re-adding a new instance with the same `Id` (which caused EF tracking conflicts)

### Frontend
- **Zoneless signal conversion** (PR #63, #64): Converted plain mutable properties to signals in `captures-list`, `capture-detail`, `commitments-list`, and `initiatives-list` components
- **AutoComplete type safety** (PR #60): Added `forceSelection` and `minLength=2` to initiative-detail people autocomplete
- **Error feedback** (PR #64): Added toast notifications for commitment list load failures

### Tests
- Added 9 new domain tests for `Guid.Empty` guard coverage on `Capture` and `Initiative`

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (281 tests)
- [x] `ng test --watch=false` passes (14 tests)
- [x] Self-reviewed diff against main

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured error handling for missing resources with clearer error messages.

* **Bug Fixes**
  * Improved validation of entity identifiers to catch invalid data earlier.
  * Enhanced error feedback in list views when data retrieval fails.
  * Stricter selection enforcement for adding people to initiatives.

* **Refactor**
  * Modernized state management in capture and initiative detail views.
  * Updated filter state management across list components for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->