### PR TITLE
feat: email/password auth alongside Google login

### DIFF
--- a/openspec/changes/email-password-auth/.openspec.yaml
+++ b/openspec/changes/email-password-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/email-password-auth/design.md
+++ b/openspec/changes/email-password-auth/design.md
@@ -1,0 +1,113 @@
+## Context
+
+Authentication today is Google OAuth only (see `user-auth-tenancy` spec). JWT bearer is the default authenticate scheme; the cookie scheme exists solely to carry Google's callback state. The `User` aggregate stores `ExternalAuthId` (Google sub, required, unique) and `Email` (unique). Token issuance and refresh rotation are already implemented and reusable (`ITokenService`, `RefreshTokens` table).
+
+Adding email/password login is additive: it introduces a second credential type on the existing `User` aggregate and two new unauthenticated endpoints that hand off to the existing token pipeline. No new auth scheme is needed — the JWT issued by a password login is indistinguishable from one issued by a Google login, so every downstream consumer (`ICurrentUserService`, interceptors, authorization) works unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can register a new account with email + password and log in.
+- Existing Google users can attach a password to their account (linking) via an authenticated endpoint and settings UI.
+- Password-auth users get the same JWT + refresh-token session as Google users — no forked auth code paths downstream.
+- Password storage uses a modern, framework-supported hash (PBKDF2 via `Microsoft.AspNetCore.Identity.PasswordHasher<T>`).
+
+**Non-Goals:**
+- Email verification on register.
+- Password reset / "forgot password".
+- Login rate limiting / account lockout (deferred to a later hardening pass; document the gap).
+- Strong password policy (minimum length only for v1).
+- Email-based account linking (a Google user is not linked to a registration attempt that happens to share the same email — registration with an existing email fails).
+- Migrating existing Google-only users; they keep working unchanged.
+
+## Decisions
+
+### D1: Extend existing User aggregate vs. separate Credential aggregate
+**Choice:** Extend `User`. Add nullable `Password` value object; make `ExternalAuthId` nullable.
+
+**Alternatives considered:**
+- *Separate `Credential` aggregate per auth method.* More flexible (multiple credentials per user, per-credential revocation) but over-engineered for two fixed methods and violates the "keep it bare bones" scope. Adds a second aggregate for data that has a 1:1 relationship with `User`.
+
+**Rationale:** `User` already owns identity fields (`Email`, `ExternalAuthId`). A password is another optional identity fact about the same user, not an independent aggregate. Mirrors how `AiProviderConfig` was added as an optional VO on `User`.
+
+### D2: Password as a value object, not a plain string
+**Choice:** New `Password` VO wrapping a hash string. Factory `Password.Create(plaintext, IPasswordHasher<User>)`; instance method `Verify(plaintext, IPasswordHasher<User>): bool`.
+
+**Alternatives considered:**
+- *Plain nullable `PasswordHash` string on `User` + domain methods on `User` itself.* Less ceremony, one fewer file, but inconsistent with `Email` (also a VO) and leaks hash-format concerns out of a cohesive type.
+
+**Rationale:** Consistency with `Email`. Encapsulates hash-vs-plaintext confusion at the type level — a `Password` instance is *always* a hash, and the only way to get one is through a factory that takes plaintext + hasher.
+
+### D3: Password hashing library
+**Choice:** `Microsoft.AspNetCore.Identity.PasswordHasher<User>` from `Microsoft.AspNetCore.Identity`. Registered as `IPasswordHasher<User>` singleton in DI.
+
+**Alternatives considered:**
+- *BCrypt.Net-Next.* Well-known, focused. But adds a third-party dependency for a capability .NET ships in-framework.
+- *Argon2 (Konscious).* Stronger (memory-hard) but overkill for current scope and adds a dep.
+
+**Rationale:** In-framework, PBKDF2 with automatic rehash detection, used by millions of ASP.NET Identity deployments. We import `Microsoft.AspNetCore.Identity` for this one type only — no Identity schema, middleware, or endpoints.
+
+### D4: Linking behaviour on email collision
+**Choice:** Register rejects with 409 if the email already exists. Existing users (Google-only) add a password via the authenticated `POST /api/auth/password` endpoint.
+
+**Alternatives considered:**
+- *Automatic linking when emails match at register time.* Friendlier but trust-unsafe: anyone who knows Alice's email could claim her account by registering, then read her data. Would require email verification to be safe — which is out of scope.
+- *Prompt "sign in with Google instead" at the UI layer on collision.* Already effectively what happens (409 surfaces a message); no backend change needed.
+
+**Rationale:** Proving account ownership by being logged in is the cheapest safe linking path. The user is already authenticated via Google when they set a password, so there's no ambiguity about who owns the account.
+
+### D5: `POST /api/auth/password` semantics
+**Choice:** One endpoint that both sets (first-time) and changes (replace) the password. Body: `{ newPassword }`. No old-password confirmation in v1.
+
+**Alternatives considered:**
+- *Separate `set` and `change` endpoints.* More REST-purist but the difference is a nullability check the backend already needs to perform.
+- *Require current password on change.* Standard security control to prevent session-hijack-to-password-takeover. Deferred: v1 relies on the short JWT lifetime; add as a hardening follow-up.
+
+**Rationale:** Single endpoint keeps handler count and UI state small. The current-password requirement is worth adding later but is not table stakes given our session lifetime.
+
+### D6: Response shape for register/login endpoints
+**Choice:** Return JWT in the JSON response body (`{ accessToken, user }`), set refresh token as HttpOnly cookie — same as the Google callback, just without the hash-fragment redirect.
+
+**Alternatives considered:**
+- *Also set access token as a cookie.* Would require frontend changes to read the token; breaks parity with the existing localStorage-based flow.
+- *Redirect with hash fragment like Google.* Google does that because it starts with a server-side redirect from Google's IdP. Password endpoints are called directly from the SPA via fetch; a redirect is the wrong primitive.
+
+**Rationale:** Parity with how `AuthService` already stores the Google-issued token (once extracted from the hash). Frontend plumbing downstream of "we got a JWT" is unchanged.
+
+### D7: `ExternalAuthId` becomes nullable
+**Choice:** Make `ExternalAuthId` nullable (drop NOT NULL, keep unique index — Postgres unique indexes ignore nulls by default).
+
+**Alternatives considered:**
+- *Sentinel value like `"local:{userId}"`.* Avoids nullability but pollutes query logic and lookups.
+
+**Rationale:** Nullable is the honest modelling. A user registered with password + no Google linkage genuinely has no external auth id.
+
+### D8: `hasPassword` exposed on `/api/users/me`
+**Choice:** Add `hasPassword: bool` to the current-user response.
+
+**Rationale:** The settings UI needs to pick "Set a password" vs "Change password" copy. Exposing only the boolean (never the hash or any derivative) is the minimal leak.
+
+## Risks / Trade-offs
+
+- **[No rate limiting]** → Brute-force attempts against `/api/auth/login` are not throttled. Mitigation: short-lived JWT limits session-theft blast radius; add middleware-level rate limiting in a follow-up hardening change. Document in the spec's non-goals.
+- **[No current-password check on change]** → An attacker with a stolen JWT can rotate the password and extend access. Mitigation: 15-minute access token lifetime keeps the window small; add old-password requirement in a follow-up.
+- **[No email verification]** → A user could register with someone else's email. Mitigation: this does not grant access to that person's existing account (register rejects on existing email), but does let an attacker squat on an unused email. Acceptable for v1; add verification in a follow-up.
+- **[Identity package footprint]** → Pulling in `Microsoft.AspNetCore.Identity` for one class. Mitigation: we register only `IPasswordHasher<User>` and do not add Identity's EF schema, middleware, or endpoints. If footprint becomes an issue, swap to BCrypt.Net-Next (single-class replacement).
+- **[Nullable ExternalAuthId + Email unique index]** → No behavioural risk, but test migration on a DB snapshot to confirm Postgres does not reject the column alter on existing rows.
+
+## Migration Plan
+
+1. Ship the migration adding `PasswordHash` (nullable text) and altering `ExternalAuthId` to nullable.
+2. Deploy backend — existing Google users unaffected (all have ExternalAuthId set, PasswordHash null).
+3. Deploy frontend — login page gains password form, settings gains password section.
+4. Rollback: revert frontend first (UI disappears, endpoints still live but unreachable from UI), then revert backend. The migration is additive-only, so no data loss; if rollback is needed the new column and relaxed constraint are left in place to avoid churn, and a later forward migration can revisit.
+
+## Dependencies
+
+- `user-auth-tenancy` (Tier 1) — being modified by this change.
+- `ai-provider-abstraction`, `person-management`, `initiative-management` — untouched; listed only to confirm no cross-capability impact.
+
+## Open Questions
+
+- Minimum password length: 8 or 10? Defaulting to 8 in tasks; flag for confirmation during implementation.
+- Should register also accept an optional `timezone` (Google flow infers from browser later)? Defaulting to a sensible server-side value (`Etc/UTC`) until the user edits it on the settings page.

--- a/openspec/changes/email-password-auth/proposal.md
+++ b/openspec/changes/email-password-auth/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Google OAuth is currently the only way to sign in. This excludes anyone who doesn't want to (or can't) use a Google account, and leaves users without a fallback if their Google identity becomes unavailable. Adding email/password as a second authentication method removes that dependency and gives existing Google users a local credential they can use to recover or diversify access.
+
+## What Changes
+
+- Add email/password registration: `POST /api/auth/register` creates a new User with a hashed password and issues the same JWT + refresh-token pair the Google flow issues.
+- Add email/password login: `POST /api/auth/login` verifies credentials and issues tokens.
+- Add authenticated password set/change: `POST /api/auth/password` lets a signed-in user attach a password to their account (the linking mechanism for existing Google-only users).
+- Extend the `User` aggregate with an optional `Password` value object wrapping a PBKDF2 hash; make `ExternalAuthId` nullable so password-only users are representable.
+- Extend `GET /api/users/me` with `hasPassword: bool` so the frontend can show "Set a password" vs "Change password".
+- Add a password form to the existing login page (beside the Google button) and a password section to the settings page.
+- Reject register attempts whose email already exists — linking happens via the authenticated `/api/auth/password` endpoint, not by matching emails at registration time.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `user-auth-tenancy`: Adds email/password as a second authentication method. Extends the User aggregate to support a password hash alongside (or instead of) an external auth identity. Extends the `/api/users/me` response with password presence.
+
+## Impact
+
+**Domain / code**
+- `src/MentalMetal.Domain/Users/User.cs` — new `Password` value object; `PasswordHash: Password?` property; `ExternalAuthId` becomes nullable; new factory `RegisterWithPassword`; new methods `SetPassword`, `VerifyPassword`.
+- `src/MentalMetal.Domain/Users/IUserRepository.cs` — add `GetByEmailAsync(Email)`.
+- `src/MentalMetal.Application/Users/` — new vertical-slice handlers: `RegisterWithPassword`, `LoginWithPassword`, `SetPassword`.
+- `src/MentalMetal.Web/Program.cs` — three new minimal-API endpoints; register `IPasswordHasher<User>` singleton.
+- `src/MentalMetal.Infrastructure/Migrations/` — new migration adding nullable `PasswordHash` column and making `ExternalAuthId` nullable.
+
+**Frontend**
+- `pages/login/login.page.ts` — email/password form alongside Google button.
+- `shared/services/auth.service.ts` — `loginWithPassword`, `registerWithPassword`, `setPassword`.
+- Settings page — new "Password" section (set/change).
+
+**Dependencies**
+- New NuGet: `Microsoft.AspNetCore.Identity` (used only for `PasswordHasher<T>`; no Identity schema or middleware).
+
+**Non-goals (explicit out of scope for v1)**
+- Email verification on register
+- Password reset / "forgot password" flow
+- Login rate limiting / lockout
+- Password strength rules beyond a minimum length
+- Linking by matching email during register (Google users must sign in first, then add a password via settings)
+
+**Tier**
+- Enhancement to Tier 1 foundation (`user-auth-tenancy`). No new tier dependencies introduced.
+
+**Affected aggregates**
+- `User` (only).

--- a/openspec/changes/email-password-auth/proposal.md
+++ b/openspec/changes/email-password-auth/proposal.md
@@ -37,7 +37,7 @@ _None._
 - Settings page — new "Password" section (set/change).
 
 **Dependencies**
-- New NuGet: `Microsoft.AspNetCore.Identity` (used only for `PasswordHasher<T>`; no Identity schema or middleware).
+- New NuGet: `Microsoft.Extensions.Identity.Core` (used only for `PasswordHasher<T>`; no Identity schema or middleware).
 
 **Non-goals (explicit out of scope for v1)**
 - Email verification on register

--- a/openspec/changes/email-password-auth/specs/user-auth-tenancy/spec.md
+++ b/openspec/changes/email-password-auth/specs/user-auth-tenancy/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: User registration via email and password
+
+The system SHALL allow a new user to register by providing email, password, and name. The system SHALL hash the password using a PBKDF2-based hasher before persisting it. The system SHALL reject registration if the email already belongs to any existing User. On success, the system SHALL create a User aggregate with a null `ExternalAuthId`, raise a `UserRegistered` domain event, and issue a JWT access token and refresh token identical in shape to those issued by the Google OAuth flow.
+
+Password MUST be at least 8 characters. Email MUST be a valid email address. Name MUST NOT be empty.
+
+#### Scenario: Successful email/password registration
+
+- **WHEN** an unauthenticated client posts to `/api/auth/register` with a valid email, password (≥ 8 chars), and non-empty name, and no User exists with that email
+- **THEN** the system creates a User with hashed password and null ExternalAuthId, sets CreatedAt and LastLoginAt to now, applies default UserPreferences, raises `UserRegistered`, and returns 200 with an access token in the body and a refresh token cookie
+
+#### Scenario: Registration with existing email rejected
+
+- **WHEN** a client posts to `/api/auth/register` with an email that already belongs to any User (whether that User has a password, an ExternalAuthId, or both)
+- **THEN** the system returns HTTP 409 Conflict and does not create a new User
+
+#### Scenario: Registration with short password rejected
+
+- **WHEN** a client posts to `/api/auth/register` with a password shorter than 8 characters
+- **THEN** the system returns HTTP 400 and does not create a User
+
+#### Scenario: Registration with invalid email rejected
+
+- **WHEN** a client posts to `/api/auth/register` with a malformed email
+- **THEN** the system returns HTTP 400 and does not create a User
+
+### Requirement: User login via email and password
+
+The system SHALL authenticate a user by email and password and issue a JWT access token and refresh token when the credentials are valid. The system SHALL update `LastLoginAt` on successful login. The system SHALL return HTTP 401 for any failure — unknown email, wrong password, or a user with no password set (i.e., a Google-only user) — without disclosing which case applies.
+
+#### Scenario: Successful email/password login
+
+- **WHEN** an unauthenticated client posts to `/api/auth/login` with an email and password that match an existing User with a password set
+- **THEN** the system updates LastLoginAt, issues a new access token and refresh token, and returns 200 with the access token in the body and the refresh token cookie
+
+#### Scenario: Wrong password
+
+- **WHEN** a client posts to `/api/auth/login` with an email that exists but the wrong password
+- **THEN** the system returns HTTP 401 and does not issue tokens
+
+#### Scenario: Unknown email
+
+- **WHEN** a client posts to `/api/auth/login` with an email that does not belong to any User
+- **THEN** the system returns HTTP 401 and does not issue tokens
+
+#### Scenario: User has no password set
+
+- **WHEN** a client posts to `/api/auth/login` with the email of a User whose `PasswordHash` is null (Google-only account)
+- **THEN** the system returns HTTP 401 without disclosing the reason
+
+### Requirement: Set or change password on current user
+
+The system SHALL allow an authenticated user to set a password on their account (first time) or replace an existing one. This is the mechanism by which a user registered via Google OAuth attaches a password to their account. The endpoint SHALL require a valid JWT. The password MUST meet the same minimum-length rule as registration.
+
+#### Scenario: Google-only user sets their first password
+
+- **WHEN** an authenticated User whose `PasswordHash` is null posts a new password (≥ 8 chars) to `/api/auth/password`
+- **THEN** the system stores the hashed password on the User aggregate and returns HTTP 204
+
+#### Scenario: User with existing password replaces it
+
+- **WHEN** an authenticated User whose `PasswordHash` is set posts a new password to `/api/auth/password`
+- **THEN** the system replaces the stored hash with the new one and returns HTTP 204
+
+#### Scenario: Short password rejected
+
+- **WHEN** an authenticated user posts a password shorter than 8 characters to `/api/auth/password`
+- **THEN** the system returns HTTP 400 and does not update the User
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** an unauthenticated client posts to `/api/auth/password`
+- **THEN** the system returns HTTP 401
+
+### Requirement: User aggregate supports optional password credential
+
+The `User` aggregate SHALL include an optional `Password` value object (`PasswordHash`) and an optional `ExternalAuthId`. A User MUST have at least one of the two. A User MAY have both (meaning the user can sign in via either method). The `Password` value object SHALL encapsulate a password hash and expose a verification operation.
+
+#### Scenario: User registered via password has null ExternalAuthId
+
+- **WHEN** a User is created via email/password registration
+- **THEN** the User's `ExternalAuthId` is null and `PasswordHash` is set
+
+#### Scenario: User registered via Google has null PasswordHash
+
+- **WHEN** a User is created via Google OAuth registration (existing flow)
+- **THEN** the User's `ExternalAuthId` is set and `PasswordHash` is null
+
+#### Scenario: Linked user has both credentials
+
+- **WHEN** a Google-registered User invokes the domain operation to set a password
+- **THEN** the User has both `ExternalAuthId` and `PasswordHash` set, and can log in via either method
+
+### Requirement: Frontend email and password login form
+
+The Angular login page SHALL present an email/password form alongside the existing Google sign-in button. On submission the form SHALL call the appropriate backend endpoint (`/api/auth/login` or `/api/auth/register`), store the returned access token via the existing auth service, and redirect into the application.
+
+#### Scenario: User logs in with email and password
+
+- **WHEN** a user enters a valid email and password on the login page and submits
+- **THEN** the app calls `/api/auth/login`, stores the returned access token, and navigates to the post-login route
+
+#### Scenario: User registers from the login page
+
+- **WHEN** a user switches to the register form, enters a valid email, name, and password, and submits
+- **THEN** the app calls `/api/auth/register`, stores the returned access token, and navigates to the post-login route
+
+#### Scenario: Failed login shows error
+
+- **WHEN** a password login attempt returns HTTP 401
+- **THEN** the login page shows a generic "invalid credentials" message and does not navigate away
+
+#### Scenario: Duplicate email on register shows error
+
+- **WHEN** a registration attempt returns HTTP 409
+- **THEN** the register form shows a message indicating the email is already in use
+
+### Requirement: Frontend password section in settings
+
+The Angular settings page SHALL include a password section that allows the authenticated user to set a first password or replace an existing one, driven by the `hasPassword` field on the current-user response.
+
+#### Scenario: Google-only user sees "Set a password"
+
+- **WHEN** an authenticated user with `hasPassword=false` views the settings page
+- **THEN** the password section shows a "Set a password" heading and a single new-password input
+
+#### Scenario: User with password set sees "Change password"
+
+- **WHEN** an authenticated user with `hasPassword=true` views the settings page
+- **THEN** the password section shows a "Change password" heading and a new-password input
+
+#### Scenario: Saving a password calls the endpoint
+
+- **WHEN** the user enters a valid new password in settings and submits
+- **THEN** the app calls `POST /api/auth/password`, shows a success confirmation on 204, and updates local state so that `hasPassword` is reflected as true
+
+## MODIFIED Requirements
+
+### Requirement: Get current user profile
+
+The system SHALL provide an endpoint to retrieve the authenticated user's profile and preferences.
+
+#### Scenario: Get current user
+
+- **WHEN** an authenticated user requests their profile via `/api/users/me`
+- **THEN** the system returns the user's Id, Email, Name, AvatarUrl, Timezone, Preferences, HasAiProvider, HasPassword, CreatedAt, and LastLoginAt
+
+#### Scenario: HasPassword reflects password state
+
+- **WHEN** an authenticated user with a non-null `PasswordHash` requests their profile
+- **THEN** the response includes `hasPassword=true`; and when the `PasswordHash` is null the response includes `hasPassword=false`
+
+### Requirement: User registration via OAuth
+
+The system SHALL create a new User aggregate when a user authenticates via Google OAuth for the first time. The User SHALL be populated with ExternalAuthId, Email, Name, and AvatarUrl from the Google identity token, and its `PasswordHash` SHALL be null. The system SHALL raise a `UserRegistered` domain event upon successful registration. ExternalAuthId and Email SHALL have unique database indexes to enforce identity uniqueness at the persistence layer; the ExternalAuthId index SHALL treat null values as non-conflicting so that password-only users do not collide.
+
+#### Scenario: First-time Google OAuth login
+
+- **WHEN** a user completes Google OAuth authentication and no User exists with that ExternalAuthId
+- **THEN** the system creates a new User aggregate with the Google profile data, sets CreatedAt and LastLoginAt to the current time, applies default UserPreferences, leaves `PasswordHash` null, and returns a JWT access token and refresh token
+
+#### Scenario: Existing ExternalAuthId treated as returning login
+
+- **WHEN** a registration attempt is made with an ExternalAuthId that already exists
+- **THEN** the system treats it as a returning user login (RecordLogin) rather than creating a duplicate
+
+#### Scenario: Duplicate email rejected
+
+- **WHEN** a registration attempt is made with an email that already belongs to a different User
+- **THEN** the system rejects the registration and returns an error indicating the email is already in use

--- a/openspec/changes/email-password-auth/tasks.md
+++ b/openspec/changes/email-password-auth/tasks.md
@@ -1,0 +1,69 @@
+## 1. Domain
+
+- [x] 1.1 Add `Microsoft.AspNetCore.Identity` NuGet reference to `MentalMetal.Domain` (or `MentalMetal.Application`, whichever already owns hashing contracts — prefer keeping Domain dependency-free and take the dep in Application/Infrastructure only, with the domain exposing an `IPasswordHasher` abstraction)
+- [x] 1.2 Create `Password` value object in `src/MentalMetal.Domain/Users/Password.cs` — private ctor taking hash string, static `Create(string plaintext, IPasswordHasher<User> hasher)`, `Verify(string plaintext, IPasswordHasher<User> hasher): bool`, equality on hash value. Mirror style of `Email` VO
+- [x] 1.3 Update `User` aggregate in `src/MentalMetal.Domain/Users/User.cs`: add nullable `Password? PasswordHash`; make `ExternalAuthId` nullable; invariant-check that at least one of the two is set after construction
+- [x] 1.4 Add `User.RegisterWithPassword(Email, Name, Password, timezone, ...)` factory that returns a User with null `ExternalAuthId` and raises `UserRegistered`
+- [x] 1.5 Add `User.SetPassword(string plaintext, IPasswordHasher<User> hasher)` domain method that replaces or sets `PasswordHash`
+- [x] 1.6 Add `User.VerifyPassword(string plaintext, IPasswordHasher<User> hasher): bool` returning false if `PasswordHash` is null
+- [x] 1.7 Add `IUserRepository.GetByEmailAsync(Email)` abstraction
+- [x] 1.8 Domain unit tests: `Password` VO creation + verification round-trip, rejects short plaintext at factory boundary; `User.RegisterWithPassword` sets state correctly; `User.SetPassword` sets and replaces; `User.VerifyPassword` returns false when hash is null, false on wrong password, true on correct
+
+## 2. Infrastructure
+
+- [x] 2.1 Implement `IUserRepository.GetByEmailAsync` in `UserRepository.cs`
+- [x] 2.2 Update EF Core config for `User`: map `PasswordHash` as owned/converted to nullable text column; relax `ExternalAuthId` nullability; keep the unique index on `ExternalAuthId` but ensure Postgres null-tolerance (default behaviour)
+- [x] 2.3 Create EF migration `AddPasswordHashToUsers` adding the nullable `PasswordHash` column and altering `ExternalAuthId` to nullable; verify the generated SQL is safe to apply to a non-empty Users table
+- [x] 2.4 Register `IPasswordHasher<User>` → `PasswordHasher<User>` singleton in DI composition (Infrastructure module registration or `Program.cs`)
+
+## 3. Application (handlers)
+
+- [x] 3.1 `RegisterWithPasswordHandler` — validates email format, password length ≥ 8, non-empty name; checks `ExistsByEmailAsync`; constructs `Password` via factory; creates User via `RegisterWithPassword`; persists; generates tokens via existing `ITokenService`
+- [x] 3.2 `LoginWithPasswordHandler` — looks up via `GetByEmailAsync`; treats null/missing user and null `PasswordHash` the same as bad credentials; calls `User.VerifyPassword`; on success calls `RecordLogin` and issues tokens
+- [x] 3.3 `SetPasswordHandler` — takes current `UserId` from `ICurrentUserService`; loads user; validates password length ≥ 8; calls `User.SetPassword`; persists
+- [x] 3.4 Application-layer unit tests for each handler: happy path, duplicate email → 409, bad credentials → 401, Google-only user login → 401, unauthenticated set-password → 401 (handler-level rejection or covered at endpoint level)
+
+## 4. Web (minimal APIs)
+
+- [x] 4.1 `POST /api/auth/register` — anonymous; binds `{ email, password, name }`; returns `{ accessToken, user }` with refresh token cookie on 200; 409 on duplicate email; 400 on validation failure
+- [x] 4.2 `POST /api/auth/login` — anonymous; binds `{ email, password }`; returns `{ accessToken, user }` with refresh token cookie on 200; 401 on any credential failure (no case disclosure)
+- [x] 4.3 `POST /api/auth/password` — requires JWT; binds `{ newPassword }`; returns 204 on success; 400 on short password
+- [x] 4.4 Update the current-user endpoint (`GET /api/users/me` or equivalent) to include `hasPassword: bool` derived from `User.PasswordHash != null`
+- [x] 4.5 Ensure OpenAPI/Swagger docs (if auto-generated) list the new endpoints and request/response types
+
+## 5. Frontend — auth service
+
+- [x] 5.1 `auth.service.ts` — add `loginWithPassword(email, password)` → POST `/api/auth/login`, take access token from response body, hand into existing token-storage signal plumbing
+- [x] 5.2 `auth.service.ts` — add `registerWithPassword(email, password, name)` → POST `/api/auth/register`, same post-success handling
+- [x] 5.3 `auth.service.ts` — add `setPassword(newPassword)` → POST `/api/auth/password`; on success update local `currentUser` signal so `hasPassword` flips to true
+- [x] 5.4 Extend the user profile model/signal with `hasPassword: boolean` (sourced from `/api/users/me`)
+
+## 6. Frontend — login page
+
+- [x] 6.1 Update `pages/login/login.page.ts` — add email/password form using Signal Forms (Angular 21); two modes (`login` / `register`) toggled via a signal; `@if` control flow (no `*ngIf`)
+- [x] 6.2 Wire submit handlers to `authService.loginWithPassword` and `authService.registerWithPassword`; on success, navigate to the same post-login route the Google flow uses
+- [x] 6.3 Surface errors: generic "invalid credentials" on 401; "email already in use" on 409; inline validation for short password / bad email / empty name
+- [x] 6.4 Keep the existing "Sign in with Google" button above/beside the form, layout via Tailwind layout utilities only — no colour utilities, no `dark:` prefix, PrimeNG components where applicable (e.g., `p-inputtext`, `p-password`, `p-button`)
+
+## 7. Frontend — settings password section
+
+- [x] 7.1 Locate the existing settings page; add a new "Password" section. If no suitable page exists, create a minimal settings page and add it to the router + side nav (follow existing routing patterns)
+- [x] 7.2 Driven by `currentUser().hasPassword`: render "Set a password" heading when false, "Change password" when true; single new-password input + submit button
+- [x] 7.3 Submit calls `authService.setPassword`; show a PrimeNG `p-message` or toast confirming success; clear input after success
+- [x] 7.4 Inline validation for short password; disabled submit button while request is in flight
+
+## 8. Tests
+
+- [x] 8.1 Backend: handler unit tests per 3.4
+- [x] 8.2 Backend: endpoint integration tests hitting a real Postgres (per project convention) — register happy path, duplicate email, login success, login failure, set-password success, set-password unauthorised
+- [x] 8.3 Frontend: component tests for the login page covering login mode, register mode, and error surfaces
+- [x] 8.4 Frontend: component tests for the settings password section covering "set" and "change" variants
+- [x] 8.5 E2E: golden-path smoke — register a new user, log out, log back in via email/password, set-password-as-Google-user link flow (only if Google flow can be stubbed in E2E; otherwise cover by integration + unit)
+
+## 9. Ship
+
+- [x] 9.1 Run backend test suite: `dotnet test src/MentalMetal.slnx`
+- [x] 9.2 Run frontend test suite: `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)`
+- [ ] 9.3 Run E2E suite with Docker dev stack if applicable
+- [ ] 9.4 Manually verify the login page, register flow, and settings password section in a browser with the dev stack running
+- [ ] 9.5 Open PR via the `/pr` skill (per project convention)

--- a/src/MentalMetal.Application/Users/GetCurrentUser.cs
+++ b/src/MentalMetal.Application/Users/GetCurrentUser.cs
@@ -12,19 +12,6 @@ public sealed class GetCurrentUserHandler(
             currentUserService.UserId, cancellationToken)
             ?? throw new InvalidOperationException("Authenticated user not found.");
 
-        return new UserProfileResponse(
-            user.Id,
-            user.Email.Value,
-            user.Name,
-            user.AvatarUrl,
-            user.Timezone,
-            new UserPreferencesDto(
-                user.Preferences.Theme.ToString(),
-                user.Preferences.NotificationsEnabled,
-                user.Preferences.BriefingTime,
-                user.Preferences.LivingBriefAutoApply),
-            user.AiProviderConfig is not null,
-            user.CreatedAt,
-            user.LastLoginAt);
+        return UserProfileResponse.FromDomain(user);
     }
 }

--- a/src/MentalMetal.Application/Users/LoginWithPassword.cs
+++ b/src/MentalMetal.Application/Users/LoginWithPassword.cs
@@ -1,0 +1,59 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Auth;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+
+namespace MentalMetal.Application.Users;
+
+public sealed record LoginWithPasswordCommand(string Email, string Password);
+
+public sealed record LoginWithPasswordResult(
+    string AccessToken,
+    string RefreshToken,
+    UserProfileResponse User);
+
+/// <summary>
+/// Thrown when email/password credentials are invalid. The caller SHOULD translate
+/// this to HTTP 401 without disclosing which aspect failed.
+/// </summary>
+public sealed class InvalidCredentialsException() : Exception("Invalid credentials.");
+
+public sealed class LoginWithPasswordHandler(
+    IUserRepository userRepository,
+    ITokenService tokenService,
+    IPasswordHasher<User> passwordHasher,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<LoginWithPasswordResult> HandleAsync(
+        LoginWithPasswordCommand command, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.Email) || string.IsNullOrWhiteSpace(command.Password))
+            throw new InvalidCredentialsException();
+
+        Email email;
+        try
+        {
+            email = Email.Create(command.Email);
+        }
+        catch (ArgumentException)
+        {
+            throw new InvalidCredentialsException();
+        }
+
+        var user = await userRepository.GetByEmailAsync(email, cancellationToken);
+        if (user is null || user.PasswordHash is null)
+            throw new InvalidCredentialsException();
+
+        if (!user.VerifyPassword(command.Password, passwordHasher))
+            throw new InvalidCredentialsException();
+
+        user.RecordLogin();
+        var tokens = tokenService.GenerateTokens(user);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new LoginWithPasswordResult(
+            tokens.AccessToken,
+            tokens.RefreshToken,
+            UserProfileResponse.FromDomain(user));
+    }
+}

--- a/src/MentalMetal.Application/Users/RegisterOrLoginUser.cs
+++ b/src/MentalMetal.Application/Users/RegisterOrLoginUser.cs
@@ -35,9 +35,10 @@ public sealed class RegisterOrLoginUserHandler(
         }
 
         // Check for email collision with a different auth provider
-        if (await userRepository.ExistsByEmailAsync(command.Email, cancellationToken))
+        var email = Email.Create(command.Email);
+        if (await userRepository.ExistsByEmailAsync(email, cancellationToken))
             throw new InvalidOperationException(
-                $"A user with email '{command.Email}' already exists.");
+                $"A user with email '{email.Value}' already exists.");
 
         var user = User.Register(
             command.ExternalAuthId,

--- a/src/MentalMetal.Application/Users/RegisterWithPassword.cs
+++ b/src/MentalMetal.Application/Users/RegisterWithPassword.cs
@@ -1,0 +1,58 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Auth;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+
+namespace MentalMetal.Application.Users;
+
+public sealed record RegisterWithPasswordCommand(
+    string Email,
+    string Password,
+    string Name);
+
+public sealed record RegisterWithPasswordResult(
+    string AccessToken,
+    string RefreshToken,
+    UserProfileResponse User);
+
+public sealed class EmailAlreadyInUseException(string email)
+    : InvalidOperationException($"A user with email '{email}' already exists.");
+
+public sealed class RegisterWithPasswordHandler(
+    IUserRepository userRepository,
+    ITokenService tokenService,
+    IPasswordHasher<User> passwordHasher,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<RegisterWithPasswordResult> HandleAsync(
+        RegisterWithPasswordCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command.Email, nameof(command.Email));
+        ArgumentException.ThrowIfNullOrWhiteSpace(command.Name, nameof(command.Name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(command.Password, nameof(command.Password));
+
+        if (command.Password.Length < Domain.Users.Password.MinimumLength)
+            throw new ArgumentException(
+                $"Password must be at least {Domain.Users.Password.MinimumLength} characters.",
+                nameof(command.Password));
+
+        // Email.Create validates format
+        var email = Email.Create(command.Email);
+
+        if (await userRepository.ExistsByEmailAsync(email.Value, cancellationToken))
+            throw new EmailAlreadyInUseException(email.Value);
+
+        var password = Domain.Users.Password.Create(command.Password, passwordHasher);
+        var user = User.RegisterWithPassword(email.Value, command.Name, password, null);
+
+        await userRepository.AddAsync(user, cancellationToken);
+
+        var tokens = tokenService.GenerateTokens(user);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new RegisterWithPasswordResult(
+            tokens.AccessToken,
+            tokens.RefreshToken,
+            UserProfileResponse.FromDomain(user));
+    }
+}

--- a/src/MentalMetal.Application/Users/RegisterWithPassword.cs
+++ b/src/MentalMetal.Application/Users/RegisterWithPassword.cs
@@ -39,7 +39,7 @@ public sealed class RegisterWithPasswordHandler(
         // Email.Create validates format
         var email = Email.Create(command.Email);
 
-        if (await userRepository.ExistsByEmailAsync(email.Value, cancellationToken))
+        if (await userRepository.ExistsByEmailAsync(email, cancellationToken))
             throw new EmailAlreadyInUseException(email.Value);
 
         var password = Domain.Users.Password.Create(command.Password, passwordHasher);

--- a/src/MentalMetal.Application/Users/SetPassword.cs
+++ b/src/MentalMetal.Application/Users/SetPassword.cs
@@ -1,0 +1,30 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+
+namespace MentalMetal.Application.Users;
+
+public sealed record SetPasswordCommand(string NewPassword);
+
+public sealed class SetPasswordHandler(
+    IUserRepository userRepository,
+    ICurrentUserService currentUserService,
+    IPasswordHasher<User> passwordHasher,
+    IUnitOfWork unitOfWork)
+{
+    public async Task HandleAsync(SetPasswordCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command.NewPassword, nameof(command.NewPassword));
+
+        if (command.NewPassword.Length < Password.MinimumLength)
+            throw new ArgumentException(
+                $"Password must be at least {Password.MinimumLength} characters.",
+                nameof(command.NewPassword));
+
+        var user = await userRepository.GetByIdAsync(currentUserService.UserId, cancellationToken)
+            ?? throw new InvalidOperationException("Authenticated user not found.");
+
+        user.SetPassword(command.NewPassword, passwordHasher);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/MentalMetal.Application/Users/UserDtos.cs
+++ b/src/MentalMetal.Application/Users/UserDtos.cs
@@ -1,3 +1,5 @@
+using MentalMetal.Domain.Users;
+
 namespace MentalMetal.Application.Users;
 
 public sealed record UserProfileResponse(
@@ -8,8 +10,27 @@ public sealed record UserProfileResponse(
     string Timezone,
     UserPreferencesDto Preferences,
     bool HasAiProvider,
+    bool HasPassword,
     DateTimeOffset CreatedAt,
-    DateTimeOffset LastLoginAt);
+    DateTimeOffset LastLoginAt)
+{
+    public static UserProfileResponse FromDomain(User user) =>
+        new(
+            user.Id,
+            user.Email.Value,
+            user.Name,
+            user.AvatarUrl,
+            user.Timezone,
+            new UserPreferencesDto(
+                user.Preferences.Theme.ToString(),
+                user.Preferences.NotificationsEnabled,
+                user.Preferences.BriefingTime,
+                user.Preferences.LivingBriefAutoApply),
+            user.AiProviderConfig is not null,
+            user.PasswordHash is not null,
+            user.CreatedAt,
+            user.LastLoginAt);
+}
 
 public sealed record UserPreferencesDto(
     string Theme,
@@ -29,3 +50,9 @@ public sealed record UpdatePreferencesRequest(
     bool LivingBriefAutoApply = false);
 
 public sealed record AuthTokenResponse(string AccessToken, string? RefreshToken = null);
+
+public sealed record RegisterWithPasswordRequest(string Email, string Password, string Name);
+
+public sealed record LoginWithPasswordRequest(string Email, string Password);
+
+public sealed record SetPasswordRequest(string NewPassword);

--- a/src/MentalMetal.Domain/MentalMetal.Domain.csproj
+++ b/src/MentalMetal.Domain/MentalMetal.Domain.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/src/MentalMetal.Domain/Users/IUserRepository.cs
+++ b/src/MentalMetal.Domain/Users/IUserRepository.cs
@@ -4,6 +4,7 @@ public interface IUserRepository
 {
     Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
     Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken);
+    Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken);
     Task<bool> ExistsByEmailAsync(string email, CancellationToken cancellationToken);
     Task AddAsync(User user, CancellationToken cancellationToken);
 }

--- a/src/MentalMetal.Domain/Users/IUserRepository.cs
+++ b/src/MentalMetal.Domain/Users/IUserRepository.cs
@@ -5,6 +5,6 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
     Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken);
     Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken);
-    Task<bool> ExistsByEmailAsync(string email, CancellationToken cancellationToken);
+    Task<bool> ExistsByEmailAsync(Email email, CancellationToken cancellationToken);
     Task AddAsync(User user, CancellationToken cancellationToken);
 }

--- a/src/MentalMetal.Domain/Users/Password.cs
+++ b/src/MentalMetal.Domain/Users/Password.cs
@@ -1,0 +1,59 @@
+using MentalMetal.Domain.Common;
+using Microsoft.AspNetCore.Identity;
+
+namespace MentalMetal.Domain.Users;
+
+public sealed class Password : ValueObject
+{
+    public const int MinimumLength = 8;
+
+    public string HashValue { get; }
+
+    private Password(string hashValue) => HashValue = hashValue;
+
+    /// <summary>
+    /// Creates a <see cref="Password"/> from a plaintext value by hashing it.
+    /// </summary>
+    public static Password Create(string plaintext, IPasswordHasher<User> hasher)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(plaintext, nameof(plaintext));
+        ArgumentNullException.ThrowIfNull(hasher);
+
+        if (plaintext.Length < MinimumLength)
+            throw new ArgumentException(
+                $"Password must be at least {MinimumLength} characters.",
+                nameof(plaintext));
+
+        // Identity's PasswordHasher<T> does not use the user instance for hashing.
+        // The parameter exists for extensibility but is unused by the built-in PBKDF2 impl.
+        var hash = hasher.HashPassword(null!, plaintext);
+        return new Password(hash);
+    }
+
+    /// <summary>
+    /// Rehydrates a <see cref="Password"/> from an already-computed hash string.
+    /// Used by EF Core and when reading from persistence.
+    /// </summary>
+    public static Password CreateFromHash(string hashValue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hashValue, nameof(hashValue));
+        return new Password(hashValue);
+    }
+
+    public bool Verify(string plaintext, IPasswordHasher<User> hasher)
+    {
+        ArgumentNullException.ThrowIfNull(hasher);
+
+        if (string.IsNullOrEmpty(plaintext))
+            return false;
+
+        var result = hasher.VerifyHashedPassword(null!, HashValue, plaintext);
+        return result == PasswordVerificationResult.Success
+            || result == PasswordVerificationResult.SuccessRehashNeeded;
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return HashValue;
+    }
+}

--- a/src/MentalMetal.Domain/Users/User.cs
+++ b/src/MentalMetal.Domain/Users/User.cs
@@ -1,13 +1,15 @@
 using MentalMetal.Domain.Common;
+using Microsoft.AspNetCore.Identity;
 
 namespace MentalMetal.Domain.Users;
 
 public sealed class User : AggregateRoot
 {
-    public string ExternalAuthId { get; private set; } = null!;
+    public string? ExternalAuthId { get; private set; }
     public Email Email { get; private set; } = null!;
     public string Name { get; private set; } = null!;
     public string? AvatarUrl { get; private set; }
+    public Password? PasswordHash { get; private set; }
     public UserPreferences Preferences { get; private set; } = null!;
     public AiProviderConfig? AiProviderConfig { get; private set; }
     public string Timezone { get; private set; } = null!;
@@ -39,6 +41,48 @@ public sealed class User : AggregateRoot
         user.RaiseDomainEvent(new UserRegistered(user.Id, user.Email.Value));
 
         return user;
+    }
+
+    public static User RegisterWithPassword(
+        string email,
+        string name,
+        Password password,
+        string? timezone = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
+        ArgumentNullException.ThrowIfNull(password);
+
+        var now = DateTimeOffset.UtcNow;
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            ExternalAuthId = null,
+            Email = Email.Create(email),
+            Name = name.Trim(),
+            AvatarUrl = null,
+            PasswordHash = password,
+            Preferences = UserPreferences.Default(),
+            Timezone = string.IsNullOrWhiteSpace(timezone) ? "UTC" : timezone,
+            CreatedAt = now,
+            LastLoginAt = now
+        };
+
+        user.RaiseDomainEvent(new UserRegistered(user.Id, user.Email.Value));
+
+        return user;
+    }
+
+    public void SetPassword(string plaintext, IPasswordHasher<User> hasher)
+    {
+        ArgumentNullException.ThrowIfNull(hasher);
+        PasswordHash = Password.Create(plaintext, hasher);
+    }
+
+    public bool VerifyPassword(string plaintext, IPasswordHasher<User> hasher)
+    {
+        ArgumentNullException.ThrowIfNull(hasher);
+        return PasswordHash is not null && PasswordHash.Verify(plaintext, hasher);
     }
 
     public void UpdateProfile(string name, string? avatarUrl, string timezone)

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -22,6 +22,7 @@ using MentalMetal.Infrastructure.Ai;
 using MentalMetal.Infrastructure.Auth;
 using MentalMetal.Infrastructure.Persistence;
 using MentalMetal.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -63,6 +64,7 @@ public static class DependencyInjection
         services.AddScoped<IDelegationRepository, DelegationRepository>();
         services.AddScoped<IChatThreadRepository, ChatThreadRepository>();
         services.AddScoped<ITokenService, TokenService>();
+        services.AddSingleton<IPasswordHasher<User>, PasswordHasher<User>>();
 
         // AI provider services
         services.AddHttpClient("GoogleAi");
@@ -78,6 +80,9 @@ public static class DependencyInjection
 
         // Application handlers
         services.AddScoped<RegisterOrLoginUserHandler>();
+        services.AddScoped<RegisterWithPasswordHandler>();
+        services.AddScoped<LoginWithPasswordHandler>();
+        services.AddScoped<SetPasswordHandler>();
         services.AddScoped<GetCurrentUserHandler>();
         services.AddScoped<UpdateUserProfileHandler>();
         services.AddScoped<UpdateUserPreferencesHandler>();

--- a/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413235235_AddPasswordHashToUsers")]
+    partial class AddPasswordHashToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPasswordHashToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalAuthId",
+                table: "Users",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PasswordHash",
+                table: "Users",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PasswordHash",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalAuthId",
+                table: "Users",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260413235235_AddPasswordHashToUsers.cs
@@ -31,21 +31,10 @@ namespace MentalMetal.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Down() intentionally leaves ExternalAuthId nullable — rolling back a data-containing deployment with password-only users cannot safely re-impose NOT NULL.
             migrationBuilder.DropColumn(
                 name: "PasswordHash",
                 table: "Users");
-
-            migrationBuilder.AlterColumn<string>(
-                name: "ExternalAuthId",
-                table: "Users",
-                type: "character varying(256)",
-                maxLength: 256,
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "character varying(256)",
-                oldMaxLength: 256,
-                oldNullable: true);
         }
     }
 }

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -13,7 +13,6 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
         builder.HasKey(u => u.Id);
 
         builder.Property(u => u.ExternalAuthId)
-            .IsRequired()
             .HasMaxLength(256);
 
         builder.HasIndex(u => u.ExternalAuthId)
@@ -36,6 +35,13 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.Property(u => u.AvatarUrl)
             .HasMaxLength(2048);
+
+        builder.OwnsOne(u => u.PasswordHash, pw =>
+        {
+            pw.Property(p => p.HashValue)
+                .HasColumnName("PasswordHash")
+                .HasMaxLength(1024);
+        });
 
         builder.OwnsOne(u => u.Preferences, prefs =>
         {

--- a/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
@@ -12,6 +12,9 @@ public sealed class UserRepository(MentalMetalDbContext dbContext) : IUserReposi
     public async Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken) =>
         await dbContext.Users.FirstOrDefaultAsync(u => u.ExternalAuthId == externalAuthId, cancellationToken);
 
+    public async Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken) =>
+        await dbContext.Users.FirstOrDefaultAsync(u => u.Email.Value == email.Value, cancellationToken);
+
     public async Task<bool> ExistsByEmailAsync(string email, CancellationToken cancellationToken) =>
         await dbContext.Users.AnyAsync(u => u.Email.Value == email.Trim().ToLower(), cancellationToken);
 

--- a/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
@@ -15,8 +15,8 @@ public sealed class UserRepository(MentalMetalDbContext dbContext) : IUserReposi
     public async Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken) =>
         await dbContext.Users.FirstOrDefaultAsync(u => u.Email.Value == email.Value, cancellationToken);
 
-    public async Task<bool> ExistsByEmailAsync(string email, CancellationToken cancellationToken) =>
-        await dbContext.Users.AnyAsync(u => u.Email.Value == email.Trim().ToLower(), cancellationToken);
+    public async Task<bool> ExistsByEmailAsync(Email email, CancellationToken cancellationToken) =>
+        await dbContext.Users.AnyAsync(u => u.Email.Value == email.Value, cancellationToken);
 
     public async Task AddAsync(User user, CancellationToken cancellationToken) =>
         await dbContext.Users.AddAsync(user, cancellationToken);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.spec.ts
@@ -1,0 +1,156 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { LoginPage } from './login.page';
+
+describe('LoginPage', () => {
+  let httpMock: HttpTestingController;
+  let router: Router;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+      imports: [LoginPage],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: '**', children: [] }]),
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    // Drain any eager /api/users/me call from AuthService constructor if a prior test
+    // stored a token. Tests themselves clear localStorage in beforeEach.
+    httpMock.match('/api/users/me').forEach((r) => r.flush(null, { status: 401, statusText: 'Unauthorized' }));
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('renders the login form by default', () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Sign in');
+    // No Name field in login mode
+    expect(host.querySelector('input#name')).toBeNull();
+  });
+
+  it('toggles to register mode and shows the Name field', () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const toggleButton = Array.from(host.querySelectorAll('button')).find((b) =>
+      (b.textContent ?? '').includes('Need an account'),
+    ) as HTMLButtonElement;
+    expect(toggleButton).toBeTruthy();
+    toggleButton.click();
+    fixture.detectChanges();
+
+    expect(host.querySelector('input#name')).not.toBeNull();
+    expect(host.textContent).toContain('Create account');
+  });
+
+  it('posts login credentials and stores the access token', async () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      email: string;
+      password: string;
+      submit: () => Promise<void>;
+    };
+    component.email = 'user@example.com';
+    component.password = 'secret-pw';
+
+    const pending = component.submit();
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email: 'user@example.com', password: 'secret-pw' });
+    req.flush({
+      accessToken: 'at',
+      user: {
+        id: '1',
+        email: 'user@example.com',
+        name: 'User',
+        avatarUrl: null,
+        timezone: 'UTC',
+        preferences: {
+          theme: 'Light',
+          notificationsEnabled: true,
+          briefingTime: '08:00',
+          livingBriefAutoApply: false,
+        },
+        hasAiProvider: false,
+        hasPassword: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        lastLoginAt: '2026-01-01T00:00:00Z',
+      },
+    });
+
+    await pending;
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('shows an invalid-credentials message on 401', async () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      email: string;
+      password: string;
+      submit: () => Promise<void>;
+    };
+    component.email = 'user@example.com';
+    component.password = 'wrong-pw';
+
+    const pending = component.submit();
+
+    const req = httpMock.expectOne('/api/auth/login');
+    req.flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    await pending;
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Invalid email or password');
+  });
+
+  it('shows an email-in-use message on 409 during register', async () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      email: string;
+      password: string;
+      name: string;
+      mode: () => string;
+      toggleMode: () => void;
+      submit: () => Promise<void>;
+    };
+    component.toggleMode();
+    component.email = 'taken@example.com';
+    component.password = 'secret-pw';
+    component.name = 'New User';
+
+    const pending = component.submit();
+
+    const req = httpMock.expectOne('/api/auth/register');
+    req.flush({}, { status: 409, statusText: 'Conflict' });
+
+    await pending;
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('already in use');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.spec.ts
@@ -66,12 +66,12 @@ describe('LoginPage', () => {
     fixture.detectChanges();
 
     const component = fixture.componentInstance as unknown as {
-      email: string;
-      password: string;
+      email: { set: (v: string) => void };
+      password: { set: (v: string) => void };
       submit: () => Promise<void>;
     };
-    component.email = 'user@example.com';
-    component.password = 'secret-pw';
+    component.email.set('user@example.com');
+    component.password.set('secret-pw');
 
     const pending = component.submit();
 
@@ -108,12 +108,12 @@ describe('LoginPage', () => {
     fixture.detectChanges();
 
     const component = fixture.componentInstance as unknown as {
-      email: string;
-      password: string;
+      email: { set: (v: string) => void };
+      password: { set: (v: string) => void };
       submit: () => Promise<void>;
     };
-    component.email = 'user@example.com';
-    component.password = 'wrong-pw';
+    component.email.set('user@example.com');
+    component.password.set('wrong-pw');
 
     const pending = component.submit();
 
@@ -131,17 +131,17 @@ describe('LoginPage', () => {
     fixture.detectChanges();
 
     const component = fixture.componentInstance as unknown as {
-      email: string;
-      password: string;
-      name: string;
+      email: { set: (v: string) => void };
+      password: { set: (v: string) => void };
+      name: { set: (v: string) => void };
       mode: () => string;
       toggleMode: () => void;
       submit: () => Promise<void>;
     };
     component.toggleMode();
-    component.email = 'taken@example.com';
-    component.password = 'secret-pw';
-    component.name = 'New User';
+    component.email.set('taken@example.com');
+    component.password.set('secret-pw');
+    component.name.set('New User');
 
     const pending = component.submit();
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.ts
@@ -1,29 +1,190 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { DividerModule } from 'primeng/divider';
+import { MessageModule } from 'primeng/message';
 import { AuthService } from '../../shared/services/auth.service';
+import { Password } from '../../shared/models/password.constants';
+
+type Mode = 'login' | 'register';
 
 @Component({
   selector: 'app-login',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonModule],
+  imports: [
+    FormsModule,
+    ButtonModule,
+    InputTextModule,
+    PasswordModule,
+    DividerModule,
+    MessageModule,
+  ],
   template: `
-    <div class="flex items-center justify-center h-screen">
-      <div class="flex flex-col items-center gap-6 p-8">
+    <div class="flex items-center justify-center min-h-screen p-6">
+      <div class="flex flex-col items-center gap-6 w-full max-w-sm">
         <h1 class="text-4xl font-bold text-primary">Mental Metal</h1>
-        <p class="text-muted-color text-lg">
+        <p class="text-muted-color text-center">
           AI-powered command centre for engineering managers
         </p>
+
         <p-button
           label="Sign in with Google"
           icon="pi pi-google"
           (onClick)="authService.login()"
           size="large"
+          styleClass="w-full"
         />
+
+        <p-divider align="center">
+          <span class="text-muted-color text-sm">or</span>
+        </p-divider>
+
+        <form
+          class="flex flex-col gap-3 w-full"
+          (ngSubmit)="submit()"
+          #form="ngForm"
+        >
+          <h2 class="text-xl font-semibold">
+            {{ mode() === 'login' ? 'Sign in' : 'Create account' }}
+          </h2>
+
+          @if (mode() === 'register') {
+            <div class="flex flex-col gap-1">
+              <label for="name" class="text-sm font-medium text-muted-color">Name</label>
+              <input
+                pInputText
+                id="name"
+                name="name"
+                type="text"
+                [(ngModel)]="name"
+                required
+                autocomplete="name"
+              />
+            </div>
+          }
+
+          <div class="flex flex-col gap-1">
+            <label for="email" class="text-sm font-medium text-muted-color">Email</label>
+            <input
+              pInputText
+              id="email"
+              name="email"
+              type="email"
+              [(ngModel)]="email"
+              required
+              autocomplete="email"
+            />
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="password" class="text-sm font-medium text-muted-color">Password</label>
+            <p-password
+              id="password"
+              name="password"
+              [(ngModel)]="password"
+              [feedback]="mode() === 'register'"
+              [toggleMask]="true"
+              styleClass="w-full"
+              inputStyleClass="w-full"
+              autocomplete="{{ mode() === 'register' ? 'new-password' : 'current-password' }}"
+              required
+            />
+            @if (mode() === 'register') {
+              <small class="text-muted-color">
+                At least {{ minPasswordLength }} characters.
+              </small>
+            }
+          </div>
+
+          @if (errorMessage()) {
+            <p-message severity="error" [text]="errorMessage()!" />
+          }
+
+          <p-button
+            type="submit"
+            [label]="mode() === 'login' ? 'Sign in' : 'Create account'"
+            [loading]="submitting()"
+            [disabled]="!canSubmit()"
+            styleClass="w-full"
+          />
+
+          <button
+            type="button"
+            class="text-sm text-primary hover:underline self-center"
+            (click)="toggleMode()"
+          >
+            @if (mode() === 'login') {
+              <span>Need an account? Create one</span>
+            } @else {
+              <span>Already have an account? Sign in</span>
+            }
+          </button>
+        </form>
       </div>
     </div>
   `,
 })
 export class LoginPage {
   protected readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  protected readonly mode = signal<Mode>('login');
+  protected readonly submitting = signal(false);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly minPasswordLength = Password.MinimumLength;
+
+  protected email = '';
+  protected password = '';
+  protected name = '';
+
+  toggleMode(): void {
+    this.mode.update((m) => (m === 'login' ? 'register' : 'login'));
+    this.errorMessage.set(null);
+  }
+
+  canSubmit(): boolean {
+    if (this.submitting()) return false;
+    if (!this.email.trim() || !this.password) return false;
+    if (this.mode() === 'register') {
+      if (!this.name.trim()) return false;
+      if (this.password.length < Password.MinimumLength) return false;
+    }
+    return true;
+  }
+
+  async submit(): Promise<void> {
+    if (!this.canSubmit()) return;
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      if (this.mode() === 'login') {
+        await this.authService.loginWithPassword(this.email.trim(), this.password);
+      } else {
+        await this.authService.registerWithPassword(
+          this.email.trim(),
+          this.password,
+          this.name.trim(),
+        );
+      }
+      await this.router.navigate(['/']);
+    } catch (err: unknown) {
+      this.errorMessage.set(this.resolveErrorMessage(err));
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  private resolveErrorMessage(err: unknown): string {
+    const status = (err as { status?: number })?.status;
+    if (status === 401) return 'Invalid email or password.';
+    if (status === 409) return 'That email is already in use.';
+    if (status === 400) return 'Please check your details and try again.';
+    return 'Something went wrong. Please try again.';
+  }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/login/login.page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -60,7 +60,8 @@ type Mode = 'login' | 'register';
                 id="name"
                 name="name"
                 type="text"
-                [(ngModel)]="name"
+                [ngModel]="name()"
+                (ngModelChange)="name.set($event)"
                 required
                 autocomplete="name"
               />
@@ -74,7 +75,8 @@ type Mode = 'login' | 'register';
               id="email"
               name="email"
               type="email"
-              [(ngModel)]="email"
+              [ngModel]="email()"
+              (ngModelChange)="email.set($event)"
               required
               autocomplete="email"
             />
@@ -85,7 +87,8 @@ type Mode = 'login' | 'register';
             <p-password
               id="password"
               name="password"
-              [(ngModel)]="password"
+              [ngModel]="password()"
+              (ngModelChange)="password.set($event)"
               [feedback]="mode() === 'register'"
               [toggleMask]="true"
               styleClass="w-full"
@@ -137,23 +140,23 @@ export class LoginPage {
   protected readonly errorMessage = signal<string | null>(null);
   protected readonly minPasswordLength = Password.MinimumLength;
 
-  protected email = '';
-  protected password = '';
-  protected name = '';
+  protected readonly email = signal<string>('');
+  protected readonly password = signal<string>('');
+  protected readonly name = signal<string>('');
+
+  protected readonly canSubmit = computed(() => {
+    if (this.submitting()) return false;
+    if (!this.email().trim() || !this.password()) return false;
+    if (this.mode() === 'register') {
+      if (!this.name().trim()) return false;
+      if (this.password().length < Password.MinimumLength) return false;
+    }
+    return true;
+  });
 
   toggleMode(): void {
     this.mode.update((m) => (m === 'login' ? 'register' : 'login'));
     this.errorMessage.set(null);
-  }
-
-  canSubmit(): boolean {
-    if (this.submitting()) return false;
-    if (!this.email.trim() || !this.password) return false;
-    if (this.mode() === 'register') {
-      if (!this.name.trim()) return false;
-      if (this.password.length < Password.MinimumLength) return false;
-    }
-    return true;
   }
 
   async submit(): Promise<void> {
@@ -164,12 +167,12 @@ export class LoginPage {
 
     try {
       if (this.mode() === 'login') {
-        await this.authService.loginWithPassword(this.email.trim(), this.password);
+        await this.authService.loginWithPassword(this.email().trim(), this.password());
       } else {
         await this.authService.registerWithPassword(
-          this.email.trim(),
-          this.password,
-          this.name.trim(),
+          this.email().trim(),
+          this.password(),
+          this.name().trim(),
         );
       }
       await this.router.navigate(['/']);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.spec.ts
@@ -78,10 +78,10 @@ describe('PasswordSettingsComponent', () => {
     fixture.detectChanges();
 
     const component = fixture.componentInstance as unknown as {
-      newPassword: string;
+      newPassword: { set: (v: string) => void };
       submit: () => Promise<void>;
     };
-    component.newPassword = 'brand-new-pw';
+    component.newPassword.set('brand-new-pw');
 
     const pending = component.submit();
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.spec.ts
@@ -1,0 +1,96 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../shared/services/auth.service';
+import { UserProfile } from '../../shared/models/user.model';
+import { PasswordSettingsComponent } from './password-settings.component';
+
+function makeUser(hasPassword: boolean): UserProfile {
+  return {
+    id: '1',
+    email: 'user@example.com',
+    name: 'User',
+    avatarUrl: null,
+    timezone: 'UTC',
+    preferences: {
+      theme: 'Light',
+      notificationsEnabled: true,
+      briefingTime: '08:00',
+      livingBriefAutoApply: false,
+    },
+    hasAiProvider: false,
+    hasPassword,
+    createdAt: '2026-01-01T00:00:00Z',
+    lastLoginAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('PasswordSettingsComponent', () => {
+  let httpMock: HttpTestingController;
+  let authService: AuthService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PasswordSettingsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('shows "Set a password" when the user has no password', () => {
+    authService.currentUser.set(makeUser(false));
+
+    const fixture = TestBed.createComponent(PasswordSettingsComponent);
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Set a password');
+  });
+
+  it('shows "Change password" when the user has a password', () => {
+    authService.currentUser.set(makeUser(true));
+
+    const fixture = TestBed.createComponent(PasswordSettingsComponent);
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Change password');
+  });
+
+  it('submits the new password and flips hasPassword to true on success', async () => {
+    authService.currentUser.set(makeUser(false));
+
+    const fixture = TestBed.createComponent(PasswordSettingsComponent);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      newPassword: string;
+      submit: () => Promise<void>;
+    };
+    component.newPassword = 'brand-new-pw';
+
+    const pending = component.submit();
+
+    const req = httpMock.expectOne('/api/auth/password');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ newPassword: 'brand-new-pw' });
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    await pending;
+    expect(authService.currentUser()?.hasPassword).toBe(true);
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.ts
@@ -1,0 +1,109 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { PasswordModule } from 'primeng/password';
+import { MessageModule } from 'primeng/message';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../shared/services/auth.service';
+import { Password } from '../../shared/models/password.constants';
+
+@Component({
+  selector: 'app-password-settings',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, ButtonModule, PasswordModule, MessageModule],
+  template: `
+    <section class="flex flex-col gap-4">
+      <h2 class="text-xl font-semibold">{{ heading() }}</h2>
+
+      @if (!hasPassword()) {
+        <p class="text-muted-color text-sm">
+          Add a password so you can sign in without Google.
+        </p>
+      }
+
+      <div class="flex flex-col gap-2">
+        <label for="newPassword" class="text-sm font-medium text-muted-color">
+          New password
+        </label>
+        <p-password
+          id="newPassword"
+          name="newPassword"
+          [(ngModel)]="newPassword"
+          [feedback]="true"
+          [toggleMask]="true"
+          styleClass="w-full"
+          inputStyleClass="w-full"
+          autocomplete="new-password"
+        />
+        <small class="text-muted-color">
+          At least {{ minPasswordLength }} characters.
+        </small>
+      </div>
+
+      @if (validationMessage()) {
+        <p-message severity="error" [text]="validationMessage()!" />
+      }
+
+      <div>
+        <p-button
+          [label]="heading()"
+          (onClick)="submit()"
+          [loading]="submitting()"
+          [disabled]="!canSubmit()"
+        />
+      </div>
+    </section>
+  `,
+})
+export class PasswordSettingsComponent {
+  private readonly authService = inject(AuthService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly minPasswordLength = Password.MinimumLength;
+  protected readonly submitting = signal(false);
+  protected readonly validationMessage = signal<string | null>(null);
+  protected readonly hasPassword = computed(
+    () => this.authService.currentUser()?.hasPassword ?? false,
+  );
+  protected readonly heading = computed(() =>
+    this.hasPassword() ? 'Change password' : 'Set a password',
+  );
+
+  protected newPassword = '';
+
+  canSubmit(): boolean {
+    return (
+      !this.submitting() &&
+      this.newPassword.length >= Password.MinimumLength
+    );
+  }
+
+  async submit(): Promise<void> {
+    if (this.newPassword.length < Password.MinimumLength) {
+      this.validationMessage.set(
+        `Password must be at least ${Password.MinimumLength} characters.`,
+      );
+      return;
+    }
+
+    this.submitting.set(true);
+    this.validationMessage.set(null);
+
+    try {
+      await this.authService.setPassword(this.newPassword);
+      this.newPassword = '';
+      this.messageService.add({
+        severity: 'success',
+        summary: this.hasPassword() ? 'Password updated' : 'Password set',
+      });
+    } catch {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Failed to save password',
+      });
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/password-settings.component.ts
@@ -29,7 +29,8 @@ import { Password } from '../../shared/models/password.constants';
         <p-password
           id="newPassword"
           name="newPassword"
-          [(ngModel)]="newPassword"
+          [ngModel]="newPassword()"
+          (ngModelChange)="newPassword.set($event)"
           [feedback]="true"
           [toggleMask]="true"
           styleClass="w-full"
@@ -70,17 +71,16 @@ export class PasswordSettingsComponent {
     this.hasPassword() ? 'Change password' : 'Set a password',
   );
 
-  protected newPassword = '';
+  protected readonly newPassword = signal<string>('');
 
-  canSubmit(): boolean {
-    return (
+  protected readonly canSubmit = computed(
+    () =>
       !this.submitting() &&
-      this.newPassword.length >= Password.MinimumLength
-    );
-  }
+      this.newPassword().length >= Password.MinimumLength,
+  );
 
   async submit(): Promise<void> {
-    if (this.newPassword.length < Password.MinimumLength) {
+    if (this.newPassword().length < Password.MinimumLength) {
       this.validationMessage.set(
         `Password must be at least ${Password.MinimumLength} characters.`,
       );
@@ -90,12 +90,16 @@ export class PasswordSettingsComponent {
     this.submitting.set(true);
     this.validationMessage.set(null);
 
+    // Capture BEFORE the async call — hasPassword() will flip to true after the
+    // server succeeds, so reading it later would always show 'Password updated'.
+    const hadPassword = this.hasPassword();
+
     try {
-      await this.authService.setPassword(this.newPassword);
-      this.newPassword = '';
+      await this.authService.setPassword(this.newPassword());
+      this.newPassword.set('');
       this.messageService.add({
         severity: 'success',
-        summary: this.hasPassword() ? 'Password updated' : 'Password set',
+        summary: hadPassword ? 'Password updated' : 'Password set',
       });
     } catch {
       this.messageService.add({

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
@@ -10,6 +10,7 @@ import { AuthService } from '../../shared/services/auth.service';
 import { UserService } from '../../shared/services/user.service';
 import { ThemeService } from '../../shared/services/theme.service';
 import { AiProviderSettingsComponent } from './ai-provider-settings.component';
+import { PasswordSettingsComponent } from './password-settings.component';
 
 @Component({
   selector: 'app-settings',
@@ -23,6 +24,7 @@ import { AiProviderSettingsComponent } from './ai-provider-settings.component';
     ToggleSwitchModule,
     ToastModule,
     AiProviderSettingsComponent,
+    PasswordSettingsComponent,
   ],
   providers: [MessageService],
   template: `
@@ -98,6 +100,9 @@ import { AiProviderSettingsComponent } from './ai-provider-settings.component';
           [loading]="savingPreferences()"
         />
       </section>
+
+      <!-- Password Section -->
+      <app-password-settings />
 
       <!-- AI Provider Section -->
       <app-ai-provider-settings />

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/password.constants.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/password.constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Password policy constants. Mirrors the backend's `Password.MinimumLength`.
+ */
+export const Password = {
+  MinimumLength: 8,
+} as const;

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/user.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/user.model.ts
@@ -5,6 +5,8 @@ export interface UserProfile {
   avatarUrl: string | null;
   timezone: string;
   preferences: UserPreferences;
+  hasAiProvider: boolean;
+  hasPassword: boolean;
   createdAt: string;
   lastLoginAt: string;
 }
@@ -33,4 +35,24 @@ export interface UpdatePreferencesRequest {
 
 export interface AuthTokenResponse {
   accessToken: string;
+}
+
+export interface PasswordAuthResponse {
+  accessToken: string;
+  user: UserProfile;
+}
+
+export interface LoginWithPasswordRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterWithPasswordRequest {
+  email: string;
+  password: string;
+  name: string;
+}
+
+export interface SetPasswordRequest {
+  newPassword: string;
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
@@ -2,7 +2,14 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
-import { AuthTokenResponse, UserProfile } from '../models/user.model';
+import {
+  AuthTokenResponse,
+  LoginWithPasswordRequest,
+  PasswordAuthResponse,
+  RegisterWithPasswordRequest,
+  SetPasswordRequest,
+  UserProfile,
+} from '../models/user.model';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -22,6 +29,41 @@ export class AuthService {
 
   login(): void {
     window.location.href = '/api/auth/login?returnUrl=/';
+  }
+
+  async loginWithPassword(email: string, password: string): Promise<void> {
+    const body: LoginWithPasswordRequest = { email, password };
+    const response = await firstValueFrom(
+      this.http.post<PasswordAuthResponse>('/api/auth/login', body),
+    );
+    this.handlePasswordAuthSuccess(response);
+  }
+
+  async registerWithPassword(
+    email: string,
+    password: string,
+    name: string,
+  ): Promise<void> {
+    const body: RegisterWithPasswordRequest = { email, password, name };
+    const response = await firstValueFrom(
+      this.http.post<PasswordAuthResponse>('/api/auth/register', body),
+    );
+    this.handlePasswordAuthSuccess(response);
+  }
+
+  async setPassword(newPassword: string): Promise<void> {
+    const body: SetPasswordRequest = { newPassword };
+    await firstValueFrom(this.http.post('/api/auth/password', body));
+    const current = this.currentUser();
+    if (current) {
+      this.currentUser.set({ ...current, hasPassword: true });
+    }
+  }
+
+  private handlePasswordAuthSuccess(response: PasswordAuthResponse): void {
+    this.accessToken.set(response.accessToken);
+    this.storeToken(response.accessToken);
+    this.currentUser.set(response.user);
   }
 
   async logout(): Promise<void> {

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -250,6 +250,66 @@ app.MapPost("/api/auth/refresh", async (
     return Results.Ok(new { result.AccessToken });
 });
 
+app.MapPost("/api/auth/register", async (
+    HttpContext httpContext,
+    RegisterWithPasswordRequest body,
+    RegisterWithPasswordHandler handler) =>
+{
+    try
+    {
+        var result = await handler.HandleAsync(
+            new RegisterWithPasswordCommand(body.Email, body.Password, body.Name),
+            httpContext.RequestAborted);
+
+        httpContext.Response.Cookies.Append("refresh_token", result.RefreshToken, RefreshTokenCookieOptions());
+        return Results.Ok(new { result.AccessToken, User = result.User });
+    }
+    catch (EmailAlreadyInUseException)
+    {
+        return Results.Conflict(new { error = "Email already in use." });
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapPost("/api/auth/login", async (
+    HttpContext httpContext,
+    LoginWithPasswordRequest body,
+    LoginWithPasswordHandler handler) =>
+{
+    try
+    {
+        var result = await handler.HandleAsync(
+            new LoginWithPasswordCommand(body.Email, body.Password),
+            httpContext.RequestAborted);
+
+        httpContext.Response.Cookies.Append("refresh_token", result.RefreshToken, RefreshTokenCookieOptions());
+        return Results.Ok(new { result.AccessToken, User = result.User });
+    }
+    catch (InvalidCredentialsException)
+    {
+        return Results.Unauthorized();
+    }
+});
+
+app.MapPost("/api/auth/password", async (
+    SetPasswordRequest body,
+    SetPasswordHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        await handler.HandleAsync(new SetPasswordCommand(body.NewPassword), cancellationToken);
+        return Results.NoContent();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
 app.MapPost("/api/auth/logout", async (
     HttpContext httpContext,
     LogoutUserHandler handler) =>
@@ -1572,3 +1632,6 @@ app.MapFallbackToFile("index.html");
 app.Run();
 
 internal sealed record TestLoginRequest(string Email, string Name);
+
+// Expose the top-level-statements Program class to WebApplicationFactory<Program> in integration tests.
+public partial class Program { }

--- a/src/MentalMetal.slnx
+++ b/src/MentalMetal.slnx
@@ -5,4 +5,5 @@
   <Project Path="MentalMetal.Web/MentalMetal.Web.csproj" />
   <Project Path="../tests/MentalMetal.Domain.Tests/MentalMetal.Domain.Tests.csproj" />
   <Project Path="../tests/MentalMetal.Application.Tests/MentalMetal.Application.Tests.csproj" />
+  <Project Path="../tests/MentalMetal.Web.IntegrationTests/MentalMetal.Web.IntegrationTests.csproj" />
 </Solution>

--- a/tests/MentalMetal.Application.Tests/Users/LoginWithPasswordTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/LoginWithPasswordTests.cs
@@ -1,0 +1,97 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Auth;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class LoginWithPasswordTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ITokenService _tokenService = Substitute.For<ITokenService>();
+    private readonly IPasswordHasher<User> _passwordHasher = new PasswordHasher<User>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly LoginWithPasswordHandler _handler;
+
+    public LoginWithPasswordTests()
+    {
+        _handler = new LoginWithPasswordHandler(
+            _userRepository, _tokenService, _passwordHasher, _unitOfWork);
+    }
+
+    private User CreatePasswordUser(string email, string password)
+    {
+        var pw = Password.Create(password, _passwordHasher);
+        return User.RegisterWithPassword(email, "Test User", pw, null);
+    }
+
+    [Fact]
+    public async Task HappyPath_ReturnsTokens()
+    {
+        var user = CreatePasswordUser("user@example.com", "secret-pw");
+        _userRepository.GetByEmailAsync(Arg.Is<Email>(e => e.Value == "user@example.com"), Arg.Any<CancellationToken>())
+            .Returns(user);
+        _tokenService.GenerateTokens(user)
+            .Returns(new TokenResult("access-token", "refresh-token"));
+
+        var result = await _handler.HandleAsync(
+            new LoginWithPasswordCommand("user@example.com", "secret-pw"), CancellationToken.None);
+
+        Assert.Equal("access-token", result.AccessToken);
+        Assert.Equal("refresh-token", result.RefreshToken);
+        Assert.True(result.User.HasPassword);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnknownEmail_ThrowsInvalidCredentials()
+    {
+        _userRepository.GetByEmailAsync(Arg.Any<Email>(), Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        await Assert.ThrowsAsync<InvalidCredentialsException>(
+            () => _handler.HandleAsync(
+                new LoginWithPasswordCommand("nobody@example.com", "secret-pw"),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WrongPassword_ThrowsInvalidCredentials()
+    {
+        var user = CreatePasswordUser("user@example.com", "correct-pw");
+        _userRepository.GetByEmailAsync(Arg.Any<Email>(), Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        await Assert.ThrowsAsync<InvalidCredentialsException>(
+            () => _handler.HandleAsync(
+                new LoginWithPasswordCommand("user@example.com", "wrong-pw"),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GoogleOnlyUser_ThrowsInvalidCredentials()
+    {
+        var user = User.Register("auth-123", "user@example.com", "Name", null);
+        _userRepository.GetByEmailAsync(Arg.Any<Email>(), Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        await Assert.ThrowsAsync<InvalidCredentialsException>(
+            () => _handler.HandleAsync(
+                new LoginWithPasswordCommand("user@example.com", "anything-pw"),
+                CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("", "pw-12345")]
+    [InlineData("user@example.com", "")]
+    [InlineData("not-an-email", "pw-12345")]
+    public async Task BlankOrInvalidInputs_ThrowInvalidCredentials(string email, string password)
+    {
+        await Assert.ThrowsAsync<InvalidCredentialsException>(
+            () => _handler.HandleAsync(
+                new LoginWithPasswordCommand(email, password),
+                CancellationToken.None));
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/RegisterOrLoginUserTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/RegisterOrLoginUserTests.cs
@@ -25,7 +25,7 @@ public class RegisterOrLoginUserTests
 
         _userRepository.GetByExternalAuthIdAsync("auth-123", Arg.Any<CancellationToken>())
             .Returns((User?)null);
-        _userRepository.ExistsByEmailAsync("new@example.com", Arg.Any<CancellationToken>())
+        _userRepository.ExistsByEmailAsync(Arg.Is<Email>(e => e.Value == "new@example.com"), Arg.Any<CancellationToken>())
             .Returns(false);
         _tokenService.GenerateTokens(Arg.Any<User>())
             .Returns(new TokenResult("access-token", "refresh-token"));
@@ -66,7 +66,7 @@ public class RegisterOrLoginUserTests
 
         _userRepository.GetByExternalAuthIdAsync("auth-new", Arg.Any<CancellationToken>())
             .Returns((User?)null);
-        _userRepository.ExistsByEmailAsync("taken@example.com", Arg.Any<CancellationToken>())
+        _userRepository.ExistsByEmailAsync(Arg.Is<Email>(e => e.Value == "taken@example.com"), Arg.Any<CancellationToken>())
             .Returns(true);
 
         await Assert.ThrowsAsync<InvalidOperationException>(

--- a/tests/MentalMetal.Application.Tests/Users/RegisterWithPasswordTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/RegisterWithPasswordTests.cs
@@ -26,7 +26,7 @@ public class RegisterWithPasswordTests
     {
         var command = new RegisterWithPasswordCommand("new@example.com", "secret-pw", "New User");
 
-        _userRepository.ExistsByEmailAsync("new@example.com", Arg.Any<CancellationToken>())
+        _userRepository.ExistsByEmailAsync(Arg.Is<Email>(e => e.Value == "new@example.com"), Arg.Any<CancellationToken>())
             .Returns(false);
         _tokenService.GenerateTokens(Arg.Any<User>())
             .Returns(new TokenResult("access-token", "refresh-token"));
@@ -47,7 +47,7 @@ public class RegisterWithPasswordTests
     {
         var command = new RegisterWithPasswordCommand("taken@example.com", "secret-pw", "N");
 
-        _userRepository.ExistsByEmailAsync("taken@example.com", Arg.Any<CancellationToken>())
+        _userRepository.ExistsByEmailAsync(Arg.Is<Email>(e => e.Value == "taken@example.com"), Arg.Any<CancellationToken>())
             .Returns(true);
 
         await Assert.ThrowsAsync<EmailAlreadyInUseException>(

--- a/tests/MentalMetal.Application.Tests/Users/RegisterWithPasswordTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/RegisterWithPasswordTests.cs
@@ -1,0 +1,91 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Auth;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class RegisterWithPasswordTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ITokenService _tokenService = Substitute.For<ITokenService>();
+    private readonly IPasswordHasher<User> _passwordHasher = new PasswordHasher<User>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly RegisterWithPasswordHandler _handler;
+
+    public RegisterWithPasswordTests()
+    {
+        _handler = new RegisterWithPasswordHandler(
+            _userRepository, _tokenService, _passwordHasher, _unitOfWork);
+    }
+
+    [Fact]
+    public async Task HappyPath_RegistersUserAndReturnsTokens()
+    {
+        var command = new RegisterWithPasswordCommand("new@example.com", "secret-pw", "New User");
+
+        _userRepository.ExistsByEmailAsync("new@example.com", Arg.Any<CancellationToken>())
+            .Returns(false);
+        _tokenService.GenerateTokens(Arg.Any<User>())
+            .Returns(new TokenResult("access-token", "refresh-token"));
+
+        var result = await _handler.HandleAsync(command, CancellationToken.None);
+
+        Assert.Equal("access-token", result.AccessToken);
+        Assert.Equal("refresh-token", result.RefreshToken);
+        Assert.True(result.User.HasPassword);
+        Assert.False(result.User.HasAiProvider);
+        Assert.Equal("new@example.com", result.User.Email);
+        await _userRepository.Received(1).AddAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DuplicateEmail_ThrowsEmailAlreadyInUseException()
+    {
+        var command = new RegisterWithPasswordCommand("taken@example.com", "secret-pw", "N");
+
+        _userRepository.ExistsByEmailAsync("taken@example.com", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await Assert.ThrowsAsync<EmailAlreadyInUseException>(
+            () => _handler.HandleAsync(command, CancellationToken.None));
+
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("short")]
+    [InlineData("1234567")]
+    public async Task ShortPassword_Throws(string password)
+    {
+        var command = new RegisterWithPasswordCommand("new@example.com", password, "N");
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => _handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InvalidEmail_Throws()
+    {
+        var command = new RegisterWithPasswordCommand("not-an-email", "secret-pw", "N");
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => _handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task EmptyName_Throws(string name)
+    {
+        var command = new RegisterWithPasswordCommand("new@example.com", "secret-pw", name);
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => _handler.HandleAsync(command, CancellationToken.None));
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/SetPasswordTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/SetPasswordTests.cs
@@ -1,0 +1,73 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Users;
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Users;
+
+public class SetPasswordTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly IPasswordHasher<User> _passwordHasher = new PasswordHasher<User>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly SetPasswordHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public SetPasswordTests()
+    {
+        _currentUserService.UserId.Returns(_userId);
+        _handler = new SetPasswordHandler(
+            _userRepository, _currentUserService, _passwordHasher, _unitOfWork);
+    }
+
+    [Fact]
+    public async Task GoogleOnlyUser_SetsFirstPassword()
+    {
+        var user = User.Register("auth-123", "user@example.com", "Name", null);
+        _userRepository.GetByIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        await _handler.HandleAsync(new SetPasswordCommand("brand-new-pw"), CancellationToken.None);
+
+        Assert.NotNull(user.PasswordHash);
+        Assert.True(user.VerifyPassword("brand-new-pw", _passwordHasher));
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UserWithExistingPassword_ReplacesIt()
+    {
+        var existing = Password.Create("old-password", _passwordHasher);
+        var user = User.RegisterWithPassword("user@example.com", "Name", existing, null);
+        _userRepository.GetByIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        await _handler.HandleAsync(new SetPasswordCommand("new-password"), CancellationToken.None);
+
+        Assert.True(user.VerifyPassword("new-password", _passwordHasher));
+        Assert.False(user.VerifyPassword("old-password", _passwordHasher));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("short")]
+    [InlineData("1234567")]
+    public async Task ShortPassword_Throws(string password)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => _handler.HandleAsync(new SetPasswordCommand(password), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UserNotFound_Throws()
+    {
+        _userRepository.GetByIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.HandleAsync(new SetPasswordCommand("secret-pw"), CancellationToken.None));
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Users/SetPasswordTests.cs
+++ b/tests/MentalMetal.Application.Tests/Users/SetPasswordTests.cs
@@ -51,14 +51,15 @@ public class SetPasswordTests
     }
 
     [Theory]
+    [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("short")]
     [InlineData("1234567")]
-    public async Task ShortPassword_Throws(string password)
+    public async Task ShortPassword_Throws(string? password)
     {
         await Assert.ThrowsAnyAsync<ArgumentException>(
-            () => _handler.HandleAsync(new SetPasswordCommand(password), CancellationToken.None));
+            () => _handler.HandleAsync(new SetPasswordCommand(password!), CancellationToken.None));
     }
 
     [Fact]

--- a/tests/MentalMetal.Domain.Tests/Users/PasswordTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/PasswordTests.cs
@@ -1,0 +1,72 @@
+using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
+
+namespace MentalMetal.Domain.Tests.Users;
+
+public class PasswordTests
+{
+    private static readonly IPasswordHasher<User> Hasher = new PasswordHasher<User>();
+
+    [Fact]
+    public void Create_ValidPlaintext_ProducesHash()
+    {
+        var password = Password.Create("correct-horse-battery", Hasher);
+
+        Assert.False(string.IsNullOrWhiteSpace(password.HashValue));
+        Assert.NotEqual("correct-horse-battery", password.HashValue);
+    }
+
+    [Fact]
+    public void Create_And_Verify_RoundTrip()
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        Assert.True(password.Verify("secret-pw", Hasher));
+        Assert.False(password.Verify("wrong-pw", Hasher));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("short")]
+    [InlineData("1234567")]
+    public void Create_ShortOrEmpty_Throws(string plaintext)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => Password.Create(plaintext, Hasher));
+    }
+
+    [Fact]
+    public void Create_NullHasher_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Password.Create("valid-pw-12", null!));
+    }
+
+    [Fact]
+    public void CreateFromHash_PreservesHash()
+    {
+        var original = Password.Create("another-pw", Hasher);
+        var rehydrated = Password.CreateFromHash(original.HashValue);
+
+        Assert.Equal(original.HashValue, rehydrated.HashValue);
+        Assert.True(rehydrated.Verify("another-pw", Hasher));
+    }
+
+    [Fact]
+    public void Verify_EmptyPlaintext_ReturnsFalse()
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        Assert.False(password.Verify("", Hasher));
+        Assert.False(password.Verify(null!, Hasher));
+    }
+
+    [Fact]
+    public void Equality_SameHash_AreEqual()
+    {
+        var hash = Password.Create("pw-12345", Hasher).HashValue;
+        var a = Password.CreateFromHash(hash);
+        var b = Password.CreateFromHash(hash);
+
+        Assert.Equal(a, b);
+    }
+}

--- a/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
@@ -1,9 +1,12 @@
 using MentalMetal.Domain.Users;
+using Microsoft.AspNetCore.Identity;
 
 namespace MentalMetal.Domain.Tests.Users;
 
 public class UserTests
 {
+    private static readonly IPasswordHasher<User> Hasher = new PasswordHasher<User>();
+
     [Fact]
     public void Register_ValidInput_CreatesUserWithCorrectState()
     {
@@ -213,6 +216,107 @@ public class UserTests
 
         Assert.Null(user.AiProviderConfig);
         Assert.Empty(user.DomainEvents);
+    }
+
+    [Fact]
+    public void RegisterWithPassword_SetsStateCorrectly()
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        var user = User.RegisterWithPassword("new@example.com", "New User", password, null);
+
+        Assert.NotEqual(Guid.Empty, user.Id);
+        Assert.Null(user.ExternalAuthId);
+        Assert.Equal("new@example.com", user.Email.Value);
+        Assert.Equal("New User", user.Name);
+        Assert.Null(user.AvatarUrl);
+        Assert.NotNull(user.PasswordHash);
+        Assert.Equal(password, user.PasswordHash);
+        Assert.Equal("UTC", user.Timezone);
+        Assert.NotNull(user.Preferences);
+    }
+
+    [Fact]
+    public void RegisterWithPassword_UsesProvidedTimezone()
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        var user = User.RegisterWithPassword("x@y.com", "N", password, "Australia/Sydney");
+
+        Assert.Equal("Australia/Sydney", user.Timezone);
+    }
+
+    [Fact]
+    public void RegisterWithPassword_RaisesUserRegisteredEvent()
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        var user = User.RegisterWithPassword("n@example.com", "N", password, null);
+
+        var ev = Assert.Single(user.DomainEvents);
+        var registered = Assert.IsType<UserRegistered>(ev);
+        Assert.Equal(user.Id, registered.UserId);
+        Assert.Equal("n@example.com", registered.Email);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void RegisterWithPassword_EmptyName_Throws(string? name)
+    {
+        var password = Password.Create("secret-pw", Hasher);
+
+        Assert.ThrowsAny<ArgumentException>(() =>
+            User.RegisterWithPassword("a@b.com", name!, password, null));
+    }
+
+    [Fact]
+    public void SetPassword_OnGoogleUser_SetsHash()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        user.SetPassword("new-password", Hasher);
+
+        Assert.NotNull(user.PasswordHash);
+        Assert.True(user.VerifyPassword("new-password", Hasher));
+    }
+
+    [Fact]
+    public void SetPassword_ReplacesExistingHash()
+    {
+        var password = Password.Create("first-pw", Hasher);
+        var user = User.RegisterWithPassword("a@b.com", "N", password, null);
+
+        user.SetPassword("second-pw", Hasher);
+
+        Assert.True(user.VerifyPassword("second-pw", Hasher));
+        Assert.False(user.VerifyPassword("first-pw", Hasher));
+    }
+
+    [Fact]
+    public void SetPassword_ShortPassword_Throws()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        Assert.ThrowsAny<ArgumentException>(() => user.SetPassword("short", Hasher));
+    }
+
+    [Fact]
+    public void VerifyPassword_WhenHashIsNull_ReturnsFalse()
+    {
+        var user = User.Register("auth-123", "test@example.com", "Name", null);
+
+        Assert.False(user.VerifyPassword("anything", Hasher));
+    }
+
+    [Fact]
+    public void VerifyPassword_WrongPassword_ReturnsFalse()
+    {
+        var password = Password.Create("correct-pw", Hasher);
+        var user = User.RegisterWithPassword("a@b.com", "N", password, null);
+
+        Assert.False(user.VerifyPassword("wrong-pw", Hasher));
     }
 
     [Fact]

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
@@ -1,0 +1,188 @@
+import { test as baseTest, expect, Page } from '@playwright/test';
+import { API_BASE } from './fixtures/auth.fixture';
+
+/**
+ * Builds an email unique per worker + invocation so tests never collide across
+ * retries or parallel shards.
+ */
+function uniqueEmail(prefix: string, workerIndex: number): string {
+  return `e2e-pwd-${prefix}-worker${workerIndex}-${Date.now()}@test.local`;
+}
+
+/**
+ * Fills the login page in register mode and submits. Assumes we start on /login
+ * in default (login) mode — toggles over to register first.
+ */
+async function submitRegister(
+  page: Page,
+  email: string,
+  name: string,
+  password: string,
+): Promise<void> {
+  await page.goto('/login');
+
+  // Default mode is 'login'; the toggle button is labelled with this text.
+  await page.getByRole('button', { name: 'Need an account? Create one' }).click();
+
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('Email').fill(email);
+  // p-password renders a single password input; getByLabel resolves to it via
+  // the associated label[for="password"].
+  await page.getByLabel('Password', { exact: true }).fill(password);
+
+  await page.getByRole('button', { name: 'Create account' }).click();
+}
+
+/**
+ * Fills the login page in login mode and submits. Assumes we start on /login
+ * and the default mode is already 'login'.
+ */
+async function submitLogin(
+  page: Page,
+  email: string,
+  password: string,
+): Promise<void> {
+  await page.goto('/login');
+
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password', { exact: true }).fill(password);
+
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+}
+
+/**
+ * Logs the user out via the API + clears local token state. We do this instead
+ * of driving a UI control because the current app shell does not expose a
+ * visible logout button.
+ */
+async function logout(page: Page): Promise<void> {
+  await page.request.post(`${API_BASE}/api/auth/logout`);
+  await page.evaluate(() => {
+    localStorage.removeItem('access_token');
+  });
+  await page.context().clearCookies();
+}
+
+baseTest.describe('Email/Password Auth — Register', () => {
+  baseTest('Registers a new user and lands in the app', async ({ page }, testInfo) => {
+    const email = uniqueEmail('register', testInfo.workerIndex);
+    const name = `E2E Register ${testInfo.workerIndex}`;
+    const password = 'pw-test-12345';
+
+    await submitRegister(page, email, name, password);
+
+    // Login page navigates to '/', which redirects to /dashboard.
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const token = await page.evaluate(() =>
+      localStorage.getItem('access_token'),
+    );
+    expect(token).toBeTruthy();
+
+    const response = await page.request.get(`${API_BASE}/api/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(response.ok()).toBeTruthy();
+    const user = await response.json();
+    expect(user.email).toBe(email);
+    expect(user.hasPassword).toBe(true);
+  });
+});
+
+baseTest.describe('Email/Password Auth — Register then Login', () => {
+  baseTest('User can log out and sign back in with email + password', async ({
+    page,
+  }, testInfo) => {
+    const email = uniqueEmail('roundtrip', testInfo.workerIndex);
+    const name = `E2E Roundtrip ${testInfo.workerIndex}`;
+    const password = 'pw-test-12345';
+
+    // 1. Register.
+    await submitRegister(page, email, name, password);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    // 2. Log out (API + clear local state — no visible logout UI control).
+    await logout(page);
+
+    // Visiting /dashboard without a token should redirect to /login.
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+
+    // 3. Log back in via email/password.
+    await submitLogin(page, email, password);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const token = await page.evaluate(() =>
+      localStorage.getItem('access_token'),
+    );
+    expect(token).toBeTruthy();
+  });
+});
+
+baseTest.describe('Email/Password Auth — Add password to Google-only user', () => {
+  baseTest('Google-only user can set a password and then log in with it', async ({
+    page,
+  }, testInfo) => {
+    // Build a FRESH Google-like user per invocation. We can't reuse the shared
+    // auth fixture's worker-stable email here: once this test runs, that user
+    // has a password, so the "Set a password" heading assertion would fail on
+    // subsequent runs against the same database. The existing /api/auth/test-login
+    // endpoint creates a user with no password — behaviourally equivalent to a
+    // Google-only user for the linking flow.
+    const email = uniqueEmail('link', testInfo.workerIndex);
+    const name = `E2E Link ${testInfo.workerIndex}`;
+    const password = `pw-link-${testInfo.workerIndex}-${Date.now()}`;
+
+    const loginResponse = await page.request.post(
+      `${API_BASE}/api/auth/test-login`,
+      { data: { email, name } },
+    );
+    expect(loginResponse.ok()).toBeTruthy();
+    const loginBody = await loginResponse.json();
+    expect(loginBody.accessToken).toBeTruthy();
+
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('access_token', token);
+    }, loginBody.accessToken);
+
+    // Navigate to settings — the freshly created user has no password yet, so
+    // the password section should prompt to set one.
+    await page.goto('/settings');
+    await expect(page).toHaveURL(/\/settings/);
+
+    await expect(
+      page.getByRole('heading', { name: 'Set a password' }),
+    ).toBeVisible();
+
+    await page.getByLabel('New password').fill(password);
+    await page.getByRole('button', { name: 'Set a password' }).click();
+
+    // Success toast from MessageService.
+    await expect(page.getByText('Password set')).toBeVisible();
+
+    // Verify via API that hasPassword flipped to true.
+    const token = await page.evaluate(() =>
+      localStorage.getItem('access_token'),
+    );
+    const meResponse = await page.request.get(`${API_BASE}/api/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(meResponse.ok()).toBeTruthy();
+    const me = await meResponse.json();
+    expect(me.hasPassword).toBe(true);
+
+    // Log out and log back in via email/password using the newly set password.
+    await logout(page);
+
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+
+    await submitLogin(page, email, password);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const newToken = await page.evaluate(() =>
+      localStorage.getItem('access_token'),
+    );
+    expect(newToken).toBeTruthy();
+  });
+});

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
@@ -56,7 +56,8 @@ async function submitLogin(
  * visible logout button.
  */
 async function logout(page: Page): Promise<void> {
-  await page.request.post(`${API_BASE}/api/auth/logout`);
+  const response = await page.request.post(`${API_BASE}/api/auth/logout`);
+  expect(response.ok()).toBeTruthy();
   await page.evaluate(() => {
     localStorage.removeItem('access_token');
   });

--- a/tests/MentalMetal.Web.IntegrationTests/Auth/AuthEndpointsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Auth/AuthEndpointsTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Json;
+using MentalMetal.Web.IntegrationTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MentalMetal.Web.IntegrationTests.Auth;
+
+/// <summary>
+/// End-to-end-through-HTTP coverage for the three email/password endpoints introduced by
+/// the <c>email-password-auth</c> change: register, login, and set-password.
+/// </summary>
+public sealed class AuthEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private sealed record AuthEnvelope(string AccessToken, UserEnvelope User);
+
+    private sealed record UserEnvelope(
+        Guid Id,
+        string Email,
+        string Name,
+        bool HasPassword);
+
+    // ---------- Register -----------------------------------------------------
+
+    [Fact]
+    public async Task Register_WithValidBody_Returns200_PersistsUser_AndSetsRefreshCookie()
+    {
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            email = "new-user@example.com",
+            password = "correct-horse-battery",
+            name = "New User"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadJsonAsync<AuthEnvelope>(response);
+        Assert.NotNull(body);
+        Assert.False(string.IsNullOrWhiteSpace(body!.AccessToken));
+        Assert.Equal("new-user@example.com", body.User.Email);
+        Assert.True(body.User.HasPassword);
+
+        var cookies = response.Headers.TryGetValues("Set-Cookie", out var values) ? values.ToArray() : [];
+        Assert.Contains(cookies, c => c.StartsWith("refresh_token=", StringComparison.Ordinal));
+
+        var persisted = await FindUserByEmailAsync("new-user@example.com");
+        Assert.NotNull(persisted);
+        Assert.NotNull(persisted!.PasswordHash);
+        Assert.Null(persisted.ExternalAuthId);
+        Assert.True(await CountRefreshTokensAsync(persisted.Id) >= 1);
+    }
+
+    [Fact]
+    public async Task Register_WithDuplicateEmail_Returns409()
+    {
+        const string email = "dup@example.com";
+        await SeedUserWithPasswordAndSignInAsync(email, "initial-password");
+
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            email,
+            password = "another-password-123",
+            name = "Second User"
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    // ---------- Login --------------------------------------------------------
+
+    [Fact]
+    public async Task Login_WithCorrectCredentials_Returns200_AndAccessToken()
+    {
+        const string email = "login-ok@example.com";
+        const string password = "valid-password-01";
+        await SeedUserWithPasswordAndSignInAsync(email, password);
+
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new { email, password });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadJsonAsync<AuthEnvelope>(response);
+        Assert.NotNull(body);
+        Assert.False(string.IsNullOrWhiteSpace(body!.AccessToken));
+        Assert.Equal(email, body.User.Email);
+        Assert.True(body.User.HasPassword);
+    }
+
+    [Fact]
+    public async Task Login_WithWrongPassword_Returns401()
+    {
+        const string email = "wrong-pass@example.com";
+        await SeedUserWithPasswordAndSignInAsync(email, "the-correct-one");
+
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = "nope-this-is-wrong"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithUnknownEmail_Returns401()
+    {
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email = "ghost@example.com",
+            password = "anything-at-all"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_ForGoogleOnlyUser_Returns401()
+    {
+        const string email = "google-only@example.com";
+        await SeedGoogleOnlyUserAsync("google-sub-123", email);
+
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = "any-password-works"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ---------- Set password -------------------------------------------------
+
+    [Fact]
+    public async Task SetPassword_WithoutToken_Returns401()
+    {
+        var client = CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/password", new
+        {
+            newPassword = "brand-new-password"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetPassword_ForGoogleOnlyUser_SetsPassword_AndEnablesPasswordLogin()
+    {
+        const string email = "link-password@example.com";
+        var userId = await SeedGoogleOnlyUserAsync("google-sub-link", email);
+
+        // Mint an access token for the Google user via the in-DI TokenService.
+        string accessToken;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var sp = scope.ServiceProvider;
+            var repo = sp.GetRequiredService<MentalMetal.Domain.Users.IUserRepository>();
+            var tokenService = sp.GetRequiredService<MentalMetal.Application.Common.Auth.ITokenService>();
+            var uow = sp.GetRequiredService<MentalMetal.Application.Common.IUnitOfWork>();
+            var user = await repo.GetByIdAsync(userId, CancellationToken.None);
+            Assert.NotNull(user);
+            var tokens = tokenService.GenerateTokens(user!);
+            await uow.SaveChangesAsync(CancellationToken.None);
+            accessToken = tokens.AccessToken;
+        }
+
+        var authedClient = WithBearer(CreateClient(), accessToken);
+        const string newPassword = "freshly-chosen-pw";
+
+        var setResponse = await authedClient.PostAsJsonAsync("/api/auth/password", new { newPassword });
+        Assert.Equal(HttpStatusCode.NoContent, setResponse.StatusCode);
+
+        // Confirm login now works with the password the user just set.
+        var anonClient = CreateClient();
+        var loginResponse = await anonClient.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = newPassword
+        });
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetPassword_WithShortPassword_Returns400()
+    {
+        var (_, accessToken) = await SeedUserWithPasswordAndSignInAsync(
+            "short-pw@example.com", "initial-long-password");
+
+        var authedClient = WithBearer(CreateClient(), accessToken);
+
+        var response = await authedClient.PostAsJsonAsync("/api/auth/password", new
+        {
+            newPassword = "short"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -22,20 +22,15 @@ public abstract class IntegrationTestBase : IAsyncLifetime
 
     protected IntegrationTestBase(PostgresFixture postgres)
     {
-        Factory = new MentalMetalWebApplicationFactory(postgres.ConnectionString);
+        // Factory + schema are owned by the collection fixture — a single factory
+        // instance is shared across every test class so migrations run once, not
+        // per test. Per-test isolation is provided by ResetDatabaseAsync() below.
+        Factory = postgres.Factory;
     }
 
-    public async Task InitializeAsync()
-    {
-        await Factory.EnsureSchemaAsync();
-        await Factory.ResetDatabaseAsync();
-    }
+    public Task InitializeAsync() => Factory.ResetDatabaseAsync();
 
-    public Task DisposeAsync()
-    {
-        Factory.Dispose();
-        return Task.CompletedTask;
-    }
+    public Task DisposeAsync() => Task.CompletedTask;
 
     protected HttpClient CreateClient() => Factory.CreateClient();
 
@@ -82,7 +77,7 @@ public abstract class IntegrationTestBase : IAsyncLifetime
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
-        var normalised = email.Trim().ToLower();
+        var normalised = email.Trim().ToLowerInvariant();
         return await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
             db.Users,
             u => u.Email.Value == normalised);

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -1,0 +1,111 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Auth;
+using MentalMetal.Domain.Users;
+// IUserRepository lives in MentalMetal.Domain.Users (domain-owned abstraction).
+using MentalMetal.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MentalMetal.Web.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Per-test lifecycle base: ensures schema + wipes users/refresh-tokens before each test.
+/// Requires the xUnit collection fixture <see cref="PostgresFixture"/> to have booted Postgres.
+/// </summary>
+[Collection(PostgresCollection.Name)]
+public abstract class IntegrationTestBase : IAsyncLifetime
+{
+    protected readonly MentalMetalWebApplicationFactory Factory;
+    protected static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    protected IntegrationTestBase(PostgresFixture postgres)
+    {
+        Factory = new MentalMetalWebApplicationFactory(postgres.ConnectionString);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await Factory.EnsureSchemaAsync();
+        await Factory.ResetDatabaseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        Factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    protected HttpClient CreateClient() => Factory.CreateClient();
+
+    /// <summary>
+    /// Seeds a user directly through the domain + repository (bypasses the HTTP register endpoint)
+    /// and returns an access token for them. Use when a test needs an authenticated principal but
+    /// is not exercising registration itself.
+    /// </summary>
+    protected async Task<(Guid UserId, string AccessToken)> SeedUserWithPasswordAndSignInAsync(
+        string email, string password, string name = "Test User")
+    {
+        using var scope = Factory.Services.CreateScope();
+        var sp = scope.ServiceProvider;
+        var hasher = sp.GetRequiredService<Microsoft.AspNetCore.Identity.IPasswordHasher<User>>();
+        var repo = sp.GetRequiredService<IUserRepository>();
+        var tokenService = sp.GetRequiredService<ITokenService>();
+        var uow = sp.GetRequiredService<IUnitOfWork>();
+
+        var user = User.RegisterWithPassword(email, name, Password.Create(password, hasher), null);
+        await repo.AddAsync(user, CancellationToken.None);
+        var tokens = tokenService.GenerateTokens(user);
+        await uow.SaveChangesAsync(CancellationToken.None);
+
+        return (user.Id, tokens.AccessToken);
+    }
+
+    /// <summary>
+    /// Seeds a Google-only user (no password) and returns their id.
+    /// </summary>
+    protected async Task<Guid> SeedGoogleOnlyUserAsync(string externalAuthId, string email, string name = "Google User")
+    {
+        using var scope = Factory.Services.CreateScope();
+        var sp = scope.ServiceProvider;
+        var repo = sp.GetRequiredService<IUserRepository>();
+        var uow = sp.GetRequiredService<IUnitOfWork>();
+
+        var user = User.Register(externalAuthId, email, name, avatarUrl: null);
+        await repo.AddAsync(user, CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+        return user.Id;
+    }
+
+    protected async Task<User?> FindUserByEmailAsync(string email)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
+        var normalised = email.Trim().ToLower();
+        return await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
+            db.Users,
+            u => u.Email.Value == normalised);
+    }
+
+    protected async Task<int> CountRefreshTokensAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
+        return await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.CountAsync(
+            db.RefreshTokens,
+            t => t.UserId == userId);
+    }
+
+    protected static HttpClient WithBearer(HttpClient client, string accessToken)
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return client;
+    }
+
+    protected static StringContent JsonBody(object value) =>
+        new(JsonSerializer.Serialize(value, JsonOptions), System.Text.Encoding.UTF8, "application/json");
+
+    protected static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response) =>
+        await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+}

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/MentalMetalWebApplicationFactory.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/MentalMetalWebApplicationFactory.cs
@@ -8,8 +8,11 @@ namespace MentalMetal.Web.IntegrationTests.Infrastructure;
 
 /// <summary>
 /// WebApplicationFactory that swaps the Postgres connection string for the one
-/// exposed by the shared Testcontainers Postgres, applies migrations once at
-/// startup, and injects minimum valid config for JWT + AI-provider startup checks.
+/// exposed by the shared Testcontainers Postgres, and injects minimum valid config
+/// for JWT + AI-provider startup checks. A single instance is created per test
+/// collection in <see cref="PostgresFixture"/> and shared across every test class.
+/// Migrations run once in the fixture's <see cref="PostgresFixture.InitializeAsync"/>;
+/// per-test isolation is handled via <see cref="ResetDatabaseAsync"/>.
 /// </summary>
 public sealed class MentalMetalWebApplicationFactory : WebApplicationFactory<Program>
 {
@@ -22,8 +25,6 @@ public sealed class MentalMetalWebApplicationFactory : WebApplicationFactory<Pro
     internal const string IntegrationJwtSecret = "integration-test-secret-key-minimum-32-chars-long!";
     internal const string IntegrationJwtIssuer = "MentalMetal.IntegrationTests";
     internal const string IntegrationJwtAudience = "MentalMetal.IntegrationTests";
-
-    private bool _schemaInitialised;
 
     public MentalMetalWebApplicationFactory(string connectionString)
     {
@@ -51,16 +52,6 @@ public sealed class MentalMetalWebApplicationFactory : WebApplicationFactory<Pro
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
-    }
-
-    public async Task EnsureSchemaAsync()
-    {
-        if (_schemaInitialised) return;
-
-        using var scope = Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
-        await db.Database.MigrateAsync();
-        _schemaInitialised = true;
     }
 
     public async Task ResetDatabaseAsync()

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/MentalMetalWebApplicationFactory.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/MentalMetalWebApplicationFactory.cs
@@ -1,0 +1,74 @@
+using MentalMetal.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MentalMetal.Web.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// WebApplicationFactory that swaps the Postgres connection string for the one
+/// exposed by the shared Testcontainers Postgres, applies migrations once at
+/// startup, and injects minimum valid config for JWT + AI-provider startup checks.
+/// </summary>
+public sealed class MentalMetalWebApplicationFactory : WebApplicationFactory<Program>
+{
+    // Program.cs reads Jwt + ConnectionStrings from builder.Configuration during
+    // top-level-statements execution (before WebApplicationFactory's
+    // ConfigureAppConfiguration callback runs), so we must have these values present
+    // as environment variables at the moment the entry point is invoked. Setting
+    // them in a static ctor guarantees that — every test fixture that references
+    // this factory triggers the initialiser, which is idempotent.
+    internal const string IntegrationJwtSecret = "integration-test-secret-key-minimum-32-chars-long!";
+    internal const string IntegrationJwtIssuer = "MentalMetal.IntegrationTests";
+    internal const string IntegrationJwtAudience = "MentalMetal.IntegrationTests";
+
+    private bool _schemaInitialised;
+
+    public MentalMetalWebApplicationFactory(string connectionString)
+    {
+        // Program.cs top-level statements read configuration eagerly (Jwt settings,
+        // connection string) BEFORE WebApplicationFactory.ConfigureAppConfiguration
+        // would fire. Environment variables are read by the default builder's env
+        // source, so seed them before the entry point runs (entry point runs lazily
+        // on first Services / CreateClient access).
+        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", connectionString);
+    }
+
+    static MentalMetalWebApplicationFactory()
+    {
+        Environment.SetEnvironmentVariable("Jwt__Secret", IntegrationJwtSecret);
+        Environment.SetEnvironmentVariable("Jwt__Issuer", IntegrationJwtIssuer);
+        Environment.SetEnvironmentVariable("Jwt__Audience", IntegrationJwtAudience);
+        // AiProvider:EncryptionKey is ValidateOnStart-required and must be non-empty.
+        Environment.SetEnvironmentVariable(
+            "AiProvider__EncryptionKey",
+            "aW50ZWdyYXRpb24tdGVzdC1lbmNyeXB0aW9uLWtleS0xMjM0NTY=");
+        // Disable Google auth registration — no ClientId => the block in Program.cs is skipped.
+        Environment.SetEnvironmentVariable("Authentication__Google__ClientId", "");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+    }
+
+    public async Task EnsureSchemaAsync()
+    {
+        if (_schemaInitialised) return;
+
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
+        await db.Database.MigrateAsync();
+        _schemaInitialised = true;
+    }
+
+    public async Task ResetDatabaseAsync()
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
+        // Cascade truncate wipes child tables (RefreshTokens) alongside Users.
+        await db.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"RefreshTokens\", \"Users\" RESTART IDENTITY CASCADE;");
+    }
+}

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/PostgresFixture.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/PostgresFixture.cs
@@ -1,0 +1,30 @@
+using Testcontainers.PostgreSql;
+
+namespace MentalMetal.Web.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Boots a disposable Postgres container once per xUnit collection. The container is
+/// shared by every test class in the collection; per-test isolation is provided by
+/// <see cref="IntegrationTestBase.InitializeAsync"/> which truncates user/token tables.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    public PostgreSqlContainer Container { get; } = new PostgreSqlBuilder()
+        .WithImage("postgres:16-alpine")
+        .WithDatabase("mentalmetal_integration")
+        .WithUsername("mentalmetal")
+        .WithPassword("integration-test")
+        .Build();
+
+    public string ConnectionString => Container.GetConnectionString();
+
+    public Task InitializeAsync() => Container.StartAsync();
+
+    public Task DisposeAsync() => Container.DisposeAsync().AsTask();
+}
+
+[CollectionDefinition(Name)]
+public sealed class PostgresCollection : ICollectionFixture<PostgresFixture>
+{
+    public const string Name = "Postgres";
+}

--- a/tests/MentalMetal.Web.IntegrationTests/Infrastructure/PostgresFixture.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/Infrastructure/PostgresFixture.cs
@@ -1,10 +1,15 @@
+using MentalMetal.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Testcontainers.PostgreSql;
 
 namespace MentalMetal.Web.IntegrationTests.Infrastructure;
 
 /// <summary>
-/// Boots a disposable Postgres container once per xUnit collection. The container is
-/// shared by every test class in the collection; per-test isolation is provided by
+/// Boots a disposable Postgres container once per xUnit collection and creates a
+/// single <see cref="MentalMetalWebApplicationFactory"/> shared across every test
+/// class in the collection. Migrations therefore run exactly once per test run,
+/// not per test. Per-test isolation is provided by
 /// <see cref="IntegrationTestBase.InitializeAsync"/> which truncates user/token tables.
 /// </summary>
 public sealed class PostgresFixture : IAsyncLifetime
@@ -18,9 +23,27 @@ public sealed class PostgresFixture : IAsyncLifetime
 
     public string ConnectionString => Container.GetConnectionString();
 
-    public Task InitializeAsync() => Container.StartAsync();
+    public MentalMetalWebApplicationFactory Factory { get; private set; } = null!;
 
-    public Task DisposeAsync() => Container.DisposeAsync().AsTask();
+    public async Task InitializeAsync()
+    {
+        await Container.StartAsync();
+        Factory = new MentalMetalWebApplicationFactory(ConnectionString);
+
+        // Run migrations once, up-front, against the shared container.
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MentalMetalDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (Factory is not null)
+        {
+            await Factory.DisposeAsync();
+        }
+        await Container.DisposeAsync();
+    }
 }
 
 [CollectionDefinition(Name)]

--- a/tests/MentalMetal.Web.IntegrationTests/MentalMetal.Web.IntegrationTests.csproj
+++ b/tests/MentalMetal.Web.IntegrationTests/MentalMetal.Web.IntegrationTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MentalMetal.Web\MentalMetal.Web.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds email/password as a second sign-in method alongside the existing Google OAuth flow. Existing Google users can link a password to their account via a new settings section. Scope is deliberately bare-bones — no email verification, no reset, no rate limiting (tracked as follow-ups in the design doc).

**OpenSpec:** [openspec/changes/email-password-auth/](openspec/changes/email-password-auth/)

## Changes

**Backend**
- Domain: new `Password` value object (PBKDF2 via Identity's `PasswordHasher<T>`); `User` gains nullable `PasswordHash`; `ExternalAuthId` becomes nullable; new `RegisterWithPassword` factory + `SetPassword` / `VerifyPassword` methods.
- Application: three new vertical-slice handlers (`RegisterWithPassword`, `LoginWithPassword`, `SetPassword`) reusing the existing `ITokenService`.
- Web: `POST /api/auth/register`, `POST /api/auth/login`, `POST /api/auth/password` (auth-required); `hasPassword: bool` added to `GET /api/users/me`.
- Migration: `AddPasswordHashToUsers` — nullable `PasswordHash` column + relaxes `ExternalAuthId` to nullable.

**Frontend**
- Login page gains a login/register toggle form beside the Google button (Signal-based, PrimeNG components, `@if` control flow).
- Settings page gains a password section — "Set a password" or "Change password" driven by `hasPassword`.

**Tests**
- 9 backend integration tests against a real Postgres via Testcontainers (new `MentalMetal.Web.IntegrationTests` project).
- Unit tests: Domain VO, User aggregate changes, all three Application handlers, both new Angular components.
- 3 Playwright E2E smoke tests: register → land, register → logout → re-login, link-flow (Google-only user sets a password then logs in with it).

## Design decisions worth calling out

- **Linking on email collision:** register returns 409 — linking happens via authenticated `/api/auth/password`, not by matching emails. Prevents a safe linking path without an email-verification flow.
- **Login failure modes:** all return 401 without disclosing which case (unknown email, wrong password, Google-only user).
- **`Microsoft.Extensions.Identity.Core` in Domain:** ships both the `IPasswordHasher<T>` interface and the PBKDF2 impl — one package, no wrapper abstraction. Deviates from the initial "Domain dep-free" preference in design.md but is the cleaner landing.
- **Form technology:** used `FormsModule` + `[(ngModel)]` + signals to match every other form in the codebase rather than Signal Forms (which tasks.md initially requested).

See `openspec/changes/email-password-auth/design.md` for the full set of decisions and alternatives considered.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — 433/433 pass (Domain 319 + Application 105 + Integration 9)
- [x] `ng test --watch=false` — 27/27 pass across 5 specs
- [ ] Manual browser verification: register new account → lands in app; log out → log back in with email+password; sign in with Google → settings shows "Set a password" → set one → log out → log back in with email+password
- [ ] E2E Playwright run against Docker dev stack

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Email and password registration and login now available as an alternative to Google OAuth
  - New password management section in user settings to set or change your account password
  - User profile now indicates whether password authentication is configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->