### PR TITLE
fix: Use USING clause for text→jsonb migration

### DIFF
--- a/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
@@ -10,11 +10,9 @@ namespace MentalMetal.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            // Clear any existing non-JSON text values before converting to jsonb
-            migrationBuilder.Sql("""UPDATE "Captures" SET "AiExtraction" = NULL WHERE "AiExtraction" IS NOT NULL""");
-
-            // AlterColumn doesn't generate USING clause; PostgreSQL requires it for text→jsonb cast
-            migrationBuilder.Sql("""ALTER TABLE "Captures" ALTER COLUMN "AiExtraction" TYPE jsonb USING "AiExtraction"::jsonb""");
+            // AlterColumn doesn't generate USING clause; PostgreSQL requires it for text→jsonb cast.
+            // USING NULL::jsonb discards existing text values atomically — no race window with concurrent writes.
+            migrationBuilder.Sql("""ALTER TABLE "Captures" ALTER COLUMN "AiExtraction" TYPE jsonb USING NULL::jsonb""");
 
             migrationBuilder.AddColumn<string>(
                 name: "FailureReason",

--- a/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413031942_AddAiExtractionJsonAndFailureReason.cs
@@ -13,14 +13,8 @@ namespace MentalMetal.Infrastructure.Migrations
             // Clear any existing non-JSON text values before converting to jsonb
             migrationBuilder.Sql("""UPDATE "Captures" SET "AiExtraction" = NULL WHERE "AiExtraction" IS NOT NULL""");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AiExtraction",
-                table: "Captures",
-                type: "jsonb",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "text",
-                oldNullable: true);
+            // AlterColumn doesn't generate USING clause; PostgreSQL requires it for text→jsonb cast
+            migrationBuilder.Sql("""ALTER TABLE "Captures" ALTER COLUMN "AiExtraction" TYPE jsonb USING "AiExtraction"::jsonb""");
 
             migrationBuilder.AddColumn<string>(
                 name: "FailureReason",
@@ -37,14 +31,7 @@ namespace MentalMetal.Infrastructure.Migrations
                 name: "FailureReason",
                 table: "Captures");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AiExtraction",
-                table: "Captures",
-                type: "text",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "jsonb",
-                oldNullable: true);
+            migrationBuilder.Sql("""ALTER TABLE "Captures" ALTER COLUMN "AiExtraction" TYPE text USING "AiExtraction"::text""");
         }
     }
 }


### PR DESCRIPTION
## Summary
- All 3 recent deployments failing at the EF Core migration step
- `migrationBuilder.AlterColumn` generates `ALTER COLUMN ... TYPE jsonb` without a `USING` clause
- PostgreSQL requires `USING "AiExtraction"::jsonb` when casting `text → jsonb` (even with NULLed data)
- Fixed by replacing `AlterColumn` with raw SQL that includes the `USING` clause

## Root cause
PostgreSQL error: `column "AiExtraction" cannot be cast automatically to type jsonb` (error code 42804)

The hint from Postgres was: _You might need to specify `"USING "AiExtraction"::jsonb"`_

## Test plan
- [ ] PR CI passes (build + unit tests)
- [ ] Deploy to staging completes without migration error
- [ ] Health check on staging passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve PostgreSQL migration failures by replacing the AiExtraction AlterColumn operation with SQL that specifies a USING cast from text to jsonb and back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to improve storage and handling of AI extraction data in the system backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->