### PR TITLE
fix: Login page UX, dark-mode active nav, OAuth token capture, and DP keys (#75)

### DIFF
--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -62,6 +62,30 @@ module "secrets" {
   accessor_service_account = google_service_account.cloud_run.email
 }
 
+# --- DataProtection Keys Bucket ---
+# Persists ASP.NET Core DataProtection keys outside the Cloud Run container so
+# OAuth state cookies issued by one container instance can be validated by
+# another after a cold start (#75 Bug 4).
+
+resource "google_storage_bucket" "data_protection_keys" {
+  project                     = var.project_id
+  name                        = "${var.project_id}-mental-metal-staging-dp-keys"
+  location                    = var.region
+  force_destroy               = false
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "google_storage_bucket_iam_member" "data_protection_keys_writer" {
+  bucket = google_storage_bucket.data_protection_keys.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
 # --- Cloud Run ---
 
 module "cloud_run" {
@@ -74,6 +98,9 @@ module "cloud_run" {
   secret_ids              = {
     "DATABASE_URL" = "STAGING_DATABASE_URL"
     "Jwt__Secret"  = "STAGING_JWT_SECRET"
+  }
+  env_vars = {
+    "DataProtection__BucketName" = google_storage_bucket.data_protection_keys.name
   }
   runtime_service_account = google_service_account.cloud_run.email
   allow_public_access     = true

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -80,9 +80,19 @@ resource "google_storage_bucket" "data_protection_keys" {
   }
 }
 
-resource "google_storage_bucket_iam_member" "data_protection_keys_writer" {
+# Least-privilege access: the repository needs to list + read existing key
+# objects and create new ones on key rotation. It never needs to delete keys
+# (stale keys are harmless and can be pruned administratively), so we split
+# the grants rather than using the broader roles/storage.objectAdmin.
+resource "google_storage_bucket_iam_member" "data_protection_keys_viewer" {
   bucket = google_storage_bucket.data_protection_keys.name
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_storage_bucket_iam_member" "data_protection_keys_creator" {
+  bucket = google_storage_bucket.data_protection_keys.name
+  role   = "roles/storage.objectCreator"
   member = "serviceAccount:${google_service_account.cloud_run.email}"
 }
 

--- a/infra/modules/cloud-run/main.tf
+++ b/infra/modules/cloud-run/main.tf
@@ -42,6 +42,14 @@ resource "google_cloud_run_v2_service" "this" {
           }
         }
       }
+
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
     }
   }
 }

--- a/infra/modules/cloud-run/variables.tf
+++ b/infra/modules/cloud-run/variables.tf
@@ -29,6 +29,12 @@ variable "secret_ids" {
   default     = {}
 }
 
+variable "env_vars" {
+  description = "Map of plain (non-secret) environment variables to set on the container"
+  type        = map(string)
+  default     = {}
+}
+
 variable "allow_public_access" {
   description = "Whether to allow unauthenticated access to the service"
   type        = bool

--- a/src/MentalMetal.Web/Auth/GoogleCloudStorageXmlRepository.cs
+++ b/src/MentalMetal.Web/Auth/GoogleCloudStorageXmlRepository.cs
@@ -1,0 +1,82 @@
+using System.Xml.Linq;
+using Google;
+using Google.Cloud.Storage.V1;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+
+namespace MentalMetal.Web.Auth;
+
+/// <summary>
+/// Persists ASP.NET Core DataProtection keys to a Google Cloud Storage object.
+/// Used in environments (e.g. Cloud Run) where the local filesystem is ephemeral
+/// and keys must survive container restarts so OAuth state cookies issued by one
+/// instance can be validated by another (#75 Bug 4).
+/// </summary>
+internal sealed class GoogleCloudStorageXmlRepository : IXmlRepository
+{
+    private readonly StorageClient _storageClient;
+    private readonly string _bucketName;
+    private readonly string _objectName;
+    private readonly ILogger<GoogleCloudStorageXmlRepository> _logger;
+    private readonly object _writeLock = new();
+
+    public GoogleCloudStorageXmlRepository(
+        StorageClient storageClient,
+        string bucketName,
+        string objectName,
+        ILogger<GoogleCloudStorageXmlRepository> logger)
+    {
+        _storageClient = storageClient;
+        _bucketName = bucketName;
+        _objectName = objectName;
+        _logger = logger;
+    }
+
+    public IReadOnlyCollection<XElement> GetAllElements()
+    {
+        try
+        {
+            using var stream = new MemoryStream();
+            _storageClient.DownloadObject(_bucketName, _objectName, stream);
+            stream.Position = 0;
+            if (stream.Length == 0)
+            {
+                return Array.Empty<XElement>();
+            }
+
+            var doc = XDocument.Load(stream);
+            return doc.Root?.Elements().ToList().AsReadOnly()
+                ?? (IReadOnlyCollection<XElement>)Array.Empty<XElement>();
+        }
+        catch (GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return Array.Empty<XElement>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load DataProtection keys from gs://{Bucket}/{Object}", _bucketName, _objectName);
+            throw;
+        }
+    }
+
+    public void StoreElement(XElement element, string friendlyName)
+    {
+        // The DataProtection contract does not require atomic concurrent writes —
+        // serialise locally to avoid clobbering when multiple keys rotate at once.
+        lock (_writeLock)
+        {
+            var existing = GetAllElements();
+            var root = new XElement("repository");
+            foreach (var existingElement in existing)
+            {
+                root.Add(existingElement);
+            }
+            root.Add(element);
+
+            using var stream = new MemoryStream();
+            new XDocument(root).Save(stream);
+            stream.Position = 0;
+
+            _storageClient.UploadObject(_bucketName, _objectName, "application/xml", stream);
+        }
+    }
+}

--- a/src/MentalMetal.Web/Auth/GoogleCloudStorageXmlRepository.cs
+++ b/src/MentalMetal.Web/Auth/GoogleCloudStorageXmlRepository.cs
@@ -6,46 +6,66 @@ using Microsoft.AspNetCore.DataProtection.Repositories;
 namespace MentalMetal.Web.Auth;
 
 /// <summary>
-/// Persists ASP.NET Core DataProtection keys to a Google Cloud Storage object.
+/// Persists ASP.NET Core DataProtection keys to Google Cloud Storage as one
+/// object per key (mirroring the behaviour of <c>FileSystemXmlRepository</c>).
 /// Used in environments (e.g. Cloud Run) where the local filesystem is ephemeral
 /// and keys must survive container restarts so OAuth state cookies issued by one
 /// instance can be validated by another (#75 Bug 4).
+///
+/// Each <see cref="StoreElement"/> call writes a distinct object named
+/// <c>{prefix}{friendlyName}.xml</c>, so concurrent writes from multiple Cloud
+/// Run instances cannot clobber each other (the previous single-object,
+/// read-modify-write design could drop keys under a last-writer-wins race).
 /// </summary>
 internal sealed class GoogleCloudStorageXmlRepository : IXmlRepository
 {
     private readonly StorageClient _storageClient;
     private readonly string _bucketName;
-    private readonly string _objectName;
+    private readonly string _objectPrefix;
     private readonly ILogger<GoogleCloudStorageXmlRepository> _logger;
-    private readonly object _writeLock = new();
 
     public GoogleCloudStorageXmlRepository(
         StorageClient storageClient,
         string bucketName,
-        string objectName,
+        string objectPrefix,
         ILogger<GoogleCloudStorageXmlRepository> logger)
     {
         _storageClient = storageClient;
         _bucketName = bucketName;
-        _objectName = objectName;
+        // Normalise the prefix so callers may pass "keys" or "keys/" interchangeably;
+        // empty means "store at the bucket root".
+        _objectPrefix = string.IsNullOrEmpty(objectPrefix) || objectPrefix.EndsWith('/')
+            ? objectPrefix ?? string.Empty
+            : objectPrefix + "/";
         _logger = logger;
     }
 
     public IReadOnlyCollection<XElement> GetAllElements()
     {
+        var elements = new List<XElement>();
         try
         {
-            using var stream = new MemoryStream();
-            _storageClient.DownloadObject(_bucketName, _objectName, stream);
-            stream.Position = 0;
-            if (stream.Length == 0)
+            foreach (var obj in _storageClient.ListObjects(_bucketName, _objectPrefix))
             {
-                return Array.Empty<XElement>();
-            }
+                if (!obj.Name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
 
-            var doc = XDocument.Load(stream);
-            return doc.Root?.Elements().ToList().AsReadOnly()
-                ?? (IReadOnlyCollection<XElement>)Array.Empty<XElement>();
+                using var stream = new MemoryStream();
+                _storageClient.DownloadObject(_bucketName, obj.Name, stream);
+                if (stream.Length == 0)
+                {
+                    continue;
+                }
+
+                stream.Position = 0;
+                var doc = XDocument.Load(stream);
+                if (doc.Root is not null)
+                {
+                    elements.Add(doc.Root);
+                }
+            }
         }
         catch (GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -53,30 +73,50 @@ internal sealed class GoogleCloudStorageXmlRepository : IXmlRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to load DataProtection keys from gs://{Bucket}/{Object}", _bucketName, _objectName);
+            _logger.LogError(ex, "Failed to list DataProtection keys from gs://{Bucket}/{Prefix}", _bucketName, _objectPrefix);
             throw;
         }
+
+        return elements.AsReadOnly();
     }
 
     public void StoreElement(XElement element, string friendlyName)
     {
-        // The DataProtection contract does not require atomic concurrent writes —
-        // serialise locally to avoid clobbering when multiple keys rotate at once.
-        lock (_writeLock)
+        // One object per key — avoids the read-modify-write race that would
+        // otherwise let two concurrent writers drop each other's keys.
+        var safeName = SanitiseFriendlyName(friendlyName);
+        var objectName = $"{_objectPrefix}{safeName}.xml";
+
+        using var stream = new MemoryStream();
+        new XDocument(element).Save(stream);
+        stream.Position = 0;
+
+        try
         {
-            var existing = GetAllElements();
-            var root = new XElement("repository");
-            foreach (var existingElement in existing)
-            {
-                root.Add(existingElement);
-            }
-            root.Add(element);
-
-            using var stream = new MemoryStream();
-            new XDocument(root).Save(stream);
-            stream.Position = 0;
-
-            _storageClient.UploadObject(_bucketName, _objectName, "application/xml", stream);
+            _storageClient.UploadObject(_bucketName, objectName, "application/xml", stream);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write DataProtection key to gs://{Bucket}/{Object}", _bucketName, objectName);
+            throw;
+        }
+    }
+
+    private static string SanitiseFriendlyName(string friendlyName)
+    {
+        if (string.IsNullOrWhiteSpace(friendlyName))
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        // Replace characters that would produce awkward object names; the DataProtection
+        // framework typically passes the key's GUID, so this is a belt-and-braces guard.
+        var invalid = new[] { '/', '\\', '\0', '\r', '\n' };
+        var cleaned = friendlyName;
+        foreach (var c in invalid)
+        {
+            cleaned = cleaned.Replace(c, '_');
+        }
+        return cleaned;
     }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/app.html
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.html
@@ -1,44 +1,51 @@
-<div class="flex h-screen shell">
+@if (isLoginRoute()) {
+  <!-- Login route: full-screen with no shell chrome (#75 Bug 1) -->
+  <router-outlet />
+} @else {
+  <div class="flex h-screen shell">
 
-  <!-- Sidebar: always visible on desktop -->
-  <aside class="hidden lg:flex flex-col w-64 border-r shrink-0 shell-panel">
-    <app-sidebar />
-  </aside>
+    <!-- Sidebar: always visible on desktop -->
+    <aside class="hidden lg:flex flex-col w-64 border-r shrink-0 shell-panel">
+      <app-sidebar />
+    </aside>
 
-  <!-- Mobile sidebar overlay -->
-  @if (sidebarOpen()) {
-    <div class="fixed inset-0 z-40 lg:hidden">
-      <div class="absolute inset-0 sidebar-scrim" (click)="sidebarOpen.set(false)"></div>
-      <aside class="relative z-50 flex flex-col w-64 h-full shell-panel">
-        <app-sidebar (navClick)="sidebarOpen.set(false)" />
-      </aside>
+    <!-- Mobile sidebar overlay -->
+    @if (sidebarOpen()) {
+      <div class="fixed inset-0 z-40 lg:hidden">
+        <div class="absolute inset-0 sidebar-scrim" (click)="sidebarOpen.set(false)"></div>
+        <aside class="relative z-50 flex flex-col w-64 h-full shell-panel">
+          <app-sidebar (navClick)="sidebarOpen.set(false)" />
+        </aside>
+      </div>
+    }
+
+    <!-- Main content area -->
+    <div class="flex flex-col flex-1 min-w-0">
+
+      <!-- Header: shows current page title from route data, not duplicate brand (#75 Bug 2) -->
+      <header class="flex items-center gap-4 h-14 px-4 border-b shrink-0 shell-panel">
+        <button type="button" class="lg:hidden p-2 rounded-md hamburger-btn"
+                (click)="sidebarOpen.set(true)"
+                [attr.aria-expanded]="sidebarOpen()"
+                aria-label="Open navigation menu">
+          <i class="pi pi-bars text-lg"></i>
+        </button>
+        @if (pageTitle()) {
+          <span class="text-sm font-medium header-title">{{ pageTitle() }}</span>
+        }
+        <span class="ml-auto">
+          <app-global-chat-launcher />
+        </span>
+      </header>
+
+      <!-- Page content -->
+      <main class="flex-1 overflow-y-auto p-6">
+        <router-outlet />
+      </main>
+
     </div>
-  }
 
-  <!-- Main content area -->
-  <div class="flex flex-col flex-1 min-w-0">
-
-    <!-- Header -->
-    <header class="flex items-center gap-4 h-14 px-4 border-b shrink-0 shell-panel">
-      <button type="button" class="lg:hidden p-2 rounded-md hamburger-btn"
-              (click)="sidebarOpen.set(true)"
-              [attr.aria-expanded]="sidebarOpen()"
-              aria-label="Open navigation menu">
-        <i class="pi pi-bars text-lg"></i>
-      </button>
-      <span class="text-sm font-medium header-title">Mental Metal</span>
-      <span class="ml-auto">
-        <app-global-chat-launcher />
-      </span>
-    </header>
-
-    <!-- Page content -->
-    <main class="flex-1 overflow-y-auto p-6">
-      <router-outlet />
-    </main>
-
+    <!-- Global chat slide-over: rendered once for the whole shell, controlled by GlobalChatStateService. -->
+    <app-global-chat-slide-over />
   </div>
-
-  <!-- Global chat slide-over: rendered once for the whole shell, controlled by GlobalChatStateService. -->
-  <app-global-chat-slide-over />
-</div>
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/app.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.spec.ts
@@ -1,8 +1,15 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { App } from './app';
+
+@Component({ selector: 'login-stub', standalone: true, template: 'login stub' })
+class LoginStubComponent {}
+
+@Component({ selector: 'dashboard-stub', standalone: true, template: 'dashboard stub' })
+class DashboardStubComponent {}
 
 beforeAll(() => {
   if (!window.matchMedia) {
@@ -28,7 +35,10 @@ describe('App', () => {
     await TestBed.configureTestingModule({
       imports: [App],
       providers: [
-        provideRouter([]),
+        provideRouter([
+          { path: 'login', component: LoginStubComponent },
+          { path: 'dashboard', component: DashboardStubComponent, data: { title: 'Dashboard' } },
+        ]),
         provideHttpClient(),
         provideHttpClientTesting(),
       ],
@@ -39,5 +49,36 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('hides the shell chrome on the /login route', async () => {
+    const fixture = TestBed.createComponent(App);
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/login');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('aside')).toBeNull();
+    expect(host.querySelector('header')).toBeNull();
+    expect(host.querySelector('app-sidebar')).toBeNull();
+  });
+
+  it('renders the shell chrome and page title on an authenticated route', async () => {
+    const fixture = TestBed.createComponent(App);
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/dashboard');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('header')).not.toBeNull();
+    expect(host.querySelector('aside')).not.toBeNull();
+    const title = host.querySelector('.header-title');
+    expect(title?.textContent?.trim()).toBe('Dashboard');
   });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/app.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.spec.ts
@@ -1,3 +1,5 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { App } from './app';
@@ -25,7 +27,11 @@ describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     }).compileComponents();
   });
 

--- a/src/MentalMetal.Web/ClientApp/src/app/app.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.ts
@@ -1,8 +1,11 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/router';
+import { filter, map, startWith } from 'rxjs/operators';
 import { SidebarComponent } from './shared/components/sidebar.component';
 import { GlobalChatLauncherComponent } from './shared/components/global-chat-launcher.component';
 import { GlobalChatSlideOverComponent } from './shared/components/global-chat-slide-over.component';
+import { AuthService } from './shared/services/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -13,5 +16,43 @@ import { GlobalChatSlideOverComponent } from './shared/components/global-chat-sl
   styleUrl: './app.css',
 })
 export class App {
+  // Inject AuthService eagerly so its constructor runs during bootstrap —
+  // before Angular's router processes the initial navigation and strips the
+  // URL fragment via history.replaceState. This ensures extractTokenFromHash()
+  // sees the access token returned in the OAuth callback redirect (#75 Bug 5).
+  private readonly _auth = inject(AuthService);
+
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+
   protected readonly sidebarOpen = signal(false);
+
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      map((event) => event.urlAfterRedirects),
+      startWith(this.router.url),
+    ),
+    { initialValue: this.router.url },
+  );
+
+  protected readonly isLoginRoute = computed(() => this.currentUrl().startsWith('/login'));
+
+  protected readonly pageTitle = toSignal(
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      map(() => this.resolveTitle()),
+      startWith(this.resolveTitle()),
+    ),
+    { initialValue: this.resolveTitle() },
+  );
+
+  private resolveTitle(): string {
+    let route = this.activatedRoute;
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    const title = route.snapshot.data?.['title'];
+    return typeof title === 'string' ? title : '';
+  }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/app.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.ts
@@ -16,11 +16,12 @@ import { AuthService } from './shared/services/auth.service';
   styleUrl: './app.css',
 })
 export class App {
-  // Inject AuthService eagerly so its constructor runs during bootstrap —
-  // before Angular's router processes the initial navigation and strips the
-  // URL fragment via history.replaceState. This ensures extractTokenFromHash()
-  // sees the access token returned in the OAuth callback redirect (#75 Bug 5).
-  private readonly _auth = inject(AuthService);
+  // AuthService is injected for its constructor side effect: it calls
+  // extractTokenFromHash() during bootstrap, before Angular's router processes
+  // the initial navigation and strips the URL fragment via history.replaceState.
+  // The reference is intentionally unused — holding it keeps the DI instance
+  // alive and guarantees construction order (#75 Bug 5).
+  protected readonly eagerAuthInit = inject(AuthService);
 
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -33,6 +33,10 @@ import { ThemeService } from '../services/theme.service';
       border-left: 3px solid var(--p-primary-color);
     }
 
+    :host-context(.dark) .sidebar-link-active {
+      background-color: var(--p-primary-950);
+    }
+
     .theme-toggle {
       color: var(--p-text-color);
     }

--- a/src/MentalMetal.Web/MentalMetal.Web.csproj
+++ b/src/MentalMetal.Web/MentalMetal.Web.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -53,15 +53,17 @@ builder.Services.AddDataProtection()
     .SetApplicationName("MentalMetal");
 if (!string.IsNullOrWhiteSpace(dataProtectionBucket))
 {
-    var dataProtectionObjectName =
-        builder.Configuration["DataProtection:ObjectName"] ?? "data-protection-keys.xml";
+    // Prefix under which each key is stored as its own object (one object per key,
+    // to avoid read-modify-write races between Cloud Run instances).
+    var dataProtectionObjectPrefix =
+        builder.Configuration["DataProtection:ObjectPrefix"] ?? "keys/";
 
     builder.Services.TryAddSingleton(_ => StorageClient.Create());
     builder.Services.AddSingleton<IXmlRepository>(sp =>
         new GoogleCloudStorageXmlRepository(
             sp.GetRequiredService<StorageClient>(),
             dataProtectionBucket,
-            dataProtectionObjectName,
+            dataProtectionObjectPrefix,
             sp.GetRequiredService<ILogger<GoogleCloudStorageXmlRepository>>()));
     builder.Services.AddOptions<KeyManagementOptions>()
         .Configure<IServiceProvider>((options, sp) =>

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -19,9 +19,15 @@ using MentalMetal.Domain.Delegations;
 using MentalMetal.Domain.Initiatives;
 using MentalMetal.Domain.Initiatives.LivingBrief;
 using MentalMetal.Domain.People;
+using Google.Cloud.Storage.V1;
 using MentalMetal.Infrastructure;
 using MentalMetal.Infrastructure.Auth;
+using MentalMetal.Web.Auth;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -34,6 +40,35 @@ builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 builder.Services.AddInfrastructure(builder.Configuration);
+
+// --- DataProtection ---
+// In hosted environments (e.g. Cloud Run) the local filesystem is ephemeral, so
+// keys must be persisted to durable storage. When DataProtection:BucketName is
+// set, store keys in a Google Cloud Storage object so OAuth state cookies issued
+// by one container instance can be validated by another (#75 Bug 4). Otherwise
+// fall back to the framework default (filesystem under the current user profile),
+// which is fine for local development.
+var dataProtectionBucket = builder.Configuration["DataProtection:BucketName"];
+builder.Services.AddDataProtection()
+    .SetApplicationName("MentalMetal");
+if (!string.IsNullOrWhiteSpace(dataProtectionBucket))
+{
+    var dataProtectionObjectName =
+        builder.Configuration["DataProtection:ObjectName"] ?? "data-protection-keys.xml";
+
+    builder.Services.TryAddSingleton(_ => StorageClient.Create());
+    builder.Services.AddSingleton<IXmlRepository>(sp =>
+        new GoogleCloudStorageXmlRepository(
+            sp.GetRequiredService<StorageClient>(),
+            dataProtectionBucket,
+            dataProtectionObjectName,
+            sp.GetRequiredService<ILogger<GoogleCloudStorageXmlRepository>>()));
+    builder.Services.AddOptions<KeyManagementOptions>()
+        .Configure<IServiceProvider>((options, sp) =>
+        {
+            options.XmlRepository = sp.GetRequiredService<IXmlRepository>();
+        });
+}
 
 var jwtSettings = builder.Configuration.GetSection(JwtSettings.SectionName).Get<JwtSettings>()
     ?? throw new InvalidOperationException("JWT settings are not configured. Add a 'Jwt' section to appsettings.");


### PR DESCRIPTION
## Summary

Addresses the six bugs reported in #75 covering login page UX, dark-mode contrast on the sidebar, OAuth token capture on the SPA, and ephemeral DataProtection keys on Cloud Run causing intermittent OAuth state failures.

Closes #75

## Bugs and fixes

- **Bug 1 (High) — Sidebar/header rendered on /login.** `app.html`/`app.ts`: signal-driven check on the current router URL via `toSignal(router.events.pipe(filter(NavigationEnd), map(...)))`. `@if (isLoginRoute()) { <router-outlet /> } @else { <shell /> }` so the login page is full-screen.
- **Bug 2 (Medium) — Top header duplicated the "Mental Metal" brand.** Replaced static span with the current page title pulled from the leaf route's `data.title` via a `toSignal` subscription on `NavigationEnd`. Falls back to nothing when the route does not set a title.
- **Bug 3 (High) — Active sidebar nav item invisible in dark mode.** Added a `:host-context(.dark) .sidebar-link-active { background-color: var(--p-primary-950); }` rule alongside the existing light-mode rule. Uses PrimeNG design tokens per CLAUDE.md.
- **Bug 4 (High) — Intermittent 500 \"oauth state was missing or invalid\".** ASP.NET DataProtection keys were stored at `/home/app/.aspnet/DataProtection-Keys` inside the Cloud Run container (ephemeral). When a new instance cold-started, keys regenerated and OAuth state cookies issued by previous instances couldn't be validated. Added a custom `IXmlRepository` backed by Google Cloud Storage (`Google.Cloud.Storage.V1` 4.14.0). Activates only when `DataProtection:BucketName` configuration is present; otherwise the framework default (filesystem) is used for local dev. Terraform: new versioned GCS bucket with uniform bucket-level access and `public_access_prevention = enforced`, service account granted `roles/storage.objectAdmin`, and `DataProtection__BucketName` env var wired into Cloud Run via a new `env_vars` input on the `cloud-run` module.
- **Bug 5 (Critical) — OAuth token never stored after callback.** Inject `AuthService` eagerly in the root `App` component so its constructor runs during bootstrap, before Angular's router's initial `replaceState` strips the URL fragment. This ensures `extractTokenFromHash()` sees `window.location.hash` while it still contains `#access_token=...`.
- **Bug 6 (High) — Nav items appear to do nothing.** Symptom of Bug 5; resolves automatically once Bug 5 is fixed.

## Caller notes

- **Bug 5 root cause is unvalidated by a browser debugger.** The router-replaceState-vs-guards ordering hypothesis is consistent with the server logs and the codebase but has not been confirmed with DevTools breakpoints (per the issue author's note). The fix (eager injection in the root component) is safe to apply regardless and matches the recommendation in the issue.
- **Infra changes require \`terraform apply\` by a human with appropriate GCP credentials.** Until the bucket exists and the env var is set on Cloud Run, the backend continues to use filesystem-backed keys (no behavioural change). After apply, a service redeploy will pick up the new env var and start using GCS for key persistence.

## Test plan

- [x] \`dotnet build src/MentalMetal.slnx\` succeeds
- [x] \`dotnet test src/MentalMetal.slnx\` — 380 tests pass
- [x] \`(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)\` — 17 tests pass
- [x] \`(cd src/MentalMetal.Web/ClientApp && npx ng build)\` succeeds
- [x] \`(cd src/MentalMetal.Web/ClientApp && npx tsc --noEmit)\` — clean
- [x] \`terraform -chdir=infra/environments/staging validate\` — Success
- [ ] Manual: navigate to /login — no sidebar/header rendered
- [ ] Manual: navigate to a protected route — header shows route data.title
- [ ] Manual: toggle dark mode — active sidebar nav item is readable
- [ ] Manual (post terraform apply + redeploy): cold-start the Cloud Run service and complete a full Google OAuth flow without intermittent 500s on /api/auth/google-callback

---
\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve login UX, OAuth reliability, and environment configuration for the web app and Cloud Run deployment.

Bug Fixes:
- Hide the application shell chrome on the /login route so the login page renders full-screen.
- Display the current page title in the header using route metadata instead of duplicating the brand text.
- Fix OAuth access tokens not being captured on SPA bootstrap by eagerly initializing the AuthService before the router strips the URL fragment.
- Persist ASP.NET Core DataProtection keys in Google Cloud Storage in hosted environments to prevent intermittent OAuth state validation failures.
- Ensure the active sidebar navigation item remains visible in dark mode.

Enhancements:
- Expose a generic env_vars map on the Cloud Run Terraform module to support plain environment variable configuration.

Deployment:
- Provision a secured, versioned GCS bucket and IAM binding for DataProtection keys and wire its name into the Cloud Run service via Terraform.

Tests:
- Update the root App component test configuration to include HTTP client providers required by the new eager AuthService injection.