### PR TITLE
fix: Address polish review feedback from PRs #54 and #52

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       ASPNETCORE_URLS: http://+:5002
       DOTNET_USE_POLLING_FILE_WATCHER: "true"
       ConnectionStrings__DefaultConnection: "Host=postgres-dev;Port=5432;Database=mentalmetal;Username=mentalmetal;Password=devTestPassword"
+      Testing__EnableTestLogin: "true"
     ports:
       - "5002:5002"
     volumes:

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.spec.ts
@@ -65,6 +65,97 @@ describe('AiProviderSettingsComponent', () => {
     expect(fixture.componentInstance.models().length).toBe(1);
   });
 
+  it('should disable save when API key entered but not validated', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: false,
+      provider: null,
+      model: null,
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    fixture.componentInstance.selectProvider('Anthropic');
+
+    const modelReq = httpMock.expectOne('/api/ai/models?provider=Anthropic');
+    modelReq.flush({
+      provider: 'Anthropic',
+      models: [
+        { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', isDefault: true },
+      ],
+    });
+
+    // Enter an API key but no validation has run yet
+    fixture.componentInstance['apiKey'] = 'sk-ant-test-key-1234567890';
+
+    // canSave should be false — validation hasn't passed
+    expect(fixture.componentInstance.canSave()).toBe(false);
+  });
+
+  it('should reset validation state on API key input', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: false,
+      provider: null,
+      model: null,
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    fixture.componentInstance.selectProvider('OpenAI');
+    httpMock.expectOne('/api/ai/models?provider=OpenAI').flush({
+      provider: 'OpenAI',
+      models: [{ id: 'gpt-4o', name: 'GPT-4o', isDefault: true }],
+    });
+
+    // Simulate a previous successful validation
+    fixture.componentInstance.validationResult.set('success');
+    fixture.componentInstance.validationMessage.set('Connected to GPT-4o');
+
+    // Typing a new key should clear the stale validation
+    fixture.componentInstance.onApiKeyInput();
+    expect(fixture.componentInstance.validationResult()).toBeNull();
+    expect(fixture.componentInstance.validationMessage()).toBeNull();
+  });
+
+  it('should reset apiKey and validation on provider switch', () => {
+    const fixture = TestBed.createComponent(AiProviderSettingsComponent);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/users/me/ai-provider').flush({
+      isConfigured: false,
+      provider: null,
+      model: null,
+      maxTokens: null,
+      tasteBudget: { remaining: 5, dailyLimit: 5, isEnabled: true },
+    });
+
+    fixture.componentInstance.selectProvider('OpenAI');
+    httpMock.expectOne('/api/ai/models?provider=OpenAI').flush({
+      provider: 'OpenAI',
+      models: [{ id: 'gpt-4o', name: 'GPT-4o', isDefault: true }],
+    });
+
+    // Enter API key and simulate validation
+    fixture.componentInstance['apiKey'] = 'sk-test-key-1234567890abcdef';
+    fixture.componentInstance.validationResult.set('success');
+
+    // Switch provider
+    fixture.componentInstance.selectProvider('Anthropic');
+    httpMock.expectOne('/api/ai/models?provider=Anthropic').flush({
+      provider: 'Anthropic',
+      models: [{ id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', isDefault: true }],
+    });
+
+    expect(fixture.componentInstance['apiKey']).toBe('');
+    expect(fixture.componentInstance.validationResult()).toBeNull();
+    expect(fixture.componentInstance.validating()).toBe(false);
+  });
+
   it('should pre-populate form when provider is configured', () => {
     const fixture = TestBed.createComponent(AiProviderSettingsComponent);
     fixture.detectChanges();

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -243,10 +243,11 @@ export class AiProviderSettingsComponent implements OnInit {
     this.selectedModel = '';
     this.apiKey = '';
     this.loadModels(provider);
-    // Reset validation when provider changes
+    // Reset validation when provider changes and cancel any in-flight validation
     this.validating.set(false);
     this.validationResult.set(null);
     this.validationMessage.set(null);
+    this.validateSubject.next();
   }
 
   onApiKeyInput(): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -8,7 +8,7 @@ import {
   DestroyRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Subject, EMPTY, debounceTime, switchMap } from 'rxjs';
+import { Subject, EMPTY, of, debounceTime, switchMap, catchError } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -215,26 +215,21 @@ export class AiProviderSettingsComponent implements OnInit {
             provider,
             apiKey: this.apiKey,
             model,
-          });
+          }).pipe(
+            catchError(() => of({ success: false as const, error: 'Connection failed', modelName: null })),
+          );
         }),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe({
-        next: (result) => {
-          this.validating.set(false);
-          if (result.success) {
-            this.validationResult.set('success');
-            this.validationMessage.set(`Connected to ${result.modelName}`);
-          } else {
-            this.validationResult.set('error');
-            this.validationMessage.set(result.error ?? 'Validation failed');
-          }
-        },
-        error: () => {
-          this.validating.set(false);
+      .subscribe((result) => {
+        this.validating.set(false);
+        if (result.success) {
+          this.validationResult.set('success');
+          this.validationMessage.set(`Connected to ${result.modelName}`);
+        } else {
           this.validationResult.set('error');
-          this.validationMessage.set('Connection failed');
-        },
+          this.validationMessage.set(result.error ?? 'Validation failed');
+        }
       });
   }
 
@@ -245,8 +240,10 @@ export class AiProviderSettingsComponent implements OnInit {
       this.providers.find((p) => p.name === provider) ?? null,
     );
     this.selectedModel = '';
+    this.apiKey = '';
     this.loadModels(provider);
     // Reset validation when provider changes
+    this.validating.set(false);
     this.validationResult.set(null);
     this.validationMessage.set(null);
   }
@@ -260,8 +257,10 @@ export class AiProviderSettingsComponent implements OnInit {
     const hasModel = !!this.selectedModel;
     const status = this.aiProviderService.status();
     const sameProvider = !!(status?.isConfigured && status.provider === provider);
-    const hasKey = !!this.apiKey || sameProvider;
-    return !!provider && hasModel && hasKey;
+    // Allow save if: (a) keeping the same provider with existing key (no new key entered),
+    // or (b) a new key was entered and validation passed
+    const keyValid = (sameProvider && !this.apiKey) || (!!this.apiKey && this.validationResult() === 'success');
+    return !!provider && hasModel && keyValid && !this.validating();
   }
 
   save(): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/ai-provider-settings.component.ts
@@ -124,6 +124,7 @@ import {
               optionLabel="name"
               optionValue="id"
               [(ngModel)]="selectedModel"
+              (ngModelChange)="onModelChange()"
               placeholder="Select model"
               class="w-full"
               [loading]="loadingModels()"
@@ -225,7 +226,7 @@ export class AiProviderSettingsComponent implements OnInit {
         this.validating.set(false);
         if (result.success) {
           this.validationResult.set('success');
-          this.validationMessage.set(`Connected to ${result.modelName}`);
+          this.validationMessage.set(result.modelName ? `Connected to ${result.modelName}` : 'Validation successful');
         } else {
           this.validationResult.set('error');
           this.validationMessage.set(result.error ?? 'Validation failed');
@@ -249,6 +250,16 @@ export class AiProviderSettingsComponent implements OnInit {
   }
 
   onApiKeyInput(): void {
+    // Clear stale validation so canSave() disables Save until the new key is validated
+    this.validationResult.set(null);
+    this.validationMessage.set(null);
+    this.validateSubject.next();
+  }
+
+  onModelChange(): void {
+    // Clear stale validation when model changes — the previous result was for a different model
+    this.validationResult.set(null);
+    this.validationMessage.set(null);
     this.validateSubject.next();
   }
 

--- a/src/MentalMetal.Web/appsettings.Development.json
+++ b/src/MentalMetal.Web/appsettings.Development.json
@@ -24,7 +24,7 @@
     }
   },
   "Testing": {
-    "EnableTestLogin": "false"
+    "EnableTestLogin": false
   },
   "Authentication": {
     "Google": {

--- a/src/MentalMetal.Web/appsettings.Development.json
+++ b/src/MentalMetal.Web/appsettings.Development.json
@@ -24,7 +24,7 @@
     }
   },
   "Testing": {
-    "EnableTestLogin": "true"
+    "EnableTestLogin": "false"
   },
   "Authentication": {
     "Google": {


### PR DESCRIPTION
## Summary

Addresses unresolved review feedback from PR #54 (AI provider frontend) and PR #52 (auth E2E tests). Fixes frontend state bugs in provider switching, validation pipeline resilience, and security hardening of the test-login endpoint default.

## Changes

- **Reset apiKey on provider switch** — `selectProvider()` now clears `apiKey` and resets `validating` to prevent stale credentials from a previous provider persisting
- **Gate Save on successful validation** — `canSave()` now requires `validationResult() === 'success'` when a new API key is entered, and disables save while validation is in-flight
- **catchError inside switchMap** — HTTP errors no longer terminate the validation subscription; errors are caught per-request and surfaced as validation failures
- **Default EnableTestLogin to false** — `appsettings.Development.json` now defaults to `"false"` so a misconfigured deployment doesn't expose the test-login endpoint
- **Explicit override in docker-compose** — The `dev-stack` API service sets `Testing__EnableTestLogin=true` via environment variable for E2E testing

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (255 + 28 tests)
- [x] `ng test --watch=false` passes (14 tests)
- [ ] Manual: switch providers and verify apiKey field clears, Save stays disabled until validation passes
- [ ] Manual: enter invalid API key, verify error shown and subscription continues to work for subsequent attempts

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)