### PR TITLE
docs(openspec): propose remaining Tier 2 specs

### DIFF
--- a/openspec/changes/global-ai-chat/.openspec.yaml
+++ b/openspec/changes/global-ai-chat/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/global-ai-chat/design.md
+++ b/openspec/changes/global-ai-chat/design.md
@@ -1,0 +1,152 @@
+## Context
+
+`initiative-ai-chat` introduced the `ChatThread` aggregate with a `ContextScope` value object designed to support multiple variants. This spec exercises the `Global` variant. The new work is almost entirely in the application layer: intent classification and dynamic context assembly across the whole user data set.
+
+The user-facing entry is an always-visible launcher in the app shell. Two modes are supported by a single underlying flow: a slide-over panel for quick one-off questions and a full-page route for longer sessions. Both create or resume the same `ChatThread` records.
+
+### Dependencies
+
+- `ai-provider-abstraction` (Tier 1) — `IAiCompletionService` and `TasteLimitExceededException`.
+- `initiative-ai-chat` (Tier 2) — `ChatThread` aggregate, `ChatMessage`/`SourceReference`/`ContextScope` value objects, repository, base events. This spec depends on that aggregate existing; it does not redefine it.
+- `person-management`, `initiative-management`, `commitment-tracking`, `delegation-tracking`, `capture-text`, `capture-ai-extraction`, `initiative-living-brief` — read-only context sources.
+- Forward-compatible with `people-lens` (when present, additional context).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reuse `ChatThread` as-is. No fork, no parallel aggregate.
+- Make global chat answer the most common question types correctly: "what's on my plate?", "how is <person> doing?", "status of <initiative>?", "what's overdue?", "what did I capture about <topic>?".
+- Keep context bounded. The total payload to the AI MUST fit comfortably in a typical 100k-token window with room to spare for response.
+- Cite every factual claim with a `SourceReference` typed correctly (Person, Initiative, Capture, Commitment, Delegation, etc.).
+- Multi-tenant isolation enforced at every context query.
+
+**Non-Goals:**
+
+- Tool-use / actions from chat.
+- Streaming responses.
+- Vector / semantic search.
+- Persistent cross-thread memory.
+- A "personality" or persona — the assistant is utilitarian.
+
+## Decisions
+
+### 1. Reuse `ChatThread` via `ContextScope.Global()`
+
+**Decision:** Add no new aggregate. `ChatThread.Start(userId, ContextScope.Global())` produces a global thread. The `ContextScope.Global()` variant carries no fields. Repository queries filter by `ContextScopeType` and (for initiative scope) `ContextInitiativeId`.
+
+**Rationale:** Threads behave identically; only context assembly differs. This was the explicit design intent of `initiative-ai-chat`.
+
+**Consequence:** A single `ChatThreads` table holds both initiative and global threads, distinguished by `ContextScopeType`. Listings filter accordingly.
+
+### 2. Distinct `GlobalChatThreadStarted` event
+
+**Decision:** Raise `GlobalChatThreadStarted` (in addition to or instead of the base `ChatThreadStarted`). Implementation choice: raise both — `ChatThreadStarted` for generic subscribers, `GlobalChatThreadStarted` for global-specific subscribers (e.g. usage analytics, future "trending questions" features).
+
+**Rationale:** Lets subscribers filter without inspecting the ContextScope payload. Cheap to add now.
+
+**Alternatives considered:**
+- Single event with scope inside payload — rejected because filtering inside a handler is ugly and event-bus consumers prefer typed channels.
+
+### 3. Intent classification: hybrid (rule-based first, AI fallback)
+
+**Decision:** A two-layer `IntentClassifier`:
+
+1. **Rule layer (cheap, deterministic):** regex/keyword matches against the user question for high-precision intents:
+   - `OverdueWork`: matches "overdue", "late", "behind".
+   - `MyDay` / `MyWeek`: matches "today", "this week", "what's on my plate".
+   - `PersonLens`: matches a known person name (substring/full-name match against the user's people).
+   - `InitiativeStatus`: matches a known initiative name.
+   - `CaptureSearch`: matches "I captured", "what did I write about", date phrases.
+2. **AI layer (fallback):** if no rule fires (or only `Generic` matches), a single small AI call classifies into the same intent set with a structured response. Cached per-thread for similar follow-up questions.
+
+The classifier returns `IntentSet` = `{ intents: ChatIntent[], entityHints: { personIds[], initiativeIds[], dateRange? } }`. Entity hints are resolved by the rule layer (matching names against the user's known people/initiatives) so the context builder can pull targeted records.
+
+**Rationale:** Most expected questions are rule-classifiable cheaply. AI fallback handles long-tail. This balances cost, latency, and coverage.
+
+**Trade-off:** The rule layer is brittle in a multilingual sense (English-first). Documented as a limitation.
+
+**Alternatives considered:**
+- AI classifier only — rejected for cost/latency on every message.
+- Rule-only — rejected because long-tail "fuzzy" questions degrade to `Generic` (everything in context, capped).
+
+### 4. `GlobalChatContextBuilder` — intent-driven context with hard caps
+
+**Decision:** Given an `IntentSet`, the builder pulls a per-intent context slice:
+
+- `MyDay` / `MyWeek`: open commitments due today/this week (mine-to-them and theirs-to-me, max 30); active delegations due today/this week (max 30); 1:1s scheduled today/this week (when `people-lens` is present).
+- `OverdueWork`: overdue commitments (max 30) and overdue delegations (max 30).
+- `PersonLens(personIds)`: for each person (max 5), pull person summary, open commitments + delegations + observations + goals + most-recent 1:1 (when `people-lens` is present).
+- `InitiativeStatus(initiativeIds)`: for each initiative (max 5), pull initiative metadata + LivingBrief summary + open risks + recent decisions (max 10) + open commitments/delegations linked to it (max 20 each).
+- `CaptureSearch(dateRange?)`: most-recent 30 confirmed captures (within date range if specified), each as { id, createdAt, summary, linkedPersonNames, linkedInitiativeNames }.
+- `Generic`: a "lightweight everything" — counts (open commitments, open delegations, active initiatives), top 5 most-overdue commitments, top 5 most-recent captures.
+
+Multiple intents stack additively up to a global section-count cap; total payload is hard-capped at a configurable token budget (default ~16k input tokens of context, leaving margin for system prompt and response). When the cap would be exceeded, the builder degrades gracefully: trims the lowest-priority sections first (recent captures → delegations → commitments → person/initiative cores).
+
+All queries are filtered by UserId.
+
+**Rationale:** Predictable cost, predictable behaviour, and graceful degradation at the upper bound.
+
+### 5. AI prompting strategy
+
+**Decision:** Same structured envelope as `initiative-ai-chat`: `{ assistantText: string, sourceReferences: SourceReference[] }`. The system prompt is global-flavoured: "You are the user's work assistant. Answer using only the supplied context. Cite every factual claim. If the question cannot be answered from the context, say so and suggest what to capture or add." Conversation history (recent N messages, capped by token estimate) is included.
+
+**Rationale:** Consistent with initiative chat. Same parser, same fallback ("if envelope unparseable, persist raw text").
+
+### 6. `SourceReference` types — extend in `initiative-ai-chat`'s enum?
+
+**Decision:** This spec uses the same `SourceReferenceEntityType` enum. The enum already includes `Capture`, `Commitment`, `Delegation`, `Initiative`, and the LivingBrief variants. We additionally need `Person` (for "how is Jane doing?" answers). The enum SHALL be extended to include `Person` (and forward-compatible `Observation`, `Goal`, `OneOnOne` for `people-lens`).
+
+This is a small modification to a value object owned by `initiative-ai-chat`. We declare it as part of this spec's `ADDED Requirements` (the `SourceReferenceEntityType` enum SHALL include these additional values). The proposal section noted no Modified Capabilities; if reviewers feel the enum extension warrants a delta on `initiative-ai-chat`'s spec, we will add it at archive-merge time. The pragmatic call: enum extensions are additive and harmless.
+
+**Rationale:** Avoid a parallel enum and inconsistent typing across initiative and global chat.
+
+### 7. API surface
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/chat/threads` | POST | Start a new global thread |
+| `/api/chat/threads` | GET | List the user's global threads (filterable by status, ordered by LastMessageAt) |
+| `/api/chat/threads/{threadId}` | GET | Get the full thread including messages |
+| `/api/chat/threads/{threadId}` | PUT | Rename |
+| `/api/chat/threads/{threadId}/messages` | POST | Post a user message; returns the assistant reply |
+| `/api/chat/threads/{threadId}/archive` | POST | Archive |
+| `/api/chat/threads/{threadId}/unarchive` | POST | Unarchive |
+
+**Rationale:** Top-level `/api/chat` namespace; mirrors the initiative-scoped surface but unbound from any initiative.
+
+### 8. Frontend: launcher + slide-over + full page
+
+**Decision:** Add a global chat launcher (PrimeNG button with a sparkle icon) in the app shell, always visible. Click opens a slide-over panel (PrimeNG Sidebar from the right) with the most-recent active thread preselected (or an empty new thread if none). The slide-over has the composer and message list, plus an "Open in full view" link that navigates to `/chat` — a full-page route with a thread rail (grouped by date: Today, Yesterday, This Week, Older), main conversation pane, composer, and rename/archive controls.
+
+**Rationale:** Quick-question users get the slide-over; deeper sessions get the full page. Both share the same backend resource.
+
+### 9. Multi-tenant isolation, restated
+
+**Decision:** Every read in `GlobalChatContextBuilder` is filtered by the thread's `UserId`. Repositories enforce UserId at the persistence layer. Integration tests cover each intent path with a two-user fixture.
+
+### 10. Reuse of `InitiativeChatCompletionService`?
+
+**Decision:** Do **not** reuse. Create a separate `GlobalChatCompletionService` with a different system prompt and a different context builder. Both services share the structured-envelope parser via a small shared utility (`ChatResponseParser`).
+
+**Rationale:** Same shape, different policies. Sharing the orchestrator would require flag-based branching that obscures the difference. Sharing the parser is appropriate and small.
+
+## Risks / Trade-offs
+
+- **[Intent misclassification]** A misclassified intent yields irrelevant context and a disappointing answer. **Mitigation:** Hybrid classifier (Decision 3); `Generic` fallback always provides a baseline; the user can rephrase. Telemetry on classification confidence to tune rules.
+- **[Cost drift]** Global chat is enticing — users may use it heavily. Each turn is an AI call (plus an optional classifier call). **Mitigation:** Existing `TasteLimitExceededException` handling per `ai-provider-abstraction`; classifier cached per thread for follow-ups.
+- **[Context window pressure]** "Tell me everything" questions could blow the budget. **Mitigation:** Hard caps + graceful degradation in the context builder (Decision 4).
+- **[Stale data]** Context is built at request time, so it's fresh — but the assistant's reply may be quoted/screenshotted later and become stale. **Mitigation:** Each assistant message stores `CreatedAt`; SourceReference chips remain clickable; not solvable in chat itself.
+- **[Hallucinated citations]** Same risk as `initiative-ai-chat`. **Mitigation:** Same defence — drop SourceReference EntityIds not present in the assembled context before persisting.
+- **[Person-name ambiguity]** Two people named "Sarah" → entity hints become ambiguous. **Mitigation:** Hint-resolver returns ALL matches; context builder includes both, the assistant disambiguates in its reply ("Did you mean Sarah Chen or Sarah Patel?").
+- **[Multi-language gaps]** Rule-based intent layer is English-first. **Mitigation:** AI fallback covers other languages, accepting the latency cost.
+
+## Migration Plan
+
+- No new EF Core migration. Reuses `ChatThreads` from `initiative-ai-chat`.
+- The `SourceReferenceEntityType` enum gains `Person` (and forward `Observation`, `Goal`, `OneOnOne`); these are additive and require no migration.
+- Frontend ships behind a feature flag `globalChatEnabled` (per-user preference, default `true`) so rollout can be paused if AI cost spikes.
+
+## Open Questions
+
+_(none — intent classifier is hybrid; enum extension declared additive; reuse boundary explicit.)_

--- a/openspec/changes/global-ai-chat/proposal.md
+++ b/openspec/changes/global-ai-chat/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Initiative-scoped chat answers questions about a specific project. But many of the manager's day-to-day questions cut across the whole portfolio — "what's on my plate today?", "how is Jane doing?", "what's overdue?", "what did I capture last week about hiring?". A global chat surface lets the user ask anything from anywhere in the app, with the AI dynamically scoping the relevant context based on the question.
+
+This is a Tier 2 spec (`global-ai-chat`) that depends on `ai-provider-abstraction` (Tier 1) and `initiative-ai-chat` (Tier 2). It reuses the `ChatThread` aggregate introduced by `initiative-ai-chat` by adding the `ContextScope.Global()` variant — no new aggregate.
+
+## Non-goals
+
+- **No new aggregate** — `ChatThread` and `ChatMessage` are reused; only the `Global` ContextScope variant is added.
+- **No actions from chat** — read-only ("what's overdue?" yes; "mark commitment X complete" no). Action-from-chat is a future concern.
+- **No streaming responses** — synchronous request/response, same as `initiative-ai-chat`.
+- **No file uploads or images** — text only.
+- **No semantic / vector retrieval** — context selection is rule-based with intent classification. A future spec can swap in semantic retrieval behind `IGlobalChatContextBuilder`.
+- **No shared / multi-user threads.**
+- **No persistent cross-thread "memory of you"** — each thread is independent; the model only sees the thread's own message history.
+- **No specialised fast-path for one-shot questions** — every question goes through a thread (which may contain only one exchange).
+
+## What Changes
+
+- **Extend `ContextScope` value object** with the `Global()` variant (the slot was reserved by `initiative-ai-chat`). A `ChatThread.Start(...)` with `ContextScope.Global()` SHALL succeed and produce a thread with no Initiative binding.
+- **New `IntentClassifier` Application service** that, given a user question, classifies the question into one or more `ChatIntent` categories (e.g. `MyDay`, `PersonLens`, `InitiativeStatus`, `OverdueWork`, `CaptureSearch`, `Generic`) and extracts entity hints (person names, initiative names, date ranges). Implementation: a small AI-assisted classifier OR a deterministic rule classifier — the design picks one and explains why.
+- **New `GlobalChatContextBuilder` Application service** that, based on the classified intents and entity hints, assembles a bounded context payload from across the user's data: people summaries, initiatives, captures (recent), commitments (open + recent), delegations (active + recent), observations / goals / 1:1s when `people-lens` is present, with strict per-section caps and total token budget.
+- **CQRS handlers and minimal API endpoints** under `/api/chat/threads` (note: NOT initiative-scoped) for: starting a global thread, listing global threads, getting a thread, posting a user message (which classifies, builds context, calls the AI, persists), renaming, archiving / unarchiving.
+- **Frontend global chat launcher** in the app shell (icon button always visible), opening either a slide-over panel for quick questions or routing to a dedicated full-page chat view for deeper sessions. The full-page view has a thread rail (active threads grouped by date), conversation pane, and composer.
+- **Domain events** `GlobalChatThreadStarted` (a typed alias / new event distinct from `ChatThreadStarted` so subscribers can filter), plus reuse of `ChatMessageSent`, `ChatMessageReceived`, `ChatThreadRenamed`, `ChatThreadArchived` from `initiative-ai-chat`.
+- **Same EF Core table** as `initiative-ai-chat`'s `ChatThreads`, with `ContextScopeType = "Global"` and `ContextInitiativeId = NULL`. No new migration.
+
+## Capabilities
+
+### New Capabilities
+
+- `global-ai-chat`: Cross-cutting AI chat available everywhere in the app, dynamically scoped by the user's question; queries across all of the user's data (people, initiatives, captures, commitments, delegations, and people-lens records when present); responses cite source records.
+
+### Modified Capabilities
+
+_(none — `initiative-ai-chat` is not modified at the spec level. The `ContextScope.Global()` slot was reserved by that spec; this proposal merely adds requirements for using it. If `initiative-ai-chat`'s spec needs an explicit modification to its `ContextScope` requirement, that will be handled at archive-merge time.)_
+
+## Impact
+
+- **Domain:** `ContextScope.Global()` variant is now exercised. New domain event `GlobalChatThreadStarted`. No new aggregate.
+- **Application:** New `IntentClassifier`, new `GlobalChatContextBuilder`, new `GlobalChatCompletionService` (parallel to `InitiativeChatCompletionService`), new vertical-slice handlers under `Chat/Global/`.
+- **Infrastructure:** No new migration; reuses the `ChatThreads` table from `initiative-ai-chat`.
+- **Web API:** New endpoints under `/api/chat/threads` (top-level, not nested under initiative).
+- **Frontend:** New global chat launcher in `AppShell`, slide-over quick-chat panel, full-page chat route, thread rail grouped by date.
+- **AI prompting:** New global system prompt; new lightweight intent classification prompt (or rule-based) — picks one in design.
+- **Dependencies:** `ai-provider-abstraction`, `initiative-ai-chat` (reuses `ChatThread`/`ChatMessage`/`SourceReference`), `initiative-living-brief`, `initiative-management`, `person-management`, `commitment-tracking`, `delegation-tracking`, `capture-text`, `capture-ai-extraction`. The spec is forward-compatible with `people-lens` (when present, observations/goals/1:1 records become eligible context).

--- a/openspec/changes/global-ai-chat/specs/global-ai-chat/spec.md
+++ b/openspec/changes/global-ai-chat/specs/global-ai-chat/spec.md
@@ -1,0 +1,264 @@
+## ADDED Requirements
+
+### Requirement: Global ContextScope variant
+
+The `ContextScope` value object (introduced by `initiative-ai-chat`) SHALL support a `Global()` variant carrying no fields. A `ChatThread` SHALL be considered global when its `ContextScope` is `Global()`. The persisted discriminator value is `"Global"` and `ContextInitiativeId` is `NULL` for global threads.
+
+#### Scenario: Construct a global ContextScope
+
+- **WHEN** `ContextScope.Global()` is constructed
+- **THEN** the value object equals other `ContextScope.Global()` instances and is distinguishable from any `ContextScope.Initiative(_)` instance
+
+#### Scenario: Persisted discriminator
+
+- **WHEN** a global ChatThread is persisted
+- **THEN** the row has ContextScopeType = "Global" and ContextInitiativeId = NULL
+
+### Requirement: SourceReferenceEntityType extended with Person
+
+The `SourceReferenceEntityType` enum SHALL include `Person` so that assistant messages can cite a Person record. The enum SHALL also reserve forward-compatible values `Observation`, `Goal`, and `OneOnOne` for use once `people-lens` is implemented.
+
+#### Scenario: Cite a person
+
+- **WHEN** an assistant message references a person ("Jane Doe is on track")
+- **THEN** the message includes a SourceReference with EntityType `Person` and EntityId set to that person's Id
+
+### Requirement: Start a global chat thread
+
+The system SHALL allow an authenticated user to start a global chat thread via `POST /api/chat/threads`. The system SHALL create a ChatThread with `ContextScope.Global()`, empty Title, Status `Active`, and raise BOTH the generic `ChatThreadStarted` event and the specific `GlobalChatThreadStarted` event.
+
+#### Scenario: Start a global thread
+
+- **WHEN** an authenticated user sends `POST /api/chat/threads` with no body (or empty body)
+- **THEN** the system creates a global ChatThread and returns HTTP 201 with the thread (id, contextScope = Global, empty title, empty messages, status Active)
+
+#### Scenario: Both events raised
+
+- **WHEN** a global thread is started
+- **THEN** subscribers to `ChatThreadStarted` and subscribers to `GlobalChatThreadStarted` both receive an event for that thread
+
+### Requirement: List global chat threads
+
+The system SHALL allow an authenticated user to list their global chat threads via `GET /api/chat/threads`, optionally filtered by `status` (default `Active`). Threads SHALL be ordered by `LastMessageAt DESC` (nulls last, then `CreatedAt DESC`). Initiative-scoped threads SHALL NOT appear in this listing.
+
+#### Scenario: List active global threads
+
+- **WHEN** an authenticated user sends `GET /api/chat/threads`
+- **THEN** the system returns only the user's global threads with Active status, newest first
+
+#### Scenario: Initiative threads not included
+
+- **WHEN** the user has both initiative-scoped and global threads
+- **THEN** `GET /api/chat/threads` returns only global threads; `GET /api/initiatives/{id}/chat/threads` returns only that initiative's threads
+
+#### Scenario: Empty list
+
+- **WHEN** the user has no global threads
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get a global chat thread
+
+The system SHALL allow an authenticated user to fetch a global thread (with all messages) via `GET /api/chat/threads/{threadId}`.
+
+#### Scenario: Get a global thread
+
+- **WHEN** the user requests an existing global thread they own
+- **THEN** the response includes thread metadata and all messages in MessageOrdinal order
+
+#### Scenario: Wrong scope returns 404
+
+- **WHEN** the user requests `GET /api/chat/threads/{threadId}` with the ID of an initiative-scoped thread
+- **THEN** the system returns HTTP 404 (route is global-only)
+
+#### Scenario: Cross-user thread
+
+- **WHEN** the user requests a global thread owned by a different user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Intent classification
+
+The system SHALL classify each posted user message into an `IntentSet` containing one or more `ChatIntent` values from `{ MyDay, MyWeek, OverdueWork, PersonLens, InitiativeStatus, CaptureSearch, Generic }` plus `entityHints` of `{ personIds, initiativeIds, dateRange? }`. Classification SHALL be performed by a hybrid classifier: a deterministic rule layer first; an AI fallback only when no rule fires or only `Generic` is matched.
+
+#### Scenario: Rule-classified person query
+
+- **WHEN** the user posts "How is Jane Doe doing?" and a Person named "Jane Doe" exists for the user
+- **THEN** the IntentSet includes `PersonLens` with that Person's Id in entityHints.personIds; no AI call is made for classification
+
+#### Scenario: Rule-classified overdue query
+
+- **WHEN** the user posts "What's overdue?"
+- **THEN** the IntentSet includes `OverdueWork` and no AI call is made for classification
+
+#### Scenario: AI-fallback classification
+
+- **WHEN** the user posts a message that the rule layer cannot classify (e.g. "Anything I should be worried about?")
+- **THEN** the system invokes an AI classifier with a structured response and uses its IntentSet
+
+#### Scenario: Ambiguous person name
+
+- **WHEN** the user posts "How is Sarah doing?" and two Persons named "Sarah Chen" and "Sarah Patel" exist
+- **THEN** the IntentSet's entityHints.personIds includes BOTH Persons' Ids
+
+#### Scenario: Generic fallback
+
+- **WHEN** neither rules nor AI yield a classification
+- **THEN** the IntentSet contains only `Generic`
+
+### Requirement: GlobalChatContextBuilder is intent-driven, capped, and user-scoped
+
+The `GlobalChatContextBuilder` SHALL assemble a context payload determined by the IntentSet. All queries SHALL be filtered by the thread's UserId. The following per-intent caps SHALL apply:
+
+- `MyDay` / `MyWeek`: at most 30 commitments and 30 delegations matching the time window.
+- `OverdueWork`: at most 30 overdue commitments and 30 overdue delegations.
+- `PersonLens`: at most 5 persons, each with summary, open commitments (max 10), open delegations (max 10), and (when `people-lens` exists) most-recent observations (max 10), goals (max 10), and most-recent OneOnOne.
+- `InitiativeStatus`: at most 5 initiatives, each with metadata, LivingBrief summary, open risks, recent decisions (max 10), and linked open commitments/delegations (max 20 each).
+- `CaptureSearch`: at most 30 confirmed captures (within the date range when supplied).
+- `Generic`: counts (open commitments/delegations/active initiatives), top 5 most-overdue commitments, top 5 most-recent captures.
+
+The total assembled payload SHALL be hard-capped by a configurable token budget (default ~16k input tokens). When the budget would be exceeded, the builder SHALL trim sections in this priority order (least-important first): recent captures → delegations → commitments → person/initiative cores.
+
+#### Scenario: Caps enforced
+
+- **WHEN** the user has 200 commitments and the intent is `OverdueWork`
+- **THEN** the assembled context contains at most 30 overdue commitments
+
+#### Scenario: User isolation
+
+- **WHEN** building context for a global thread owned by User A
+- **THEN** every record in the payload (commitments, delegations, captures, persons, initiatives, observations, goals, one-on-ones) belongs to User A; no User B records are read
+
+#### Scenario: Forward-compatible with people-lens absent
+
+- **WHEN** `people-lens` is not yet implemented and a `PersonLens` intent is classified
+- **THEN** the builder includes the Person summary, commitments, and delegations; observations/goals/one-on-ones sections are simply absent (no error)
+
+#### Scenario: Token budget triggers degradation
+
+- **WHEN** the assembled payload would exceed the configured token budget
+- **THEN** the builder trims sections in priority order until under budget; trimmed sections are noted in the payload metadata so the assistant can mention truncation if relevant
+
+#### Scenario: Generic intent payload
+
+- **WHEN** the IntentSet is `{ Generic }`
+- **THEN** the payload contains counts and the top-5 most-overdue commitments and top-5 most-recent captures only
+
+### Requirement: Post a global chat message and receive an assistant reply
+
+The system SHALL allow an authenticated user to post a user message via `POST /api/chat/threads/{threadId}/messages` with body `{ "content": "<text>" }`. The system SHALL: append the user message (raise `ChatMessageSent`), classify the question (intent + entity hints), build the context via `GlobalChatContextBuilder`, call `IAiCompletionService.CompleteAsync` with the global system prompt + assembled context + recent conversation history, parse the structured envelope, drop SourceReference EntityIds not present in the context, append the Assistant message (raise `ChatMessageReceived`), update LastMessageAt and MessageCount, and return HTTP 200 with `{ userMessage, assistantMessage }`.
+
+#### Scenario: "What's on my plate today?"
+
+- **WHEN** an authenticated user posts "What's on my plate today?" to a global thread
+- **THEN** the IntentSet includes `MyDay`; the context contains today's commitments and delegations; the assistant reply lists them with SourceReference chips of EntityType Commitment and Delegation
+
+#### Scenario: "How is Jane doing?"
+
+- **WHEN** the user posts "How is Jane doing?" and a Person named "Jane" exists
+- **THEN** the assembled context includes Jane's profile + linked work; the assistant reply cites SourceReference of EntityType Person (and any Commitments/Observations as applicable)
+
+#### Scenario: Empty content rejected
+
+- **WHEN** the content is empty or whitespace-only
+- **THEN** the system returns HTTP 400 and no messages are appended
+
+#### Scenario: Posting to an archived global thread rejected
+
+- **WHEN** the user posts to an Archived global thread
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: AI provider failure
+
+- **WHEN** `IAiCompletionService.CompleteAsync` throws an `AiProviderException`
+- **THEN** the user message is appended; an Assistant message containing a friendly error ("AI service unavailable, please retry") is appended; the system returns HTTP 200
+
+#### Scenario: Taste limit exceeded
+
+- **WHEN** the AI completion call throws a `TasteLimitExceededException`
+- **THEN** the user message is appended; a System message "Daily AI limit reached" is appended; the system returns HTTP 200
+
+#### Scenario: Hallucinated citations dropped
+
+- **WHEN** the AI returns a SourceReference whose EntityId was not present in the assembled context
+- **THEN** that SourceReference is dropped before persisting; only validated references appear on the persisted assistant message
+
+#### Scenario: Malformed envelope falls back
+
+- **WHEN** the AI response cannot be parsed into the structured envelope
+- **THEN** the entire raw text is persisted as the assistant message content with empty SourceReferences
+
+### Requirement: Auto-generated title for global threads
+
+When the first user message is appended to a global thread with empty Title, the system SHALL set Title to the user-message content truncated to 80 characters (with ellipsis if truncated).
+
+#### Scenario: Auto-title
+
+- **WHEN** the user posts the first message "What's overdue this week?" to a new global thread
+- **THEN** the thread's Title becomes "What's overdue this week?"
+
+### Requirement: Rename, archive, and unarchive global threads
+
+The system SHALL allow an authenticated user to rename a global thread via `PUT /api/chat/threads/{threadId}` with a non-empty title (max 200 chars), to archive an Active global thread via `POST /api/chat/threads/{threadId}/archive`, and to unarchive an Archived thread via `POST /api/chat/threads/{threadId}/unarchive`. Status guards behave identically to `initiative-ai-chat` thread operations.
+
+#### Scenario: Rename a global thread
+
+- **WHEN** the user renames a global thread to "Weekly review questions"
+- **THEN** Title updates and the system returns HTTP 200
+
+#### Scenario: Archive global thread
+
+- **WHEN** the user archives an Active global thread
+- **THEN** Status becomes Archived and the system returns HTTP 200
+
+#### Scenario: Re-archive rejected
+
+- **WHEN** the user archives an already-Archived thread (or unarchives an Active thread)
+- **THEN** the system returns HTTP 409
+
+### Requirement: Global chat launcher in app shell
+
+The frontend SHALL render a global chat launcher button in the app shell, visible on every authenticated route. Clicking the launcher SHALL open a slide-over chat panel. The panel SHALL preselect the user's most-recent active global thread, or open an empty new thread when none exists. The slide-over SHALL contain the message list, composer, and an "Open in full view" link to `/chat`.
+
+#### Scenario: Launcher visible on all authenticated routes
+
+- **WHEN** a signed-in user is on any authenticated route
+- **THEN** the launcher button is visible in the app shell
+
+#### Scenario: Launcher not visible when signed out
+
+- **WHEN** the user is on a public/unauthenticated route
+- **THEN** the launcher is not rendered
+
+#### Scenario: Open slide-over with most-recent thread
+
+- **WHEN** a user with at least one active global thread clicks the launcher
+- **THEN** the slide-over opens with the most-recent active thread loaded
+
+#### Scenario: Open slide-over with no existing threads
+
+- **WHEN** a user with no global threads clicks the launcher
+- **THEN** the slide-over opens with an empty new thread; on first message post, the thread is created via `POST /api/chat/threads` and the message is then posted
+
+### Requirement: Full-page global chat view
+
+The frontend SHALL provide a full-page route at `/chat` containing: a left rail of global threads grouped by date (Today, Yesterday, This Week, Older), a main pane showing the selected thread, a composer at the bottom, a "New thread" button, and per-thread rename/archive controls. The full-page view and the slide-over share the same backend resource and signal state for the active thread.
+
+#### Scenario: Navigate to full page
+
+- **WHEN** a user clicks "Open in full view" from the slide-over
+- **THEN** the system navigates to `/chat` with the same thread selected
+
+#### Scenario: Threads grouped by date
+
+- **WHEN** the user has threads with various LastMessageAt times
+- **THEN** the rail groups them under Today / Yesterday / This Week / Older sections with empty groups hidden
+
+#### Scenario: Source reference click navigates
+
+- **WHEN** the user clicks a SourceReference chip on an assistant message
+- **THEN** the system navigates to the underlying record:
+  - `Person` → person detail page
+  - `Initiative` → initiative detail (Overview tab)
+  - `Capture` → capture detail
+  - `Commitment` → commitment detail / list-with-highlight
+  - `Delegation` → delegation detail / list-with-highlight
+  - `LivingBrief*` → initiative detail (Living Brief tab) anchored at the relevant section

--- a/openspec/changes/global-ai-chat/tasks.md
+++ b/openspec/changes/global-ai-chat/tasks.md
@@ -1,0 +1,109 @@
+## 1. Domain Layer — Extend ContextScope and SourceReference
+
+- [ ] 1.1 Add `Global()` factory and equality semantics to the `ContextScope` value object (introduced by `initiative-ai-chat`)
+- [ ] 1.2 Extend `SourceReferenceEntityType` enum with `Person`; reserve `Observation`, `Goal`, `OneOnOne` (forward-compatible with `people-lens`)
+- [ ] 1.3 Update `SourceReference` validation tests to cover the new enum values
+- [ ] 1.4 Create domain event `GlobalChatThreadStarted`
+- [ ] 1.5 Update `ChatThread.Start(...)` so that when ContextScope is Global, both `ChatThreadStarted` and `GlobalChatThreadStarted` are raised
+
+## 2. Domain Unit Tests
+
+- [ ] 2.1 Test ContextScope.Global equality and discriminator
+- [ ] 2.2 Test ChatThread.Start(Global) raises both events
+- [ ] 2.3 Test SourceReference accepts Person and rejects unknown EntityTypes
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Update `ChatThreadConfiguration` (no migration needed — `ContextScopeType = "Global"` and nullable `ContextInitiativeId` already exist) to recognise Global discriminator on read/write
+- [ ] 3.2 Update `ChatThreadRepository` with global-scope listing query (filter `ContextScopeType = "Global"`, ordered by LastMessageAt desc nulls last)
+- [ ] 3.3 Add database integration test for Global thread persistence and round-trip
+
+## 4. Application Layer — Intent Classifier
+
+- [ ] 4.1 Define `ChatIntent` enum (MyDay, MyWeek, OverdueWork, PersonLens, InitiativeStatus, CaptureSearch, Generic)
+- [ ] 4.2 Define `IntentSet` DTO (intents, entityHints { personIds, initiativeIds, dateRange? })
+- [ ] 4.3 Implement `RuleIntentClassifier` (regex/keyword patterns; person/initiative name resolution against the user's records)
+- [ ] 4.4 Implement `AiIntentClassifier` (single AI call, structured-response prompt, defensive parser)
+- [ ] 4.5 Implement `HybridIntentClassifier` orchestrating rules first, AI fallback on no-rule or Generic-only
+- [ ] 4.6 Unit tests: rule paths for each intent, AI fallback path, ambiguous person names returning multiple PersonIds, multilingual fallback
+
+## 5. Application Layer — GlobalChatContextBuilder
+
+- [ ] 5.1 Create `IGlobalChatContextBuilder` and `GlobalChatContextBuilder` implementation
+- [ ] 5.2 Implement per-intent context slice queries (MyDay/MyWeek, OverdueWork, PersonLens, InitiativeStatus, CaptureSearch, Generic) with hard caps from the spec
+- [ ] 5.3 Enforce total token budget with priority-ordered degradation (recent captures → delegations → commitments → person/initiative cores) and a `truncationNotes` payload
+- [ ] 5.4 All queries filter by UserId; never read another user's data
+- [ ] 5.5 Forward-compatibility: gracefully omit observations/goals/one-on-ones sections when `people-lens` aggregates do not exist
+- [ ] 5.6 Unit tests: cap enforcement per intent, multi-intent stacking, budget degradation, user isolation, empty-data initiative/person
+
+## 6. Application Layer — GlobalChatCompletionService
+
+- [ ] 6.1 Create `IGlobalChatCompletionService` and implementation `GlobalChatCompletionService`
+- [ ] 6.2 Define global system prompt (utilitarian, citation-required, refusal on out-of-scope)
+- [ ] 6.3 Reuse the structured-envelope parser via shared `ChatResponseParser` utility (extracted from `initiative-ai-chat`)
+- [ ] 6.4 Orchestration: append user message → classify → build context → call IAiCompletionService → parse → drop unknown SourceReference IDs → append assistant message → persist
+- [ ] 6.5 Handle `AiProviderException` by appending an Assistant message with friendly error
+- [ ] 6.6 Handle `TasteLimitExceededException` by appending a System message "Daily AI limit reached"
+- [ ] 6.7 Conversation history budget: include last N messages by token estimate; hard cap
+
+## 7. Application Layer — Vertical Slice Handlers
+
+- [ ] 7.1 `StartGlobalChatThread` command handler (POST /api/chat/threads)
+- [ ] 7.2 `ListGlobalChatThreads` query handler (GET /api/chat/threads, status filter)
+- [ ] 7.3 `GetGlobalChatThread` query handler (GET /api/chat/threads/{threadId}); 404 when threadId is initiative-scoped
+- [ ] 7.4 `RenameGlobalChatThread` command handler (PUT /api/chat/threads/{threadId})
+- [ ] 7.5 `PostGlobalChatMessage` command handler (POST /api/chat/threads/{threadId}/messages) — orchestrates GlobalChatCompletionService
+- [ ] 7.6 `ArchiveGlobalChatThread` command handler (POST /archive)
+- [ ] 7.7 `UnarchiveGlobalChatThread` command handler (POST /unarchive)
+
+## 8. Application Unit Tests
+
+- [ ] 8.1 PostGlobalChatMessage happy path: classify → context → reply with citations
+- [ ] 8.2 Person query path produces SourceReferences of EntityType Person
+- [ ] 8.3 Posting to archived global thread returns Conflict
+- [ ] 8.4 Wrong-scope thread fetch returns 404 (initiative thread requested via /api/chat)
+- [ ] 8.5 AiProviderException and TasteLimitExceededException paths
+- [ ] 8.6 Unknown SourceReference EntityIds dropped
+- [ ] 8.7 Cross-user thread access returns 404
+
+## 9. Web API Layer
+
+- [ ] 9.1 Create `GlobalChatEndpoints` minimal API mapping all routes under `/api/chat/threads`
+- [ ] 9.2 Create request/response DTOs (start-thread, list-thread summary, get-thread with messages, post-message response)
+
+## 10. Frontend — Models and Service
+
+- [ ] 10.1 Reuse TypeScript models `ChatThread`, `ChatMessage`, `SourceReference`, `ContextScope` from `initiative-ai-chat`
+- [ ] 10.2 Extend the SourceReference EntityType union to include `Person` (and forward-compatible `Observation`, `Goal`, `OneOnOne`)
+- [ ] 10.3 Create `GlobalChatService` mirroring the InitiativeChatService API, but pointing at `/api/chat/threads`
+- [ ] 10.4 Create signals for active global thread, thread list, and slide-over open state in a shared `GlobalChatStateService`
+
+## 11. Frontend — Launcher and Slide-over
+
+- [ ] 11.1 Add `GlobalChatLauncherComponent` (PrimeNG button with sparkle icon) to the app shell
+- [ ] 11.2 Hide launcher on unauthenticated routes
+- [ ] 11.3 Create `GlobalChatSlideOverComponent` using PrimeNG Sidebar (right-aligned), preselecting the most-recent active thread or starting an empty one
+- [ ] 11.4 Implement composer with submit on Enter (Shift+Enter newline), disabled while awaiting reply
+- [ ] 11.5 Render assistant messages with `SourceReferenceChipComponent` (reused from `initiative-ai-chat`, extended for Person)
+- [ ] 11.6 Add "Open in full view" link routing to `/chat` and preserving the active thread
+
+## 12. Frontend — Full-page Chat View
+
+- [ ] 12.1 Add `/chat` route guarded for authenticated users
+- [ ] 12.2 Create `GlobalChatPageComponent` with thread rail and conversation pane
+- [ ] 12.3 Group rail by date sections (Today / Yesterday / This Week / Older); hide empty groups
+- [ ] 12.4 Per-thread inline rename and archive controls; collapsed Archived section
+- [ ] 12.5 New-thread button at top of rail
+- [ ] 12.6 SourceReference chip routing: Person → person detail; Initiative → overview; Capture → capture detail; Commitment/Delegation → list-with-highlight; LivingBrief* → initiative detail Living Brief tab anchored
+- [ ] 12.7 Loading state: skeleton/spinner in place of assistant message while in flight
+- [ ] 12.8 Friendly rendering of System messages (limit reached, AI error)
+
+## 13. E2E Tests
+
+- [ ] 13.1 E2E: open the launcher, post "What's overdue?", receive a reply with SourceReference chips of EntityType Commitment/Delegation
+- [ ] 13.2 E2E: post "How is <Person> doing?" and receive a reply with a SourceReference of EntityType Person
+- [ ] 13.3 E2E: open in full view; switch threads; rename a thread
+- [ ] 13.4 E2E: archive and unarchive a global thread
+- [ ] 13.5 E2E: user isolation — User A cannot see or post to User B's global thread (404)
+- [ ] 13.6 E2E: posting to an archived thread surfaces a Conflict error in the UI
+- [ ] 13.7 E2E: source-reference chips navigate to the correct destination per EntityType

--- a/openspec/changes/initiative-ai-chat/.openspec.yaml
+++ b/openspec/changes/initiative-ai-chat/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/initiative-ai-chat/design.md
+++ b/openspec/changes/initiative-ai-chat/design.md
@@ -1,0 +1,139 @@
+## Context
+
+The Living Brief turns captures into structured initiative knowledge. Chat is the natural reading interface on top of that knowledge. This spec introduces the `ChatThread` aggregate that will be reused by `global-ai-chat`. The shape of `ChatThread`, `ChatMessage`, and `SourceReference` matters because `global-ai-chat` should not require a different aggregate.
+
+### Dependencies
+
+- `ai-provider-abstraction` (Tier 1) — `IAiCompletionService.CompleteAsync` and `TasteLimitExceededException`.
+- `initiative-living-brief` (Tier 2) — the brief is the primary context source for chat.
+- `initiative-management` (Tier 1) — InitiativeId is the binding.
+- `commitment-tracking` and `delegation-tracking` (Tier 2) — read-only context sources.
+- `capture-text` and `capture-ai-extraction` (Tier 2) — capture summaries are read for context.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Design `ChatThread` once such that `global-ai-chat` can adopt it by adding a new `ContextScope` variant — no fork, no aggregate split.
+- Persist every assistant response with its `SourceReference` list so the user can click through to the underlying record.
+- Keep AI calls synchronous from the user's perspective (request/response per message) but bounded — large initiatives must not blow the context window.
+- Honour multi-tenant isolation strictly: a thread is invisible to another user, and context assembly never mixes users.
+- Treat thread state (messages, ordinal, status) as part of the aggregate; treat per-call AI cost concerns (token budgets, retries) as application-layer concerns.
+
+**Non-Goals:**
+
+- Real-time streaming responses to the client.
+- Multi-user / shared threads.
+- Vector / semantic search.
+- Tool-use / function-calling from chat (no "create commitment" actions).
+- Cross-thread or cross-initiative memory.
+
+## Decisions
+
+### 1. ChatThread is a single aggregate root reused for both initiative and global chat
+
+**Decision:** `ChatThread` has a `ContextScope` value object discriminating by variant. This spec implements `ContextScope.Initiative(InitiativeId)`. `global-ai-chat` will later add `ContextScope.Global()` without any structural change. The aggregate has a UserId (required), Title (auto-generated from first user message; user-renameable), CreatedAt, LastMessageAt, Status (`Active | Archived`), and an ordered list of embedded `ChatMessage` value objects.
+
+**Rationale:** Threads behave the same way regardless of scope; only context assembly differs. One aggregate avoids duplication and keeps the chat UI consistent.
+
+**Alternatives considered:**
+- Two aggregates (`InitiativeChatThread`, `GlobalChatThread`) — rejected for duplication.
+- One aggregate with a nullable `InitiativeId` — rejected because an explicit `ContextScope` is more expressive and future-proof for additional scopes.
+
+### 2. Messages embedded on the thread; ordinal for stable order
+
+**Decision:** `ChatMessage` is a value object embedded in `ChatThread.Messages`. Each message carries `MessageOrdinal` (monotonic int starting at 1), `Role`, `Content`, `CreatedAt`, optional `SourceReferences` (only on assistant messages), and optional `TokenUsage`. Persisted as JSONB.
+
+**Rationale:** A thread without its messages is meaningless — embedding preserves aggregate invariants (e.g. ordinal is contiguous, roles alternate U/A after the optional system message). JSONB matches the storage pattern from `LivingBrief`.
+
+**Trade-off:** Very long threads grow the aggregate row. **Mitigation:** Threads can be archived; new threads are cheap. A future spec can add server-side message pagination if real users hit the row-size ceiling.
+
+### 3. SourceReference is a structured citation, not a pointer-with-text
+
+**Decision:** `SourceReference` carries `EntityType` (one of `Capture | Commitment | Delegation | LivingBriefDecision | LivingBriefRisk | LivingBriefRequirements | LivingBriefDesignDirection | Initiative`), `EntityId` (Guid), optional `SnippetText` (the bit of context the AI quoted), and optional `RelevanceScore`. Frontend resolves the link target based on EntityType.
+
+**Rationale:** Structured citations let the UI render typed chips ("[D] Decision: Adopt PostgreSQL") and route clicks. Free-text "as the brief says..." is unverifiable.
+
+### 4. Context assembly is rule-based and bounded
+
+**Decision:** `InitiativeChatContextBuilder.Build(initiativeId, userQuestion, recentMessages)` returns a structured payload:
+
+- `initiativeMetadata`: { id, name, status, milestones }
+- `livingBrief`: { summary, recentDecisions[20], openRisks, latestRequirements, latestDesignDirection }
+- `commitments`: open and recently-completed (within 30 days), max 50 items, projected to { id, description, direction, personName, status, dueDate }
+- `delegations`: active (Assigned/InProgress/Blocked) plus recently-completed (within 30 days), max 50 items, projected to { id, description, delegateName, status, dueDate, blockedReason }
+- `linkedCaptures`: most recent 30 confirmed captures' { id, createdAt, summary } from `AiExtraction.Summary`
+
+Hard caps protect the context window. Items are ordered by recency. The `userQuestion` itself is NOT used for filtering in this spec — context is rule-based, not retrieval-based.
+
+**Rationale:** Predictable cost and behaviour. Retrieval (vector search, hybrid search) is a known evolution, called out in non-goals; this design leaves room for it (a future `IChatContextBuilder` could be swapped in).
+
+**Alternatives considered:**
+- Embedding-based retrieval — deferred; adds a vector DB dependency and a re-indexing pipeline. Rule-based covers most "what did we decide?" / "who's blocked?" questions on a single initiative.
+
+### 5. AI prompting strategy
+
+**Decision:** A system prompt instructs the model to: answer using only the provided context; cite every factual claim with a `SourceReference` JSON entry; respond with a structured envelope `{ assistantText: string, sourceReferences: SourceReference[] }`; refuse out-of-scope questions politely. The user message is the natural-language question. Conversation history (last N messages, capped by token budget) is included as prior turns.
+
+**Rationale:** Forcing a structured response keeps citations tractable. Refusal on out-of-scope keeps responses honest.
+
+**Trade-off:** Models that don't reliably emit JSON degrade gracefully — the parser falls back to "assistant text only, no citations" if the envelope can't be parsed.
+
+### 6. Synchronous request/response
+
+**Decision:** `POST /chat/threads/{threadId}/messages` blocks until the AI completes and returns both the user message and the assistant message in one response. No streaming SSE in this spec.
+
+**Rationale:** Simpler client; matches the existing capture-AI flow. Streaming is an enhancement.
+
+### 7. Title auto-generation
+
+**Decision:** When a thread is created, its title is empty. After the first user message, the application layer derives a title (truncated user message text, max 80 chars; the AI is not used for titling in this spec). The user can rename via `PUT /chat/threads/{threadId}` with `{ "title": "..." }`.
+
+**Rationale:** Avoids an extra AI call. Trivial but useful for thread navigation.
+
+### 8. API surface
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/initiatives/{id}/chat/threads` | POST | Start a new thread (returns thread with empty messages) |
+| `/api/initiatives/{id}/chat/threads` | GET | List active threads for the initiative (filter by status) |
+| `/api/initiatives/{id}/chat/threads/{threadId}` | GET | Get full thread including all messages |
+| `/api/initiatives/{id}/chat/threads/{threadId}` | PUT | Rename thread |
+| `/api/initiatives/{id}/chat/threads/{threadId}/messages` | POST | Post a user message and return the assistant reply |
+| `/api/initiatives/{id}/chat/threads/{threadId}/archive` | POST | Archive the thread (soft) |
+| `/api/initiatives/{id}/chat/threads/{threadId}/unarchive` | POST | Restore archived thread |
+
+**Rationale:** Threads as a sub-resource of an initiative; messages as a sub-collection of a thread.
+
+### 9. Frontend: chat tab on initiative detail
+
+**Decision:** A new "Chat" tab next to "Living Brief" on the initiative detail page. Layout: left rail of threads (active by default; archived expandable), main panel showing the active thread (scrollable message list), composer at the bottom. Assistant messages render `SourceReference` chips that route to the source record (capture detail, commitment detail, etc.) when clicked. New-thread button at the top of the rail. All state via Angular signals; PrimeNG components first.
+
+**Rationale:** Co-locates chat with the initiative the user is reading about; familiar two-pane chat layout.
+
+### 10. Storage shape
+
+**Decision:** Single `ChatThreads` table:
+
+- `Id` (PK), `UserId`, `ContextScopeType` (string discriminator), `ContextInitiativeId` (nullable Guid), `Title`, `Status`, `CreatedAt`, `LastMessageAt`, `Messages` (JSONB), `MessageCount` (denormalised int for cheap listing).
+- Indexes: `(UserId, ContextScopeType, ContextInitiativeId, Status, LastMessageAt DESC)`.
+
+**Rationale:** One table now, ready for `global-ai-chat` (which will use `ContextScopeType = "Global"` with null `ContextInitiativeId`). Denormalised `MessageCount` keeps thread-list queries cheap.
+
+## Risks / Trade-offs
+
+- **[Context window overflow]** Very large initiatives could exceed the model's input budget. **Mitigation:** Hard caps in the context builder (50 commitments, 50 delegations, 30 captures); recent-message window for conversation history.
+- **[Hallucinated citations]** The model could cite EntityIds that aren't in context. **Mitigation:** The parser validates that each `SourceReference.EntityId` appeared in the assembled context; unknown IDs are dropped before persisting.
+- **[Multi-tenant context leak]** If context assembly accidentally pulled cross-user data, it would leak via the AI. **Mitigation:** Every context query is filtered by UserId; integration tests cover the isolation boundary.
+- **[Thread row growth]** Long threads grow the JSONB column. **Mitigation:** Acceptable at Tier 2 scale; archiving is provided. Pagination/sharding deferred.
+- **[Fragile JSON parsing]** Models occasionally don't emit clean JSON. **Mitigation:** Best-effort parse with fallback to "no citations"; persist the raw assistant text either way so the user always sees a reply.
+- **[AI cost per turn]** Each message is a paid AI call. **Mitigation:** `TasteLimitExceededException` handled by returning a friendly assistant message ("Daily AI limit reached") that is persisted as a system message with no token usage; no thread corruption.
+
+## Migration Plan
+
+- One EF Core migration adds the `ChatThreads` table. No data migration; threads start empty.
+- No breaking changes to existing aggregates.
+
+## Open Questions
+
+_(none — defaults documented: synchronous responses, rule-based context, manual title generation.)_

--- a/openspec/changes/initiative-ai-chat/proposal.md
+++ b/openspec/changes/initiative-ai-chat/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Once an initiative has a Living Brief, linked captures, commitments, and delegations, the manager has a rich knowledge base — but interrogating it still requires clicking through screens. The natural way to ask "who's blocked on the API spec?" or "what did we decide about Postgres?" is conversation. This spec adds a multi-turn AI chat panel scoped to a single initiative, with answers grounded in that initiative's data and source-referenced back to the records that informed them.
+
+This is a Tier 2 spec (`initiative-ai-chat`) that depends on `ai-provider-abstraction` (Tier 1) and `initiative-living-brief` (Tier 2). It introduces the `ChatThread` aggregate, which `global-ai-chat` (also Tier 2) will later reuse with a global scope.
+
+## Non-goals
+
+- **No global / cross-initiative chat** — that is `global-ai-chat`. This spec creates the ChatThread aggregate with an Initiative-scoped binding only.
+- **No file uploads or image inputs** — text in, text out. Audio capture remains in `capture-audio` (Tier 3).
+- **No actions from chat** ("create a commitment for me") — chat is read-only this tier. Action-from-chat is a future concern.
+- **No streaming responses to the client** — responses are persisted whole, then returned. SSE streaming is a Tier 3 enhancement.
+- **No semantic / vector search over historic data** — context assembly is rule-based (load the initiative's brief + linked records).
+- **No shared / multi-user threads** — every thread is single-user-scoped.
+- **No fine-tuning, no memory of previous threads** — each thread is independent.
+
+## What Changes
+
+- **New `ChatThread` aggregate root** in the Domain layer, scoped to a User and bound to an Initiative via `ContextScope` (a value object — this spec only implements `ContextScope.Initiative(initiativeId)`; `Global()` is reserved for `global-ai-chat`).
+- **New `ChatMessage` value object** embedded on the thread (Role: `User | Assistant | System`, Content, CreatedAt, optional `SourceReferences` list, optional `TokenUsage`, and an `MessageOrdinal` for stable ordering).
+- **New `SourceReference` value object** capturing a citation: `EntityType` (Capture | Commitment | Delegation | LivingBrief | Initiative), `EntityId`, optional `SnippetText`, and an optional `RelevanceScore`.
+- **New `InitiativeChatContextBuilder` Application service** that, given an InitiativeId and the user's question, assembles a structured context payload from the LivingBrief, linked Captures' `AiExtraction.Summary`, open Commitments linked to the initiative, and active Delegations linked to the initiative.
+- **CQRS handlers and minimal API endpoints** under `/api/initiatives/{id}/chat/threads` for: starting a thread, listing threads, getting a thread (with all messages), posting a user message (which triggers the AI completion synchronously and returns the assistant message), renaming a thread, and archiving a thread.
+- **EF Core persistence** for `ChatThread` and embedded messages (one new migration).
+- **Angular initiative chat panel** on the initiative detail page — a new "Chat" tab with thread list, active conversation view, message composer, source-reference chips on assistant messages, and a "new thread" action.
+- **Domain events** `ChatThreadStarted`, `ChatMessageSent`, `ChatMessageReceived`, `ChatThreadRenamed`, `ChatThreadArchived`.
+
+## Capabilities
+
+### New Capabilities
+
+- `initiative-ai-chat`: Multi-turn AI chat scoped to a single Initiative — assembles context from the initiative's LivingBrief, linked captures, commitments, and delegations; responses cite the records that informed them; thread history persisted.
+
+### Modified Capabilities
+
+_(none — `initiative-living-brief`, `commitment-tracking`, `delegation-tracking`, and `capture-ai-extraction` are read from but not modified. The ChatThread aggregate is new and self-contained.)_
+
+## Impact
+
+- **Domain:** New `ChatThread` aggregate root with embedded `ChatMessage` value objects, `SourceReference` value object, `ContextScope` value object (initiative variant only), `ChatRole` and `ChatThreadStatus` enums.
+- **Application:** New `InitiativeChatContextBuilder`, new `ChatCompletionService` orchestrator wrapping `IAiCompletionService`, new vertical-slice handlers under `Initiatives/Chat/`.
+- **Infrastructure:** EF Core configuration for `ChatThreads` table with messages serialised as JSONB; one new migration.
+- **Web API:** New endpoints under `/api/initiatives/{id}/chat/threads`.
+- **Frontend:** New "Chat" tab on the initiative detail page, chat panel components, chat service.
+- **AI prompting:** New system prompt for initiative-scoped chat; respects `IAiCompletionService` and `TasteLimitExceededException`.
+- **Dependencies:** `ai-provider-abstraction`, `initiative-living-brief`, `initiative-management`, `commitment-tracking`, `delegation-tracking`, `capture-text`, `capture-ai-extraction`.

--- a/openspec/changes/initiative-ai-chat/specs/initiative-ai-chat/spec.md
+++ b/openspec/changes/initiative-ai-chat/specs/initiative-ai-chat/spec.md
@@ -1,0 +1,214 @@
+## ADDED Requirements
+
+### Requirement: ChatThread aggregate
+
+The system SHALL define a `ChatThread` aggregate root with: `Id` (Guid), `UserId` (Guid, required), `ContextScope` (value object — for this spec, only `ContextScope.Initiative(InitiativeId)` is supported), `Title` (string, may be empty), `Status` (`Active | Archived`), `CreatedAt`, `LastMessageAt` (nullable until first message), `MessageCount` (int, denormalised), and `Messages` (ordered list of `ChatMessage` value objects). All ChatThreads SHALL be scoped to a single user via UserId.
+
+#### Scenario: Aggregate invariants
+
+- **WHEN** a ChatThread is created
+- **THEN** Status is Active, MessageCount is 0, Messages is empty, LastMessageAt is null, ContextScope is set, and UserId is set
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a chat thread on Initiative X and User B has the same Initiative ID (impossible by design, but enforced)
+- **THEN** User A's threads never appear in any of User B's queries, including listings, get-by-id, and message posts (HTTP 404 for User B)
+
+### Requirement: ChatMessage value object
+
+Each `ChatMessage` SHALL contain: `MessageOrdinal` (int, monotonically increasing within a thread, starting at 1), `Role` (`User | Assistant | System`), `Content` (string, may be empty for system messages with metadata-only payloads), `CreatedAt` (datetime), optional `SourceReferences` (only valid when Role is Assistant), optional `TokenUsage` (`{ promptTokens, completionTokens }`).
+
+#### Scenario: Ordinal contiguity
+
+- **WHEN** messages are appended to a thread in order
+- **THEN** the MessageOrdinal of the Nth message is N (no gaps)
+
+#### Scenario: SourceReferences only on assistant messages
+
+- **WHEN** a User or System message is appended
+- **THEN** SourceReferences MUST be empty
+
+### Requirement: SourceReference value object
+
+A `SourceReference` SHALL contain: `EntityType` (one of `Capture`, `Commitment`, `Delegation`, `LivingBriefDecision`, `LivingBriefRisk`, `LivingBriefRequirements`, `LivingBriefDesignDirection`, `Initiative`), `EntityId` (Guid), optional `SnippetText`, and optional `RelevanceScore` (decimal 0.0-1.0).
+
+#### Scenario: Validate entity type
+
+- **WHEN** a SourceReference is constructed with an unrecognised EntityType
+- **THEN** construction throws a domain validation error
+
+### Requirement: Start a new initiative chat thread
+
+The system SHALL allow an authenticated user to start a new chat thread for one of their initiatives via `POST /api/initiatives/{id}/chat/threads`. The system SHALL create a ChatThread with `ContextScope.Initiative(initiativeId)`, empty Title, Status `Active`, and raise a `ChatThreadStarted` domain event.
+
+#### Scenario: Start a thread
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/chat/threads` for an initiative they own
+- **THEN** the system creates a new ChatThread, returns HTTP 201 with the thread (id, contextScope, title, status, createdAt, empty messages array)
+
+#### Scenario: Initiative not found
+
+- **WHEN** the InitiativeId does not exist or belongs to another user
+- **THEN** the system returns HTTP 404 and no thread is created
+
+### Requirement: List initiative chat threads
+
+The system SHALL allow an authenticated user to list chat threads for one of their initiatives via `GET /api/initiatives/{id}/chat/threads`, optionally filtered by `status` (defaulting to `Active`). Threads SHALL be ordered by `LastMessageAt DESC` (nulls last, by `CreatedAt DESC`).
+
+#### Scenario: List active threads
+
+- **WHEN** an authenticated user sends `GET /api/initiatives/{id}/chat/threads`
+- **THEN** the system returns active threads belonging to the user for that initiative, newest first, each thread summary includes id, title, status, createdAt, lastMessageAt, and messageCount
+
+#### Scenario: List archived threads
+
+- **WHEN** an authenticated user sends `GET /api/initiatives/{id}/chat/threads?status=Archived`
+- **THEN** only archived threads are returned
+
+#### Scenario: Empty list
+
+- **WHEN** the user has no threads on the initiative
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get a chat thread with messages
+
+The system SHALL allow an authenticated user to fetch a thread including all messages via `GET /api/initiatives/{id}/chat/threads/{threadId}`.
+
+#### Scenario: Get thread
+
+- **WHEN** an authenticated user requests an existing thread
+- **THEN** the response includes thread metadata and all messages in MessageOrdinal order, each message with role, content, createdAt, sourceReferences (for assistant messages), and tokenUsage when available
+
+#### Scenario: Thread not found or wrong user
+
+- **WHEN** the threadId does not exist, belongs to another user, or belongs to a different initiative than the URL specifies
+- **THEN** the system returns HTTP 404
+
+### Requirement: Post a user message and receive an assistant reply
+
+The system SHALL allow an authenticated user to post a user message via `POST /api/initiatives/{id}/chat/threads/{threadId}/messages` with body `{ "content": "<text>" }`. The system SHALL: append the user message (Role User, next MessageOrdinal, raise `ChatMessageSent`), call `InitiativeChatContextBuilder` to assemble context, call `IAiCompletionService.CompleteAsync` with the system prompt + assembled context + recent conversation history + the user message, parse the assistant reply (text + source references), append it as a single Assistant message (raise `ChatMessageReceived`), update `LastMessageAt` and `MessageCount` (incremented by 2), persist the thread, and return HTTP 200 with `{ userMessage, assistantMessage }`.
+
+#### Scenario: Post a question and receive a grounded answer
+
+- **WHEN** an authenticated user posts "What did we decide about Postgres?" to a thread on an initiative whose Living Brief contains a decision "Adopt PostgreSQL"
+- **THEN** the system appends the user message, generates an assistant reply that references the LivingBriefDecision SourceReference (EntityType LivingBriefDecision, EntityId of that decision), persists both messages, and returns HTTP 200
+
+#### Scenario: Empty content rejected
+
+- **WHEN** the user posts a message with empty or whitespace-only content
+- **THEN** the system returns HTTP 400 and no messages are appended
+
+#### Scenario: Thread is archived
+
+- **WHEN** the user posts to an Archived thread
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: AI provider failure
+
+- **WHEN** the AI completion call throws an `AiProviderException`
+- **THEN** the user message is still appended, an Assistant or System message containing a friendly error ("AI service unavailable, please retry") is appended in its place, and the system returns HTTP 200 with both messages
+
+#### Scenario: Taste limit exceeded
+
+- **WHEN** the AI completion call throws a `TasteLimitExceededException`
+- **THEN** the user message is appended, a System message with content "Daily AI limit reached" is appended, and the system returns HTTP 200
+
+#### Scenario: Invalid citations dropped
+
+- **WHEN** the AI returns a SourceReference whose EntityId is not present in the assembled context payload
+- **THEN** that SourceReference is dropped before persisting and the assistant message contains only validated references
+
+#### Scenario: Malformed AI envelope falls back gracefully
+
+- **WHEN** the AI response cannot be parsed into the structured envelope
+- **THEN** the entire raw response text is persisted as the assistant message content with empty SourceReferences
+
+### Requirement: Context assembly is bounded and user-scoped
+
+The `InitiativeChatContextBuilder` SHALL produce a context payload from data belonging to the same user as the thread, capped as follows: at most the 20 most-recent KeyDecisions, all Open risks, the latest RequirementsSnapshot, the latest DesignDirectionSnapshot; up to 50 most-recent Commitments linked to the initiative (open + recently completed within 30 days); up to 50 most-recent Delegations linked to the initiative (active + recently completed within 30 days); the 30 most-recent confirmed Captures linked to the initiative (using each capture's `AiExtraction.Summary`).
+
+#### Scenario: Context respects caps
+
+- **WHEN** an initiative has 100 commitments and 100 captures
+- **THEN** the assembled context contains at most 50 commitments and 30 capture summaries
+
+#### Scenario: Context never crosses users
+
+- **WHEN** building context for a thread belonging to User A
+- **THEN** every commitment, delegation, capture, and brief field included is owned by User A; no User B records are read
+
+#### Scenario: Empty initiative
+
+- **WHEN** the initiative has no captures, commitments, delegations, or brief content
+- **THEN** the assembled context contains only initiative metadata and the AI is invoked with an essentially empty knowledge base
+
+### Requirement: Auto-generated thread title
+
+When the first user message is appended to a thread with empty Title, the system SHALL set the Title to the user-message content truncated to 80 characters (with ellipsis if truncated). The system SHALL raise `ChatThreadRenamed` with `source = "AutoFromFirstMessage"`.
+
+#### Scenario: Auto-title from first message
+
+- **WHEN** a user posts the first message "What is blocking the API spec delivery?" to a new thread
+- **THEN** the thread's Title becomes "What is blocking the API spec delivery?"
+
+#### Scenario: Long first message truncated
+
+- **WHEN** the first message is 200 characters long
+- **THEN** the Title is the first 80 characters followed by an ellipsis
+
+### Requirement: Rename a thread
+
+The system SHALL allow an authenticated user to rename a thread via `PUT /api/initiatives/{id}/chat/threads/{threadId}` with body `{ "title": "..." }`. Title SHALL be at most 200 characters and not whitespace-only. The system SHALL raise `ChatThreadRenamed` with `source = "Manual"`.
+
+#### Scenario: Rename a thread
+
+- **WHEN** an authenticated user renames a thread to "Q3 Planning Discussion"
+- **THEN** the Title is updated and the system returns HTTP 200
+
+#### Scenario: Empty title rejected
+
+- **WHEN** the title is empty or whitespace
+- **THEN** the system returns HTTP 400
+
+### Requirement: Archive and unarchive a thread
+
+The system SHALL allow an authenticated user to archive an Active thread via `POST /api/initiatives/{id}/chat/threads/{threadId}/archive` (raise `ChatThreadArchived`) and to unarchive an Archived thread via `POST /api/initiatives/{id}/chat/threads/{threadId}/unarchive` (Status returns to Active).
+
+#### Scenario: Archive an active thread
+
+- **WHEN** an authenticated user archives an Active thread
+- **THEN** Status becomes Archived and the system returns HTTP 200
+
+#### Scenario: Unarchive an archived thread
+
+- **WHEN** an authenticated user unarchives an Archived thread
+- **THEN** Status becomes Active and the system returns HTTP 200
+
+#### Scenario: Archive twice rejected
+
+- **WHEN** the user attempts to archive an already-Archived thread (or unarchive an Active thread)
+- **THEN** the system returns HTTP 409
+
+### Requirement: Initiative chat tab in UI
+
+The frontend SHALL provide a "Chat" tab on the initiative detail page. The tab SHALL display: a left rail listing active threads (with a collapsed Archived section), a main panel showing the selected thread's messages in order, a composer at the bottom for posting a new user message, a "New thread" action at the top of the rail, and rename/archive controls on each thread. Assistant messages SHALL render `SourceReference` chips that, when clicked, navigate to the underlying record (capture detail, commitment detail, delegation detail, or scroll to the corresponding decision/risk/snapshot in the Living Brief tab). Component state SHALL use Angular signals.
+
+#### Scenario: Send a message and see a reply
+
+- **WHEN** a user types a question into the composer and submits
+- **THEN** the user message appears immediately, a loading indicator shows while the AI responds, and the assistant message renders with source-reference chips
+
+#### Scenario: Click a source reference
+
+- **WHEN** a user clicks a SourceReference chip on an assistant message of type "Capture"
+- **THEN** the system navigates to that capture's detail page
+
+#### Scenario: Switch threads
+
+- **WHEN** a user clicks a different thread in the left rail
+- **THEN** the main panel loads that thread's messages
+
+#### Scenario: New thread
+
+- **WHEN** a user clicks "New thread"
+- **THEN** an empty thread is created and selected; the composer is focused

--- a/openspec/changes/initiative-ai-chat/tasks.md
+++ b/openspec/changes/initiative-ai-chat/tasks.md
@@ -1,0 +1,102 @@
+## 1. Domain Layer — ChatThread aggregate
+
+- [ ] 1.1 Create `ChatRole` enum (User, Assistant, System) and `ChatThreadStatus` enum (Active, Archived) in `src/MentalMetal.Domain/ChatThreads/`
+- [ ] 1.2 Create `ContextScope` value object with `Initiative(InitiativeId)` factory; reserve `Global()` for global-ai-chat (not implemented in this spec)
+- [ ] 1.3 Create `SourceReferenceEntityType` enum (Capture, Commitment, Delegation, LivingBriefDecision, LivingBriefRisk, LivingBriefRequirements, LivingBriefDesignDirection, Initiative)
+- [ ] 1.4 Create `SourceReference` value object (EntityType, EntityId, SnippetText?, RelevanceScore?) with validation
+- [ ] 1.5 Create `TokenUsage` value object (PromptTokens, CompletionTokens)
+- [ ] 1.6 Create `ChatMessage` value object (MessageOrdinal, Role, Content, CreatedAt, SourceReferences, TokenUsage?) with validation that SourceReferences is empty unless Role is Assistant
+- [ ] 1.7 Create `ChatThread` aggregate root with Id, UserId, ContextScope, Title, Status, CreatedAt, LastMessageAt, MessageCount, Messages
+- [ ] 1.8 Implement factory `Start(userId, contextScope)`; raise `ChatThreadStarted`
+- [ ] 1.9 Implement `AppendUserMessage(content)` returning the new message; raise `ChatMessageSent`; auto-set Title from first user message; update LastMessageAt and MessageCount
+- [ ] 1.10 Implement `AppendAssistantMessage(content, sourceReferences, tokenUsage?)`; raise `ChatMessageReceived`
+- [ ] 1.11 Implement `AppendSystemMessage(content)` for error / limit notices
+- [ ] 1.12 Implement `Rename(title, source)` with validation; raise `ChatThreadRenamed`
+- [ ] 1.13 Implement `Archive()` and `Unarchive()` with status guards; raise `ChatThreadArchived` / unarchive equivalent
+- [ ] 1.14 Create `IChatThreadRepository` interface
+- [ ] 1.15 Create domain events: `ChatThreadStarted`, `ChatMessageSent`, `ChatMessageReceived`, `ChatThreadRenamed`, `ChatThreadArchived`
+
+## 2. Domain Unit Tests
+
+- [ ] 2.1 Test ChatThread.Start invariants
+- [ ] 2.2 Test message ordinal contiguity and updates to MessageCount/LastMessageAt
+- [ ] 2.3 Test SourceReferences rejected on User/System messages
+- [ ] 2.4 Test auto-title from first user message (truncated at 80 chars with ellipsis)
+- [ ] 2.5 Test Rename validation (empty/whitespace rejected)
+- [ ] 2.6 Test Archive/Unarchive guards (re-archive rejected)
+- [ ] 2.7 Test ContextScope.Initiative validation
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Create `ChatThreadConfiguration` (table `ChatThreads`, JSONB Messages column, JSONB ContextScope columns or discriminator + nullable InitiativeId)
+- [ ] 3.2 Implement `ChatThreadRepository` with filtered listings (by user, by initiative, by status, ordered by LastMessageAt DESC NULLS LAST)
+- [ ] 3.3 Register repository in DI
+- [ ] 3.4 Add EF Core migration `AddChatThreads`
+
+## 4. Application Layer — Context Builder
+
+- [ ] 4.1 Create `IInitiativeChatContextBuilder` interface and `InitiativeChatContextBuilder` implementation
+- [ ] 4.2 Implement `Build(userId, initiativeId, recentMessages)` enforcing caps (20 decisions, all open risks, latest req/design snapshots, 50 commitments, 50 delegations, 30 capture summaries) and filtering by UserId
+- [ ] 4.3 Define DTO `InitiativeChatContextPayload` returned by the builder
+- [ ] 4.4 Unit test the builder: caps enforced, cross-user data excluded, empty initiative produces minimal payload
+
+## 5. Application Layer — Chat Completion Service
+
+- [ ] 5.1 Create `IInitiativeChatCompletionService` and implementation `InitiativeChatCompletionService`
+- [ ] 5.2 Define structured AI response envelope DTO `{ assistantText: string, sourceReferences: SourceReference[] }` and JSON schema; implement defensive parser with fallback to "raw text, no citations"
+- [ ] 5.3 Define system prompt template: ground answers in supplied context, cite every claim, refuse out-of-scope politely
+- [ ] 5.4 Implement orchestration: append user message -> build context -> call IAiCompletionService -> parse response -> drop unknown SourceReference EntityIds -> append assistant message -> persist
+- [ ] 5.5 Handle `AiProviderException` by appending an Assistant message with friendly error text
+- [ ] 5.6 Handle `TasteLimitExceededException` by appending a System message "Daily AI limit reached"
+- [ ] 5.7 Conversation history budget: include last N messages by token estimate; enforce a hard cap
+
+## 6. Application Layer — Vertical Slice Handlers
+
+- [ ] 6.1 `StartInitiativeChatThread` command handler (POST /chat/threads)
+- [ ] 6.2 `ListInitiativeChatThreads` query handler (GET /chat/threads, filterable by status)
+- [ ] 6.3 `GetInitiativeChatThread` query handler (GET /chat/threads/{threadId})
+- [ ] 6.4 `RenameInitiativeChatThread` command handler (PUT /chat/threads/{threadId})
+- [ ] 6.5 `PostInitiativeChatMessage` command handler (POST /chat/threads/{threadId}/messages) — orchestrates the completion service
+- [ ] 6.6 `ArchiveInitiativeChatThread` command handler (POST /archive)
+- [ ] 6.7 `UnarchiveInitiativeChatThread` command handler (POST /unarchive)
+
+## 7. Application Unit Tests
+
+- [ ] 7.1 Test PostInitiativeChatMessage happy path: appends user + assistant messages with citations
+- [ ] 7.2 Test fall-back parser: malformed AI envelope persists raw text with empty citations
+- [ ] 7.3 Test invalid SourceReference EntityIds dropped before persisting
+- [ ] 7.4 Test AiProviderException path appends friendly Assistant message
+- [ ] 7.5 Test TasteLimitExceededException path appends System message
+- [ ] 7.6 Test posting to Archived thread returns Conflict
+- [ ] 7.7 Test cross-user isolation in handlers (404 for cross-user threads)
+
+## 8. Web API Layer
+
+- [ ] 8.1 Create `InitiativeChatEndpoints` minimal API mapping all routes under `/api/initiatives/{id}/chat/threads`
+- [ ] 8.2 Create request/response DTOs for thread, message, source-reference, post-message response
+
+## 9. Frontend — Models and Service
+
+- [ ] 9.1 Create TypeScript models: `ChatThread`, `ChatMessage`, `SourceReference`, `TokenUsage`, `ContextScope`
+- [ ] 9.2 Create `InitiativeChatService` with thread CRUD, listing, archive/unarchive, post-message methods
+- [ ] 9.3 Create signals for active thread and message list state
+
+## 10. Frontend — Initiative Chat Tab
+
+- [ ] 10.1 Add "Chat" tab to the initiative detail Tabs container (next to "Living Brief")
+- [ ] 10.2 Create `InitiativeChatTabComponent` shell with two-pane layout
+- [ ] 10.3 Create `ChatThreadRailComponent` showing active threads (sorted by LastMessageAt desc) and collapsed Archived section, with new-thread button and per-thread rename/archive actions
+- [ ] 10.4 Create `ChatThreadViewComponent` displaying messages in order (User right, Assistant left, System centred), timestamp and token-usage tooltips
+- [ ] 10.5 Create `ChatMessageComposerComponent` with textarea, submit on Enter (Shift+Enter newline), disabled while awaiting reply
+- [ ] 10.6 Create `SourceReferenceChipComponent` rendering typed chips and routing on click to capture/commitment/delegation detail or to the Living Brief tab anchored at the relevant section
+- [ ] 10.7 Render Failed/limit System messages distinctly (PrimeNG Message component) so users understand AI errors
+- [ ] 10.8 Loading state: show a skeleton or spinner in place of the assistant message while the request is in flight
+
+## 11. E2E Tests
+
+- [ ] 11.1 E2E: start a thread, post a question, receive a reply
+- [ ] 11.2 E2E: source reference chips are clickable and navigate to the correct record
+- [ ] 11.3 E2E: archive a thread, list shows it under Archived only
+- [ ] 11.4 E2E: rename a thread persists across reloads
+- [ ] 11.5 E2E: user isolation — User A cannot read User B's thread (404)
+- [ ] 11.6 E2E: posting to an archived thread returns Conflict and the UI surfaces an error

--- a/openspec/changes/initiative-living-brief/.openspec.yaml
+++ b/openspec/changes/initiative-living-brief/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/initiative-living-brief/design.md
+++ b/openspec/changes/initiative-living-brief/design.md
@@ -1,0 +1,151 @@
+## Context
+
+Mental Metal already has the `Initiative` aggregate (Tier 1) and the `Capture` aggregate with AI extraction (`capture-ai-extraction`, Tier 2). Captures can be linked to Initiatives via `Capture.LinkedInitiativeIds`, and confirmed extractions raise `CaptureExtractionConfirmed`. What is missing is a rolled-up, evolving narrative on the Initiative itself — the "living brief" — that turns a stream of captures into the manager's working knowledge of the project.
+
+The brief is the foundation for the next two specs: `initiative-ai-chat` queries it, and `daily-weekly-briefing` (Tier 3) summarises it. Getting its shape right matters.
+
+### Dependencies
+
+- `ai-provider-abstraction` (Tier 1) — the brief refresh calls `IAiCompletionService.CompleteAsync` and respects `TasteLimitExceededException`.
+- `capture-ai-extraction` (Tier 2) — the brief subscribes to `CaptureExtractionConfirmed` and reads each capture's `AiExtraction` value object.
+- `initiative-management` (Tier 1) — the `Initiative` aggregate is extended in place.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep brief content embedded on the `Initiative` aggregate (DDD value objects), not in a separate aggregate, so reading an initiative returns its current brief in one query.
+- Make AI updates reviewable by default. Users see *what changed and why* before it touches their initiative.
+- Keep the human escape hatch first-class: any field can be edited manually at any time, and manual edits are equally honoured in history.
+- Use the existing AI provider abstraction — no provider-specific code in this spec.
+- Idempotent and concurrency-safe brief updates: re-processing the same capture must not double-log decisions or risks.
+
+**Non-Goals:**
+
+- Real-time collaborative editing or sharing.
+- Diffing brief snapshots at sub-paragraph granularity.
+- Branching/forking briefs.
+- Storing the AI prompt response verbatim for audit (we keep the structured proposal, not the raw completion).
+- Cross-initiative roll-ups (e.g. portfolio dashboards) — Tier 3.
+- Validating that linked captures actually exist at refresh time — the application handler trusts the event payload.
+
+## Decisions
+
+### 1. LivingBrief is a value-object cluster on Initiative, not a separate aggregate
+
+**Decision:** Model `LivingBrief` as a set of owned value objects on the `Initiative` aggregate root: `Summary` (string + `LastRefreshedAt` + `BriefVersion`), `KeyDecisions` (`IReadOnlyList<KeyDecision>`), `Risks` (`IReadOnlyList<Risk>`), `RequirementsHistory` (`IReadOnlyList<RequirementsSnapshot>`), `DesignDirectionHistory` (`IReadOnlyList<DesignDirectionSnapshot>`).
+
+**Rationale:** The brief is meaningless without its initiative. Embedding it preserves the aggregate boundary (one transaction per write), keeps invariants local (e.g. "RequirementsHistory is append-only"), and matches how `Capture` embeds `AiExtraction`. A reader gets the brief by loading the initiative.
+
+**Alternatives considered:**
+- Separate `LivingBrief` aggregate referenced by `InitiativeId` — rejected because there is a 1:1 lifecycle and no independent invariants. It would also force a second query on every initiative read.
+- Event-sourced brief — rejected as overkill; we can rebuild from `RequirementsHistory`/`DesignDirectionHistory` snapshots without sourcing every event.
+
+### 2. PendingBriefUpdate is a separate aggregate root
+
+**Decision:** Proposed AI updates live in a `PendingBriefUpdate` aggregate root keyed by its own Id, with a required `InitiativeId`. Each pending update carries a `BriefUpdateProposal` value object (proposed summary, new decisions, new/resolved risks, new requirements snapshot, new design snapshot, source capture IDs, AI confidence score) plus a `Status` of `Pending | Applied | Rejected | Edited`.
+
+**Rationale:** Pending updates have their own lifecycle independent of the brief: they are created, optionally edited, and then applied or rejected. Co-locating them inside the Initiative aggregate would inflate the aggregate, complicate concurrency (two pending updates from concurrent captures), and entangle a transient queue with permanent state. As a separate aggregate they can be queried/listed cheaply.
+
+**Alternatives considered:**
+- Embed pending updates as a list on Initiative — rejected for the reasons above.
+- Apply AI updates immediately, with an "undo" — rejected because undo on a regenerated summary plus appended decisions is fiddly and surprising.
+
+### 3. Append-only history; `Summary` is the only field regenerated
+
+**Decision:** `KeyDecisions`, `RequirementsHistory`, and `DesignDirectionHistory` are append-only. `Risks` are not deleted but can be `Resolved` (status flip with `ResolvedAt`). The `Summary` field is wholly replaced on each update with the latest AI-generated or user-edited text; previous summaries are not retained verbatim (the user can scroll the decision/requirement/design history if they need provenance).
+
+**Rationale:** The summary is a derived, lossy view; storing every revision bloats the aggregate without much user value. The structured logs (decisions, risks, snapshots) are the source of truth for "how did we get here?".
+
+**Trade-off:** Users who want the previous summary text after an unwanted update must reject the pending update *before* applying it. Once applied, only the new summary remains. This is documented in the UI.
+
+### 4. AI prompting strategy
+
+**Decision:** Brief refresh uses one composite prompt rather than five field-specific prompts. The prompt input is structured JSON containing:
+
+- `currentBrief`: { summary, openRisks, recentDecisions[10], latestRequirements, latestDesignDirection }
+- `linkedCaptures`: array of { captureId, createdAt, summary, decisions, risks, requirementsHints, designHints } drawn from each capture's `AiExtraction`
+- `triggeringCaptureId`: the capture that fired the event
+
+The prompt instructs the AI to return a structured `BriefUpdateProposal` with: a regenerated summary; a list of *new* decisions not already in `recentDecisions` (matched by description similarity); a list of *new* risks and a list of *risks to resolve*; an optional new requirements snapshot (only if changes are detected); an optional new design direction snapshot; a free-text `rationale` shown in the review UI.
+
+**Rationale:** One round-trip is cheaper and gives the AI cross-section context (e.g. a decision often implies a requirement change). The prompt is responsible for de-duplication; the application layer trusts the AI's "new" lists rather than diffing again.
+
+**Alternatives considered:**
+- Five separate prompts (one per section) — rejected for cost and loss of cross-section context.
+- Streaming/incremental updates — rejected as unnecessary; brief refresh is a background job.
+
+### 5. Trigger model: domain-event handler, debounced per initiative
+
+**Decision:** A `LivingBriefUpdateHandler` subscribes to `CaptureExtractionConfirmed`. For each `LinkedInitiativeId` on the confirmed capture, the handler enqueues a brief-refresh job keyed by `(UserId, InitiativeId)`. If a job for the same key is already queued or running, the new trigger is coalesced (the in-flight or pending job will pick up the latest state when it runs).
+
+**Rationale:** A single capture confirmation can touch multiple initiatives, and several confirmations can land in quick succession (e.g. a user processes a backlog). Debouncing avoids redundant AI calls and keeps the pending-update queue from filling with near-identical proposals.
+
+**Trade-off:** A brief refresh may cover several captures at once; the proposal lists all source capture IDs.
+
+### 6. Auto-apply preference, default off
+
+**Decision:** A user preference `LivingBriefAutoApply` (boolean, default `false`) on the User aggregate controls whether `LivingBriefUpdateProposed` immediately calls `Apply()` or waits for human action. When `true`, the proposal is created and applied in the same transaction; the `LivingBriefUpdateApplied` event still fires.
+
+**Rationale:** Manual review is the safe default because AI hallucination on critical decisions is high-stakes. Power users can opt in once they trust the model.
+
+### 7. Concurrency and idempotency
+
+**Decision:** The `PendingBriefUpdate` carries the `BriefVersion` of the initiative it was generated against. When the user (or auto-apply) calls `Apply()`, the handler reloads the initiative and rejects the apply with HTTP 409 if `Initiative.LivingBrief.BriefVersion` has advanced (i.e. a different update was applied first). The user is shown a "this proposal is stale, regenerate" prompt. `BriefVersion` increments on every apply.
+
+**Rationale:** Without this, two concurrent applies could double-log decisions or stomp summaries.
+
+### 8. API surface
+
+**Decision:** Endpoints under the existing `/api/initiatives/{id}` resource:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/initiatives/{id}/brief` | GET | Get the current LivingBrief |
+| `/api/initiatives/{id}/brief/summary` | PUT | Manually edit the summary |
+| `/api/initiatives/{id}/brief/decisions` | POST | Manually log a decision |
+| `/api/initiatives/{id}/brief/risks` | POST | Manually raise a risk |
+| `/api/initiatives/{id}/brief/risks/{riskId}/resolve` | POST | Mark a risk resolved |
+| `/api/initiatives/{id}/brief/requirements` | POST | Snapshot new requirements text |
+| `/api/initiatives/{id}/brief/design-direction` | POST | Snapshot new design direction text |
+| `/api/initiatives/{id}/brief/refresh` | POST | Manually trigger an AI refresh (queues a proposal) |
+| `/api/initiatives/{id}/brief/pending-updates` | GET | List pending brief updates for the initiative |
+| `/api/initiatives/{id}/brief/pending-updates/{updateId}` | GET | Get one pending update |
+| `/api/initiatives/{id}/brief/pending-updates/{updateId}/apply` | POST | Apply a pending update |
+| `/api/initiatives/{id}/brief/pending-updates/{updateId}/reject` | POST | Reject a pending update |
+| `/api/initiatives/{id}/brief/pending-updates/{updateId}` | PUT | Edit a pending update before applying |
+
+**Rationale:** Brief is part of the Initiative resource. Pending updates are a sub-collection because they have IDs and lifecycle.
+
+### 9. Frontend: tabbed initiative detail
+
+**Decision:** Initiative detail page gains a PrimeNG `Tabs` component (or equivalent) with at minimum: "Overview" (existing), "Living Brief" (new). The Living Brief tab shows: Summary card (with edit button), Pending Updates panel (badge with count, expandable cards per proposal with Accept/Edit/Reject), Decisions list, Open Risks list, Resolved Risks (collapsed), Requirements (latest with "history" expandable), Design Direction (latest with "history" expandable). All state via Angular signals.
+
+**Rationale:** Keeps overview minimal for users who don't use the brief; opt-in deeper surface for those who do.
+
+### 10. Storage shape
+
+**Decision:** Owned EF Core configurations:
+
+- `LivingBrief` is configured as `OwnsOne` on `Initiative`, with `KeyDecisions`/`Risks`/`RequirementsHistory`/`DesignDirectionHistory` stored as JSONB columns (`jsonb` Postgres type).
+- `PendingBriefUpdate` is its own table (`PendingBriefUpdates`), with `Proposal` as a JSONB column.
+
+**Rationale:** JSONB keeps the schema simple, matches how nested value objects are typically stored in this codebase, and avoids EF Core join explosion. We do not need to query inside decisions/risks across initiatives in this spec.
+
+## Risks / Trade-offs
+
+- **[AI cost surprise]** Frequent capture confirmations could trigger many refreshes. **Mitigation:** Per-initiative debouncing (Decision 5), and the existing `TasteLimitExceededException` flow — when the limit is hit, the proposal is created with status `Failed` and surfaced in the pending-updates panel with a "limit reached" notice.
+- **[AI hallucinated decisions]** The model could invent a "decision" that wasn't really made. **Mitigation:** Manual review by default (Decision 6), explicit Reject action, and a `rationale` field in the proposal that cites which capture(s) it came from.
+- **[Stale proposals]** A pending update can become irrelevant if a more recent capture lands. **Mitigation:** `BriefVersion` check on apply (Decision 7); the UI shows a "regenerate" CTA on stale proposals.
+- **[Append-only growth]** Decisions and risks accumulate forever. **Mitigation:** Acceptable for now — UI virtualises long lists and offers "show resolved" toggles. Archival is a future concern.
+- **[JSONB migrations]** Changing the shape of `KeyDecision` etc. later requires data migration. **Mitigation:** Version the JSONB shape with a `schemaVersion` field on each value object from day one.
+- **[Cross-aggregate event consistency]** The brief depends on `CaptureExtractionConfirmed` firing reliably. **Mitigation:** Domain events are dispatched in the same transaction as the capture confirmation; a missed event simply means the next capture confirmation will re-cover the gap when it triggers another refresh.
+
+## Migration Plan
+
+- One EF Core migration adds: `LivingBrief` owned columns on `Initiatives` (initially empty), and a new `PendingBriefUpdates` table. Existing initiatives get a default empty brief on first read (no backfill needed).
+- Feature flag `LivingBriefEnabled` (per-user preference, default `true`) gates the domain-event handler subscription; users can opt out if AI cost is a concern.
+
+## Open Questions
+
+_(none — auto-apply default is documented as `false`; debounce window is a queue concern, not a domain concern, and is left to the implementation.)_

--- a/openspec/changes/initiative-living-brief/proposal.md
+++ b/openspec/changes/initiative-living-brief/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Initiatives in Mental Metal currently hold static metadata (name, status, milestones) but no narrative summary, decisions log, or evolving requirements/design history. As captures (notes, transcripts) flow in and get linked to an initiative, the manager's mental model of that initiative changes — but those changes are stranded inside individual captures rather than rolled up into a coherent, current-state view.
+
+This is a Tier 2 spec (`initiative-living-brief`) that depends on `ai-provider-abstraction` and `capture-ai-extraction` (both Tier 2). It introduces an AI-maintained "living brief" that updates automatically when linked captures are processed, plus a human review workflow so the user retains editorial control.
+
+## Non-goals
+
+- **No audio transcription** — the brief consumes captures that have already been processed by `capture-ai-extraction`. Audio capture is in `capture-audio` (Tier 3).
+- **No auto-generated presentations or stakeholder reports** — the brief is a working document, not a publishable artifact.
+- **No conversational chat over the brief** — Q&A about an initiative belongs in `initiative-ai-chat`.
+- **No briefing or queue surfacing** — the daily/weekly briefing and queue prioritization are Tier 3.
+- **No collaborative editing or shared briefs** — single-user-scoped.
+- **No diff/blame view at character granularity** — history is captured as snapshots and append-only logs, not text diffs.
+
+## What Changes
+
+- **Extend the `Initiative` aggregate** with a `LivingBrief` value-object cluster: `Summary` (regenerated each update), `KeyDecisions` (append-only log), `Risks` (raised/resolved with severity), `RequirementsHistory` (snapshot list), `DesignDirectionHistory` (snapshot list), and `BriefVersion` (monotonic counter).
+- **New domain service `BriefMaintenanceService`** in the Application layer that subscribes to the `CaptureExtractionConfirmed` domain event from `capture-ai-extraction`, gathers all captures linked to each affected initiative, calls the AI provider via `IAiCompletionService`, and produces a structured `BriefUpdateProposal`.
+- **Human-in-the-loop review** — proposed updates are persisted as `PendingBriefUpdate` records that the user can accept (apply to the initiative), reject (discard), or edit (modify before applying). Auto-apply is opt-in per user preference, defaulting to manual review.
+- **Manual edit endpoints** for every brief field (summary, decisions, risks, requirements, design direction) so the user can override AI output at any time. Manual edits also append to history.
+- **CQRS handlers and minimal API endpoints** under `/api/initiatives/{id}/brief` for reading the brief, listing pending updates, applying/rejecting them, and manual editing.
+- **EF Core persistence** for the new value objects and the `PendingBriefUpdate` table; one new migration.
+- **Angular "Living Brief" tab** on the initiative detail page — current state panels for each section, a pending-updates panel with accept/reject/edit actions, and a history viewer per section.
+- **Domain events** `LivingBriefSummaryUpdated`, `LivingBriefDecisionLogged`, `LivingBriefRiskRaised`, `LivingBriefRiskResolved`, `LivingBriefRequirementsSnapshot`, `LivingBriefDesignDirectionSnapshot`, `LivingBriefUpdateProposed`, `LivingBriefUpdateApplied`, `LivingBriefUpdateRejected`.
+
+## Capabilities
+
+### New Capabilities
+
+- `initiative-living-brief`: AI-maintained narrative brief on each Initiative — summary, decisions log, risks, requirements snapshots, and design direction snapshots — automatically refreshed when linked captures are processed, with a human review queue and manual override.
+
+### Modified Capabilities
+
+_(none — the existing `initiative-management` and `capture-ai-extraction` specs are not modified. The brief is additive: it reads from the published `CaptureExtractionConfirmed` event but does not change the contract of either parent capability. Future cross-spec coupling, if any, will be a separate proposal.)_
+
+## Impact
+
+- **Domain:** `Initiative` aggregate gains the `LivingBrief` value-object cluster and new business actions (`RefreshSummary`, `RecordDecision`, `RaiseRisk`, `ResolveRisk`, `SnapshotRequirements`, `SnapshotDesignDirection`). New `PendingBriefUpdate` aggregate root, `BriefUpdateProposal` value object, and supporting enums (`RiskSeverity`, `RiskStatus`, `BriefSection`).
+- **Application:** New `BriefMaintenanceService`, new vertical-slice handlers under `Initiatives/Brief/`, and a domain-event handler subscribing to `CaptureExtractionConfirmed`.
+- **Infrastructure:** EF Core configuration for the new owned types and the `PendingBriefUpdates` table; one migration.
+- **Web API:** New endpoints under `/api/initiatives/{id}/brief`.
+- **Frontend:** New "Living Brief" tab component, pending-updates panel, history viewer, and brief service.
+- **AI prompting:** New prompt template for brief refresh; uses the existing `IAiCompletionService` abstraction.
+- **Dependencies:** `ai-provider-abstraction`, `capture-ai-extraction`, `initiative-management`.

--- a/openspec/changes/initiative-living-brief/specs/initiative-living-brief/spec.md
+++ b/openspec/changes/initiative-living-brief/specs/initiative-living-brief/spec.md
@@ -1,0 +1,322 @@
+## ADDED Requirements
+
+### Requirement: LivingBrief value-object cluster on Initiative
+
+The `Initiative` aggregate SHALL embed a `LivingBrief` value-object cluster comprising: `Summary` (string, may be empty), `SummaryLastRefreshedAt` (datetime, nullable), `BriefVersion` (monotonic integer, starting at 0), `KeyDecisions` (append-only list of `KeyDecision`), `Risks` (list of `Risk`), `RequirementsHistory` (append-only list of `RequirementsSnapshot`), and `DesignDirectionHistory` (append-only list of `DesignDirectionSnapshot`). All embedded value objects are persisted with the Initiative.
+
+#### Scenario: New initiative starts with empty brief
+
+- **WHEN** an authenticated user creates a new Initiative
+- **THEN** the Initiative's LivingBrief has empty Summary, BriefVersion 0, no decisions, no risks, no requirements snapshots, and no design direction snapshots
+
+#### Scenario: BriefVersion increments on every applied change
+
+- **WHEN** any brief mutation (RefreshSummary, RecordDecision, RaiseRisk, ResolveRisk, SnapshotRequirements, SnapshotDesignDirection, applying a PendingBriefUpdate) is committed on an Initiative
+- **THEN** BriefVersion is incremented by 1
+
+### Requirement: Get current brief
+
+The system SHALL allow an authenticated user to retrieve the current LivingBrief for one of their initiatives via `GET /api/initiatives/{id}/brief`.
+
+#### Scenario: Get brief for an initiative
+
+- **WHEN** an authenticated user sends `GET /api/initiatives/{id}/brief` for an initiative they own
+- **THEN** the system returns HTTP 200 with the LivingBrief: summary, summaryLastRefreshedAt, briefVersion, keyDecisions, openRisks, resolvedRisks, latest requirements snapshot with full history, latest design direction snapshot with full history
+
+#### Scenario: Initiative not found
+
+- **WHEN** an authenticated user sends `GET /api/initiatives/{id}/brief` for an initiative ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+#### Scenario: User isolation
+
+- **WHEN** User A and User B each have an initiative with the same name and User A requests User B's initiative brief by ID
+- **THEN** the system returns HTTP 404
+
+### Requirement: Manually update summary
+
+The system SHALL allow an authenticated user to manually overwrite the summary on an initiative's brief via `PUT /api/initiatives/{id}/brief/summary` with a non-empty `summary` body. The system SHALL set `SummaryLastRefreshedAt` to the current time, increment `BriefVersion`, and raise a `LivingBriefSummaryUpdated` domain event with `source = "Manual"`.
+
+#### Scenario: Update summary
+
+- **WHEN** an authenticated user sends `PUT /api/initiatives/{id}/brief/summary` with body `{ "summary": "Project X is now in design review." }`
+- **THEN** the LivingBrief.Summary is replaced, SummaryLastRefreshedAt is updated, BriefVersion increments, and the system returns HTTP 200
+
+#### Scenario: Empty summary rejected
+
+- **WHEN** an authenticated user sends `PUT /api/initiatives/{id}/brief/summary` with an empty or whitespace-only summary
+- **THEN** the system returns HTTP 400
+
+### Requirement: Manually log a key decision
+
+The system SHALL allow an authenticated user to append a `KeyDecision` to an initiative's brief via `POST /api/initiatives/{id}/brief/decisions` with `description` (required), `madeBy` (optional string), `rationale` (optional string), and `decisionDate` (optional date, defaults to today). The system SHALL append the decision to `KeyDecisions`, increment `BriefVersion`, and raise a `LivingBriefDecisionLogged` event.
+
+#### Scenario: Log a decision
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/decisions` with `{ "description": "Adopt PostgreSQL", "madeBy": "Architecture review", "rationale": "Better JSONB support" }`
+- **THEN** the decision is appended with a generated DecisionId, source = Manual, returns HTTP 201
+
+#### Scenario: Empty description rejected
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/decisions` with an empty description
+- **THEN** the system returns HTTP 400
+
+### Requirement: Manually raise a risk
+
+The system SHALL allow an authenticated user to add a `Risk` to an initiative's brief via `POST /api/initiatives/{id}/brief/risks` with `description` (required), `severity` (required: `Low | Medium | High | Critical`), and `mitigation` (optional). The system SHALL append the risk with status `Open`, generate a `RiskId`, increment `BriefVersion`, and raise a `LivingBriefRiskRaised` event.
+
+#### Scenario: Raise a high-severity risk
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/risks` with `{ "description": "Vendor API may not ship in Q3", "severity": "High" }`
+- **THEN** the risk is appended with status Open and returns HTTP 201
+
+#### Scenario: Invalid severity rejected
+
+- **WHEN** an authenticated user sends a risk with `severity = "Catastrophic"`
+- **THEN** the system returns HTTP 400
+
+### Requirement: Resolve a risk
+
+The system SHALL allow an authenticated user to mark a risk as resolved via `POST /api/initiatives/{id}/brief/risks/{riskId}/resolve` with optional `resolutionNotes`. The system SHALL set the risk's status to `Resolved`, set `ResolvedAt`, increment `BriefVersion`, and raise a `LivingBriefRiskResolved` event. Only risks with status `Open` SHALL be resolvable.
+
+#### Scenario: Resolve an open risk
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/risks/{riskId}/resolve` for an open risk
+- **THEN** the risk's status is Resolved, ResolvedAt is set, returns HTTP 200
+
+#### Scenario: Resolve already-resolved risk rejected
+
+- **WHEN** the risk is already Resolved
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: Risk not found
+
+- **WHEN** the riskId does not exist on the initiative
+- **THEN** the system returns HTTP 404
+
+### Requirement: Snapshot requirements
+
+The system SHALL allow an authenticated user to append a `RequirementsSnapshot` (containing `content` text and `source` of `Manual` or `AI`) to the initiative's brief via `POST /api/initiatives/{id}/brief/requirements`. Each snapshot has a `SnapshotId`, `CreatedAt`, and `BriefVersionAtSnapshot`. The system SHALL raise a `LivingBriefRequirementsSnapshot` event.
+
+#### Scenario: Manual requirements snapshot
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/requirements` with `{ "content": "Must support SSO via Okta" }`
+- **THEN** a snapshot is appended with source = Manual and returns HTTP 201
+
+#### Scenario: Empty content rejected
+
+- **WHEN** the content is empty or whitespace
+- **THEN** the system returns HTTP 400
+
+### Requirement: Snapshot design direction
+
+The system SHALL allow an authenticated user to append a `DesignDirectionSnapshot` to the initiative's brief via `POST /api/initiatives/{id}/brief/design-direction` with `content` (required) and `source` (`Manual` or `AI`). The system SHALL raise a `LivingBriefDesignDirectionSnapshot` event.
+
+#### Scenario: Manual design snapshot
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/design-direction` with `{ "content": "Switch to event-driven architecture for billing." }`
+- **THEN** a snapshot is appended with source = Manual and returns HTTP 201
+
+### Requirement: Auto-generate brief update on capture extraction confirmed
+
+The system SHALL subscribe to the `CaptureExtractionConfirmed` domain event from `capture-ai-extraction`. For each `LinkedInitiativeId` on the confirmed capture that belongs to the same user, the system SHALL enqueue a brief-refresh job keyed by `(UserId, InitiativeId)`. If a job for the same key is already queued or in-flight, the new trigger SHALL be coalesced.
+
+#### Scenario: Capture linked to one initiative triggers a refresh
+
+- **WHEN** a capture with one LinkedInitiativeId is confirmed
+- **THEN** exactly one brief-refresh job is enqueued for that initiative
+
+#### Scenario: Capture linked to multiple initiatives triggers a refresh per initiative
+
+- **WHEN** a capture with three LinkedInitiativeIds is confirmed
+- **THEN** three brief-refresh jobs are enqueued, one per initiative
+
+#### Scenario: Coalesced trigger
+
+- **WHEN** two captures for the same initiative are confirmed within the debounce window
+- **THEN** only one in-flight or queued brief-refresh job exists for that (UserId, InitiativeId) and the second trigger is coalesced
+
+#### Scenario: User isolation in event handling
+
+- **WHEN** User B's capture confirmation references an InitiativeId that belongs to User A
+- **THEN** no refresh job is enqueued and no error escapes the handler
+
+### Requirement: BriefMaintenanceService produces a BriefUpdateProposal
+
+When a brief-refresh job runs, the `BriefMaintenanceService` SHALL: load the Initiative and its current LivingBrief, gather all confirmed captures whose `LinkedInitiativeIds` include the Initiative ID, call `IAiCompletionService.CompleteAsync` with a structured prompt containing the current brief state and the linked captures' `AiExtraction` data, parse the response into a `BriefUpdateProposal`, persist a new `PendingBriefUpdate` aggregate with status `Pending`, and raise a `LivingBriefUpdateProposed` event.
+
+#### Scenario: Successful proposal generation
+
+- **WHEN** the BriefMaintenanceService runs for an initiative with at least one linked confirmed capture
+- **THEN** a PendingBriefUpdate is created with status Pending, containing the proposed summary, new decisions, new/resolved risks, optional new requirements snapshot, optional new design direction snapshot, source capture IDs, AI confidence score, AI rationale, and the BriefVersion of the initiative at proposal time
+
+#### Scenario: AI provider failure
+
+- **WHEN** the AI completion call throws an `AiProviderException`
+- **THEN** a PendingBriefUpdate is created with status `Failed` and the error message recorded; no `LivingBriefUpdateProposed` event is raised
+
+#### Scenario: Taste limit exceeded
+
+- **WHEN** the AI completion call throws a `TasteLimitExceededException`
+- **THEN** a PendingBriefUpdate is created with status `Failed` and message "Daily AI limit reached"
+
+#### Scenario: No linked captures
+
+- **WHEN** the refresh runs but no confirmed captures are linked to the initiative
+- **THEN** no PendingBriefUpdate is created and the job completes silently
+
+### Requirement: Manually trigger a brief refresh
+
+The system SHALL allow an authenticated user to manually enqueue a brief-refresh job via `POST /api/initiatives/{id}/brief/refresh`. The system SHALL behave identically to an event-triggered refresh and return HTTP 202 Accepted.
+
+#### Scenario: Manual refresh
+
+- **WHEN** an authenticated user sends `POST /api/initiatives/{id}/brief/refresh`
+- **THEN** the system enqueues a brief-refresh job for that initiative and returns HTTP 202
+
+#### Scenario: Manual refresh on initiative with no captures
+
+- **WHEN** the user manually refreshes an initiative with no linked captures
+- **THEN** the system returns HTTP 202 and the job exits without creating a proposal
+
+### Requirement: List pending brief updates
+
+The system SHALL allow an authenticated user to list pending brief updates for an initiative via `GET /api/initiatives/{id}/brief/pending-updates`, optionally filtered by `status` (`Pending | Failed | Applied | Rejected`). The list SHALL be ordered by `CreatedAt` descending.
+
+#### Scenario: List pending updates
+
+- **WHEN** an authenticated user sends `GET /api/initiatives/{id}/brief/pending-updates`
+- **THEN** the system returns all PendingBriefUpdates for that initiative belonging to the user, newest first
+
+#### Scenario: Filter by status
+
+- **WHEN** the user sends `GET /api/initiatives/{id}/brief/pending-updates?status=Pending`
+- **THEN** only updates with status Pending are returned
+
+#### Scenario: Empty list
+
+- **WHEN** the user has no pending updates for the initiative
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get a single pending brief update
+
+The system SHALL allow an authenticated user to fetch one pending update via `GET /api/initiatives/{id}/brief/pending-updates/{updateId}`.
+
+#### Scenario: Get pending update
+
+- **WHEN** the user requests an existing pending update
+- **THEN** the system returns HTTP 200 with the full BriefUpdateProposal, status, source capture IDs, BriefVersion-at-proposal, and AI rationale
+
+#### Scenario: Pending update not found
+
+- **WHEN** the updateId does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Apply a pending brief update
+
+The system SHALL allow an authenticated user to apply a `Pending` brief update via `POST /api/initiatives/{id}/brief/pending-updates/{updateId}/apply`. The system SHALL: reload the Initiative, verify `Initiative.LivingBrief.BriefVersion == PendingBriefUpdate.BriefVersionAtProposal`, and if so, replace the Summary, append new KeyDecisions, append new Risks, set ResolvedAt on resolved Risks, append the new RequirementsSnapshot (if present, source = AI), append the new DesignDirectionSnapshot (if present, source = AI), set the PendingBriefUpdate status to `Applied`, increment `BriefVersion` once, and raise `LivingBriefUpdateApplied` plus the corresponding per-section events.
+
+#### Scenario: Apply a current proposal
+
+- **WHEN** the user applies a Pending update whose BriefVersionAtProposal matches the initiative's current BriefVersion
+- **THEN** all proposed changes are applied in one transaction, BriefVersion increments by 1, the PendingBriefUpdate.Status is Applied, and the system returns HTTP 200
+
+#### Scenario: Apply a stale proposal
+
+- **WHEN** the user applies a Pending update whose BriefVersionAtProposal is less than the initiative's current BriefVersion
+- **THEN** the system returns HTTP 409 Conflict with code "stale_proposal" and the proposal remains Pending
+
+#### Scenario: Apply a non-pending update
+
+- **WHEN** the user applies an update whose status is `Failed`, `Applied`, or `Rejected`
+- **THEN** the system returns HTTP 409 Conflict
+
+#### Scenario: Apply by wrong user
+
+- **WHEN** User A attempts to apply a pending update belonging to User B
+- **THEN** the system returns HTTP 404
+
+### Requirement: Reject a pending brief update
+
+The system SHALL allow an authenticated user to reject a `Pending` brief update via `POST /api/initiatives/{id}/brief/pending-updates/{updateId}/reject` with optional `reason`. The system SHALL set status to `Rejected`, store the reason, and raise `LivingBriefUpdateRejected`. The Initiative's brief SHALL NOT change.
+
+#### Scenario: Reject pending update
+
+- **WHEN** the user rejects a Pending update with reason "AI misread the meeting"
+- **THEN** status becomes Rejected, the reason is stored, BriefVersion does not change, returns HTTP 200
+
+#### Scenario: Reject non-pending update
+
+- **WHEN** the user rejects an update with status `Applied`, `Rejected`, or `Failed`
+- **THEN** the system returns HTTP 409
+
+### Requirement: Edit a pending brief update before applying
+
+The system SHALL allow an authenticated user to modify a `Pending` brief update via `PUT /api/initiatives/{id}/brief/pending-updates/{updateId}` with any subset of: edited summary text, edited list of new decisions, edited list of new risks, edited list of risk IDs to resolve, edited requirements snapshot text, edited design direction snapshot text. The status SHALL transition to `Edited` (still applyable). The system SHALL raise `LivingBriefUpdateProposed` again with `editedByUser = true`.
+
+#### Scenario: Edit summary in proposal
+
+- **WHEN** the user edits the proposed summary text and saves
+- **THEN** the PendingBriefUpdate.Proposal.Summary is replaced, status becomes Edited, returns HTTP 200
+
+#### Scenario: Edit non-pending update rejected
+
+- **WHEN** the user edits an update with status `Applied`, `Rejected`, or `Failed`
+- **THEN** the system returns HTTP 409
+
+### Requirement: Auto-apply preference
+
+When the user's `LivingBriefAutoApply` preference is `true`, the system SHALL apply each newly proposed brief update immediately within the same transaction that creates it, provided the proposal's BriefVersionAtProposal still matches the initiative's BriefVersion. If the preference is `false` (default), proposals SHALL remain in status `Pending` until the user explicitly applies, edits, or rejects them.
+
+#### Scenario: Auto-apply on
+
+- **WHEN** the user has LivingBriefAutoApply = true and a brief-refresh job creates a proposal
+- **THEN** the proposal is created with status `Applied`, the brief is updated, and `LivingBriefUpdateApplied` is raised
+
+#### Scenario: Auto-apply off (default)
+
+- **WHEN** the user has LivingBriefAutoApply = false and a brief-refresh job creates a proposal
+- **THEN** the proposal is created with status `Pending` and the brief is unchanged
+
+#### Scenario: Auto-apply when stale
+
+- **WHEN** auto-apply is on but BriefVersion has advanced since the proposal was generated
+- **THEN** the proposal is created with status `Pending` (the user can manually intervene) — auto-apply does NOT silently overwrite
+
+### Requirement: Source attribution on history entries
+
+Every `KeyDecision`, `RequirementsSnapshot`, and `DesignDirectionSnapshot` SHALL record `Source` (`Manual` or `AI`), `CreatedAt`, and (for AI-sourced entries) the `SourceCaptureIds` that produced it. Every `Risk` SHALL record its `Source` (`Manual` or `AI`) and (for AI-sourced) `SourceCaptureIds`.
+
+#### Scenario: Manual decision attribution
+
+- **WHEN** a decision is logged manually
+- **THEN** Source = Manual, SourceCaptureIds is empty
+
+#### Scenario: AI decision attribution
+
+- **WHEN** a decision is appended by applying a PendingBriefUpdate
+- **THEN** Source = AI, SourceCaptureIds contains the proposal's source capture IDs
+
+### Requirement: Living Brief tab in UI
+
+The frontend SHALL provide a "Living Brief" tab on the initiative detail page. The tab SHALL render: a Summary card with the current summary, last-refreshed timestamp, BriefVersion, and an Edit button; a Pending Updates panel showing a count badge and expandable proposal cards with Accept/Edit/Reject buttons; a Decisions list (newest first) with source badges; an Open Risks list with severity, with a separate collapsed Resolved Risks section; a Requirements section showing the latest snapshot with an expandable history; a Design Direction section with the same shape; and a "Refresh now" button that calls the manual refresh endpoint. All component state SHALL be managed via Angular signals.
+
+#### Scenario: View brief tab
+
+- **WHEN** a user navigates to an initiative's "Living Brief" tab
+- **THEN** the system displays the summary, decisions, open and resolved risks, latest requirements and design direction, and a pending-updates panel with count
+
+#### Scenario: Pending update review
+
+- **WHEN** a user expands a pending update card and clicks "Accept"
+- **THEN** the system applies the update, the brief refreshes, and the pending-updates count decreases
+
+#### Scenario: Pending update edit
+
+- **WHEN** a user clicks "Edit" on a pending update, modifies the summary, and saves
+- **THEN** the proposal status becomes Edited and the user can then Accept or Reject
+
+#### Scenario: Manual summary edit
+
+- **WHEN** a user clicks Edit on the Summary card, types a new summary, and saves
+- **THEN** the summary is replaced and the last-refreshed timestamp updates

--- a/openspec/changes/initiative-living-brief/tasks.md
+++ b/openspec/changes/initiative-living-brief/tasks.md
@@ -1,0 +1,100 @@
+## 1. Domain Layer — Brief Value Objects
+
+- [ ] 1.1 Create `KeyDecision`, `Risk`, `RequirementsSnapshot`, `DesignDirectionSnapshot` value objects in `src/MentalMetal.Domain/Initiatives/LivingBrief/`
+- [ ] 1.2 Create `RiskSeverity` (Low, Medium, High, Critical) and `RiskStatus` (Open, Resolved) enums
+- [ ] 1.3 Create `BriefSource` enum (Manual, AI)
+- [ ] 1.4 Create `LivingBrief` value object with Summary, SummaryLastRefreshedAt, BriefVersion, KeyDecisions, Risks, RequirementsHistory, DesignDirectionHistory; include private constructor and `Empty()` factory
+- [ ] 1.5 Add LivingBrief property to `Initiative` aggregate root with private setter; initialize as `LivingBrief.Empty()`
+- [ ] 1.6 Add domain methods on Initiative: `RefreshSummary(string, BriefSource, IReadOnlyList<Guid> sourceCaptureIds)`, `RecordDecision(...)`, `RaiseRisk(...)`, `ResolveRisk(Guid riskId, string?)`, `SnapshotRequirements(...)`, `SnapshotDesignDirection(...)` — each increments BriefVersion and raises the matching domain event
+
+## 2. Domain Layer — PendingBriefUpdate Aggregate
+
+- [ ] 2.1 Create `BriefUpdateProposal` value object (proposed summary, new decisions, new risks, risks-to-resolve IDs, requirements snapshot, design direction snapshot, source capture IDs, AI confidence, rationale)
+- [ ] 2.2 Create `PendingBriefUpdateStatus` enum (Pending, Edited, Applied, Rejected, Failed)
+- [ ] 2.3 Create `PendingBriefUpdate` aggregate root with Id, UserId, InitiativeId, Proposal, Status, BriefVersionAtProposal, FailureReason, CreatedAt, UpdatedAt
+- [ ] 2.4 Implement factory `Create(...)`, `MarkFailed(reason)`, `Edit(BriefUpdateProposal newProposal)`, `MarkApplied()`, `Reject(string? reason)` with status-transition guards
+- [ ] 2.5 Create `IPendingBriefUpdateRepository` interface
+- [ ] 2.6 Create domain events: `LivingBriefSummaryUpdated`, `LivingBriefDecisionLogged`, `LivingBriefRiskRaised`, `LivingBriefRiskResolved`, `LivingBriefRequirementsSnapshot`, `LivingBriefDesignDirectionSnapshot`, `LivingBriefUpdateProposed`, `LivingBriefUpdateApplied`, `LivingBriefUpdateRejected`
+
+## 3. Domain Unit Tests
+
+- [ ] 3.1 Test LivingBrief.Empty() returns expected zero state
+- [ ] 3.2 Test each Initiative brief mutation increments BriefVersion exactly once and raises the right event
+- [ ] 3.3 Test ResolveRisk only succeeds for Open risks and throws for unknown riskId / already-resolved
+- [ ] 3.4 Test PendingBriefUpdate status transitions (Pending->Edited, Pending->Applied, Pending->Rejected, Failed terminal, etc.)
+- [ ] 3.5 Test source attribution on appended decisions/risks/snapshots
+
+## 4. Infrastructure Layer
+
+- [ ] 4.1 Add `LivingBriefConfiguration` configuring LivingBrief as OwnsOne on Initiative with JSONB columns for the lists
+- [ ] 4.2 Add `PendingBriefUpdateConfiguration` (table `PendingBriefUpdates`, JSONB Proposal column, indexes on UserId+InitiativeId+Status+CreatedAt)
+- [ ] 4.3 Implement `PendingBriefUpdateRepository` and register in DI
+- [ ] 4.4 Add EF Core migration `AddLivingBrief`
+
+## 5. Application Layer — BriefMaintenanceService
+
+- [ ] 5.1 Create `IBriefMaintenanceService` interface in Application
+- [ ] 5.2 Implement `BriefMaintenanceService.RefreshAsync(userId, initiativeId)` orchestrating: load initiative, gather linked confirmed captures, build prompt, call IAiCompletionService, parse response, persist PendingBriefUpdate
+- [ ] 5.3 Define structured prompt template + JSON schema for `BriefUpdateProposal` AI response; add response parser with defensive validation
+- [ ] 5.4 Handle `AiProviderException` and `TasteLimitExceededException` by creating Failed proposals
+- [ ] 5.5 Implement debouncing/coalescing of refresh jobs per (UserId, InitiativeId) via background queue (Channels or hosted background service)
+- [ ] 5.6 Implement domain-event handler `LivingBriefUpdateOnCaptureConfirmed` subscribing to `CaptureExtractionConfirmed` and enqueuing refresh jobs per linked initiative belonging to the same user
+
+## 6. Application Layer — Vertical Slice Handlers
+
+- [ ] 6.1 `GetInitiativeBrief` query handler (GET /api/initiatives/{id}/brief)
+- [ ] 6.2 `UpdateInitiativeBriefSummary` command handler (PUT .../brief/summary)
+- [ ] 6.3 `LogInitiativeBriefDecision` command handler (POST .../brief/decisions)
+- [ ] 6.4 `RaiseInitiativeBriefRisk` command handler (POST .../brief/risks)
+- [ ] 6.5 `ResolveInitiativeBriefRisk` command handler (POST .../brief/risks/{riskId}/resolve)
+- [ ] 6.6 `SnapshotInitiativeBriefRequirements` command handler (POST .../brief/requirements)
+- [ ] 6.7 `SnapshotInitiativeBriefDesignDirection` command handler (POST .../brief/design-direction)
+- [ ] 6.8 `RefreshInitiativeBrief` command handler (POST .../brief/refresh) calling BriefMaintenanceService
+- [ ] 6.9 `ListPendingBriefUpdates` query handler (GET .../brief/pending-updates) with status filter
+- [ ] 6.10 `GetPendingBriefUpdate` query handler (GET .../brief/pending-updates/{updateId})
+- [ ] 6.11 `ApplyPendingBriefUpdate` command handler (POST .../brief/pending-updates/{updateId}/apply) with stale-version 409
+- [ ] 6.12 `RejectPendingBriefUpdate` command handler (POST .../brief/pending-updates/{updateId}/reject)
+- [ ] 6.13 `EditPendingBriefUpdate` command handler (PUT .../brief/pending-updates/{updateId})
+- [ ] 6.14 Add `LivingBriefAutoApply` boolean to user preferences and gate auto-apply in BriefMaintenanceService
+
+## 7. Application Unit Tests
+
+- [ ] 7.1 Test BriefMaintenanceService creates a Pending proposal on success
+- [ ] 7.2 Test BriefMaintenanceService creates a Failed proposal on AiProviderException and on TasteLimitExceededException
+- [ ] 7.3 Test debouncing coalesces concurrent triggers per (UserId, InitiativeId)
+- [ ] 7.4 Test ApplyPendingBriefUpdate returns Conflict when BriefVersion has advanced
+- [ ] 7.5 Test auto-apply path with auto-apply preference on (current version) and off (default)
+- [ ] 7.6 Test event handler ignores cross-user initiative IDs
+
+## 8. Web API Layer
+
+- [ ] 8.1 Create `InitiativeBriefEndpoints` minimal API mapping all routes under `/api/initiatives/{id}/brief`
+- [ ] 8.2 Create request/response DTOs for brief, pending updates, manual mutations
+
+## 9. Frontend — Models and Services
+
+- [ ] 9.1 Create TypeScript models: `LivingBrief`, `KeyDecision`, `Risk`, `RequirementsSnapshot`, `DesignDirectionSnapshot`, `PendingBriefUpdate`, `BriefUpdateProposal`
+- [ ] 9.2 Create `InitiativeBriefService` with methods for all brief endpoints
+- [ ] 9.3 Add user-preferences signal extension for `livingBriefAutoApply`
+
+## 10. Frontend — Living Brief Tab Components
+
+- [ ] 10.1 Add a Tabs container to the initiative detail page (Overview + Living Brief)
+- [ ] 10.2 Create `LivingBriefTabComponent` shell with signals for brief data and pending updates
+- [ ] 10.3 Create `BriefSummaryCardComponent` with view + manual edit dialog
+- [ ] 10.4 Create `BriefDecisionsListComponent` (with manual log dialog and source badges)
+- [ ] 10.5 Create `BriefRisksListComponent` (open list, resolved collapsible, raise/resolve dialogs)
+- [ ] 10.6 Create `BriefRequirementsHistoryComponent` (latest + expandable history)
+- [ ] 10.7 Create `BriefDesignDirectionHistoryComponent`
+- [ ] 10.8 Create `PendingBriefUpdatesPanelComponent` with expandable cards, Accept/Edit/Reject buttons, stale-proposal indicator
+- [ ] 10.9 Add "Refresh now" button wired to the manual refresh endpoint
+- [ ] 10.10 Show user-friendly error states for Failed pending updates ("Daily AI limit reached", "AI provider error")
+
+## 11. E2E Tests
+
+- [ ] 11.1 E2E: manually log a decision and see it on the brief tab
+- [ ] 11.2 E2E: confirming a capture extraction linked to an initiative produces a pending brief update visible to the user
+- [ ] 11.3 E2E: applying a pending brief update updates the summary, decisions, and risks; BriefVersion increments
+- [ ] 11.4 E2E: rejecting a pending update leaves the brief unchanged
+- [ ] 11.5 E2E: user isolation — User A cannot read or apply User B's pending updates (404)
+- [ ] 11.6 E2E: stale proposal — apply returns Conflict when another update was applied first


### PR DESCRIPTION
## Summary

Proposes the three remaining Tier 2 capability specs as a single docs-only batch:

- **initiative-living-brief** — AI-maintained summary, decisions log, risk tracking, requirements/design evolution, auto-updated from Capture extractions.
- **initiative-ai-chat** — Initiative-scoped conversational AI with source references back to linked captures/commitments/delegations. Introduces the \`ChatThread\` aggregate.
- **global-ai-chat** — App-wide context-aware chat reusing \`ChatThread\` with a Global scope discriminator; rule-based intent classifier with AI fallback.

Proposing all three together lets the \`ChatThread\` aggregate be designed once and reused coherently across both chat specs. Implementation work is **not** part of this PR.

## Changes

- \`openspec/changes/initiative-living-brief/\` — proposal, design, spec delta, tasks
- \`openspec/changes/initiative-ai-chat/\` — proposal, design, spec delta, tasks
- \`openspec/changes/global-ai-chat/\` — proposal, design, spec delta, tasks

All three pass \`openspec validate --strict\`.

## Key design decisions worth reviewer attention

1. \`PendingBriefUpdate\` is a separate aggregate (not embedded on \`Initiative\`) so concurrent capture confirmations can queue proposals without bloating the \`Initiative\` aggregate root. \`BriefVersion\` provides optimistic concurrency on apply.
2. Living Brief auto-apply defaults to **off** — manual review is the safe default for AI-proposed decisions/risks; opt-in via a new \`LivingBriefAutoApply\` user preference.
3. Single \`ChatThread\` aggregate reused across both chat specs, distinguished by a \`ContextScope\` discriminator (\`Initiative(id)\` vs \`Global\`). No second migration for global chat.
4. Chat is text-only, synchronous, no streaming, no tool-use/actions. SSE streaming and \"create commitment from chat\" deferred to Tier 3.
5. Context assembly is rule-based with hard caps (global builder: 30 captures, 50 commitments, 50 delegations per intent slice; ~16k token budget with priority-ordered degradation). Vector/semantic retrieval deferred — can slot in behind the same builder interface later.
6. Global chat uses a hybrid intent classifier — deterministic rule layer first (cheap, English-first), single AI-call fallback for unclassified questions.

## Test Plan

- [x] \`openspec validate initiative-living-brief --strict\` passes
- [x] \`openspec validate initiative-ai-chat --strict\` passes
- [x] \`openspec validate global-ai-chat --strict\` passes
- [ ] CI passes
- [ ] Reviewer sanity-checks the \`ChatThread\` reuse decision (spec #3 vs #4 above)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)