### PR TITLE
fix: make dev-stack E2E runnable + wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,74 @@ jobs:
       - name: Build Angular app
         run: npx ng build
         working-directory: src/MentalMetal.Web/ClientApp
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-and-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tests/MentalMetal.E2E.Tests/package-lock.json
+
+      - name: Install Playwright dependencies
+        run: npm ci
+        working-directory: tests/MentalMetal.E2E.Tests
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: tests/MentalMetal.E2E.Tests
+
+      - name: Start dev-stack
+        # Matches the command developers run locally so CI and local parity is
+        # preserved. --wait blocks until containers report healthy.
+        run: docker compose --profile dev-stack up -d --wait
+
+      - name: Wait for API + frontend to be ready
+        # docker compose --wait only checks container healthchecks; the API and
+        # frontend dev servers take longer to compile on a cold cache, so poll
+        # the HTTP endpoints directly before handing off to Playwright.
+        run: |
+          for i in $(seq 1 120); do
+            api=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5002/api/health || echo 000)
+            fe=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4200/ || echo 000)
+            echo "attempt $i: api=$api frontend=$fe"
+            if [ "$api" = "200" ] && [ "$fe" = "200" ]; then
+              echo "stack is ready"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Dev-stack did not become ready within 10 minutes"
+          docker compose --profile dev-stack logs --tail 200
+          exit 1
+
+      - name: Run Playwright E2E tests
+        run: npx playwright test
+        working-directory: tests/MentalMetal.E2E.Tests
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/MentalMetal.E2E.Tests/playwright-report
+          retention-days: 14
+
+      - name: Dump dev-stack logs on failure
+        if: failure()
+        run: docker compose --profile dev-stack logs --tail 500
+
+      - name: Tear down dev-stack
+        if: always()
+        run: docker compose --profile dev-stack down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,18 @@ services:
     # the schema matches the model before the API or E2E tests touch it.
     # `dotnet ef database update` requires a restored project (it reads
     # project.assets.json); the fresh SDK container has no restore cache, so
-    # we restore first.
-    command: sh -c "dotnet tool install --global dotnet-ef --version 10.0.* >/dev/null 2>&1 || true; export PATH=$PATH:/root/.dotnet/tools; dotnet restore ../MentalMetal.Web/MentalMetal.Web.csproj && dotnet ef database update --startup-project ../MentalMetal.Web"
+    # we restore first. `dotnet tool install` fails with exit 1 if the tool
+    # is already present — we tolerate that specific case but surface all
+    # other failures so a broken container is obvious rather than confusing.
+    command: |
+      sh -eu -c '
+        export PATH="$PATH:/root/.dotnet/tools"
+        if ! command -v dotnet-ef >/dev/null 2>&1; then
+          dotnet tool install --global dotnet-ef --version 10.0.*
+        fi
+        dotnet restore ../MentalMetal.Web/MentalMetal.Web.csproj
+        dotnet ef database update --startup-project ../MentalMetal.Web
+      '
     environment:
       DATABASE_URL: "Host=postgres-dev;Port=5432;Database=mentalmetal;Username=mentalmetal;Password=devTestPassword"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,37 @@ services:
       timeout: 5s
       retries: 5
 
+  migrations:
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    container_name: mentalmetal-migrations-dev
+    profiles: ["dev-stack"]
+    working_dir: /src/MentalMetal.Infrastructure
+    # Install dotnet-ef (not in the SDK image by default) and apply migrations.
+    # The API does not auto-migrate at startup, so this one-shot service ensures
+    # the schema matches the model before the API or E2E tests touch it.
+    # `dotnet ef database update` requires a restored project (it reads
+    # project.assets.json); the fresh SDK container has no restore cache, so
+    # we restore first.
+    command: sh -c "dotnet tool install --global dotnet-ef --version 10.0.* >/dev/null 2>&1 || true; export PATH=$PATH:/root/.dotnet/tools; dotnet restore ../MentalMetal.Web/MentalMetal.Web.csproj && dotnet ef database update --startup-project ../MentalMetal.Web"
+    environment:
+      DATABASE_URL: "Host=postgres-dev;Port=5432;Database=mentalmetal;Username=mentalmetal;Password=devTestPassword"
+    volumes:
+      - ./src:/src
+    depends_on:
+      postgres-dev:
+        condition: service_healthy
+    restart: "no"
+
   api:
     image: mcr.microsoft.com/dotnet/sdk:10.0
     container_name: mentalmetal-api-dev
     profiles: ["dev-stack"]
     working_dir: /src/MentalMetal.Web
-    command: dotnet watch run
+    # --no-launch-profile skips Properties/launchSettings.json so ASPNETCORE_URLS
+    # below wins; otherwise the http profile's applicationUrl (http://localhost:5289)
+    # takes precedence and the API binds to the loopback interface inside the
+    # container — making the published port unreachable from the host.
+    command: dotnet watch run --no-launch-profile
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:5002
@@ -40,13 +65,18 @@ services:
     depends_on:
       postgres-dev:
         condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
 
   frontend:
     image: node:22-alpine
     container_name: mentalmetal-frontend-dev
     profiles: ["dev-stack"]
     working_dir: /app
-    command: sh -c "[ -d node_modules ] || npm ci; API_TARGET=http://api:5002 npx ng serve --host 0.0.0.0 --poll 2000"
+    # The anonymous volume for node_modules pre-creates an empty dir, so a plain
+    # `[ -d node_modules ]` check is always true. Probe for the ng binary instead
+    # to decide whether we need to install.
+    command: sh -c "[ -x node_modules/.bin/ng ] || npm ci; API_TARGET=http://api:5002 npx ng serve --host 0.0.0.0 --poll 2000"
     ports:
       - "4200:4200"
     volumes:

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
@@ -6,19 +6,34 @@ import { AuthService } from './auth.service';
 
 let isRefreshing = false;
 
+// Auth endpoints that must NOT receive a bearer token. `/api/auth/password`
+// is deliberately excluded — it requires authentication. Matched against the
+// URL path exactly so something like `/api/auth/login-extra` or a query
+// string containing one of these values doesn't accidentally bypass auth.
+const UNAUTHENTICATED_AUTH_PATHS = new Set<string>([
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/refresh',
+  '/api/auth/logout',
+  '/api/auth/test-login',
+]);
+
+function isUnauthenticatedAuthRequest(url: string): boolean {
+  try {
+    // `new URL` handles both absolute (http://host/path) and the relative
+    // form produced by HttpClient when no base is set; fall back to a
+    // starts-with check if the URL is malformed.
+    const pathname = new URL(url, 'http://_').pathname;
+    return UNAUTHENTICATED_AUTH_PATHS.has(pathname);
+  } catch {
+    return false;
+  }
+}
+
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
 
-  // Don't attach token to unauthenticated auth endpoints (login, register,
-  // refresh, logout). /api/auth/password requires auth and must get the token.
-  const unauthenticatedAuthEndpoints = [
-    '/api/auth/login',
-    '/api/auth/register',
-    '/api/auth/refresh',
-    '/api/auth/logout',
-    '/api/auth/test-login',
-  ];
-  if (unauthenticatedAuthEndpoints.some((p) => req.url.includes(p))) {
+  if (isUnauthenticatedAuthRequest(req.url)) {
     return next(req);
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
@@ -9,8 +9,16 @@ let isRefreshing = false;
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
 
-  // Don't attach token to auth endpoints
-  if (req.url.includes('/api/auth/')) {
+  // Don't attach token to unauthenticated auth endpoints (login, register,
+  // refresh, logout). /api/auth/password requires auth and must get the token.
+  const unauthenticatedAuthEndpoints = [
+    '/api/auth/login',
+    '/api/auth/register',
+    '/api/auth/refresh',
+    '/api/auth/logout',
+    '/api/auth/test-login',
+  ];
+  if (unauthenticatedAuthEndpoints.some((p) => req.url.includes(p))) {
     return next(req);
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
@@ -23,7 +23,14 @@ export class AuthService {
   constructor() {
     this.extractTokenFromHash();
     if (this.isAuthenticated()) {
-      this.loadCurrentUser();
+      // Defer to break the circular DI between AuthService and authInterceptor:
+      // the interceptor calls inject(AuthService) for every outgoing request,
+      // and firing the /api/users/me call synchronously from the constructor
+      // lands inside that interceptor while AuthService is still being
+      // constructed (NG0200 cyclic resolution -> subscribe errors synchronously
+      // with no network request, which clears the just-restored token).
+      // Queueing a microtask lets the constructor return first.
+      queueMicrotask(() => this.loadCurrentUser());
     }
   }
 

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/ai-provider.spec.ts
@@ -5,7 +5,7 @@ test.describe('AI Provider Settings', () => {
     await authenticatedPage.goto('/settings');
 
     await expect(authenticatedPage).toHaveURL(/\/settings/);
-    await expect(authenticatedPage.getByText('AI Provider')).toBeVisible();
+    await expect(authenticatedPage.getByRole('heading', { name: 'AI Provider' })).toBeVisible();
   });
 
   test('Provider status returns isConfigured=false for new user', async ({ authenticatedPage, testUser }) => {

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
@@ -26,9 +26,16 @@ async function submitRegister(
 
   await page.getByLabel('Name').fill(name);
   await page.getByLabel('Email').fill(email);
-  // p-password renders a single password input; getByLabel resolves to it via
-  // the associated label[for="password"].
-  await page.getByLabel('Password', { exact: true }).fill(password);
+  // p-password wraps the actual <input type="password"> in a custom element, and
+  // the label's for="password" points at the <p-password> host (not the input).
+  // Playwright's getByLabel therefore does not resolve the input; select the
+  // real input directly via its name attribute.
+  const pwdInput = page.locator('input[name="password"]');
+  await pwdInput.fill(password);
+  // In register mode p-password shows a strength-meter overlay on focus which
+  // intercepts clicks on the submit button. Clicking outside the password
+  // control (the page heading) is what PrimeNG uses to dismiss the overlay.
+  await page.locator('h1').click();
 
   await page.getByRole('button', { name: 'Create account' }).click();
 }
@@ -45,7 +52,8 @@ async function submitLogin(
   await page.goto('/login');
 
   await page.getByLabel('Email').fill(email);
-  await page.getByLabel('Password', { exact: true }).fill(password);
+  // See note in submitRegister re: p-password and the label/for association.
+  await page.locator('input[name="password"]').fill(password);
 
   await page.getByRole('button', { name: 'Sign in', exact: true }).click();
 }
@@ -142,8 +150,14 @@ baseTest.describe('Email/Password Auth — Add password to Google-only user', ()
     const loginBody = await loginResponse.json();
     expect(loginBody.accessToken).toBeTruthy();
 
+    // Use a sessionStorage-flagged init script so the token is only seeded on
+    // the FIRST navigation — otherwise the logout() step later in this test
+    // would be undone by the next goto() re-seeding localStorage.
     await page.addInitScript((token: string) => {
-      localStorage.setItem('access_token', token);
+      if (!sessionStorage.getItem('__seededAuthToken')) {
+        localStorage.setItem('access_token', token);
+        sessionStorage.setItem('__seededAuthToken', '1');
+      }
     }, loginBody.accessToken);
 
     // Navigate to settings — the freshly created user has no password yet, so
@@ -155,7 +169,12 @@ baseTest.describe('Email/Password Auth — Add password to Google-only user', ()
       page.getByRole('heading', { name: 'Set a password' }),
     ).toBeVisible();
 
-    await page.getByLabel('New password').fill(password);
+    // p-password wraps the input; target the real <input> by its name attribute.
+    const newPwdInput = page.locator('input[name="newPassword"]');
+    await newPwdInput.fill(password);
+    // Dismiss the p-password strength-meter overlay by clicking the heading;
+    // it otherwise intercepts clicks on the submit button below.
+    await page.getByRole('heading', { name: 'Set a password' }).click();
     await page.getByRole('button', { name: 'Set a password' }).click();
 
     // Success toast from MessageService.

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/email-password-auth.spec.ts
@@ -194,8 +194,15 @@ baseTest.describe('Email/Password Auth — Add password to Google-only user', ()
     // Log out and log back in via email/password using the newly set password.
     await logout(page);
 
+    // Verify the init-script's seed-once guard actually prevents re-seeding
+    // on the next navigation — otherwise the logout we just performed would
+    // silently be undone and this test would pass for the wrong reason.
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/login/);
+    const tokenAfterLogout = await page.evaluate(() =>
+      localStorage.getItem('access_token'),
+    );
+    expect(tokenAfterLogout).toBeNull();
 
     await submitLogin(page, email, password);
     await expect(page).toHaveURL(/\/dashboard/);

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/health.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/health.spec.ts
@@ -2,8 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Health Check', () => {
   test('Unmatched API routes return 404', async ({ request }) => {
-    const response = await request.get('http://localhost:5002/api/health');
+    const response = await request.get('http://localhost:5002/api/does-not-exist');
     expect(response.status()).toBe(404);
+  });
+
+  test('Health endpoint returns 200', async ({ request }) => {
+    const response = await request.get('http://localhost:5002/api/health');
+    expect(response.status()).toBe(200);
   });
 
   test('Frontend loads successfully', async ({ page }) => {

--- a/tests/MentalMetal.E2E.Tests/smoke-tests/settings.spec.ts
+++ b/tests/MentalMetal.E2E.Tests/smoke-tests/settings.spec.ts
@@ -5,9 +5,9 @@ test.describe('Settings Page', () => {
     await authenticatedPage.goto('/settings');
 
     await expect(authenticatedPage).toHaveURL(/\/settings/);
-    await expect(authenticatedPage.getByText('Settings')).toBeVisible();
-    await expect(authenticatedPage.getByText('Profile')).toBeVisible();
-    await expect(authenticatedPage.getByText('Preferences')).toBeVisible();
+    await expect(authenticatedPage.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(authenticatedPage.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await expect(authenticatedPage.getByRole('heading', { name: 'Preferences' })).toBeVisible();
   });
 
   test('User can update profile name', async ({ authenticatedPage }) => {


### PR DESCRIPTION
## Summary

Makes the Docker dev-stack actually usable for E2E testing, wires the Playwright suite into GitHub Actions CI, and fixes two real Angular bugs from #80 that only a live-browser run would catch.

## What was broken

1. **Dev-stack API bound to `localhost` inside the container.** `launchSettings.json`'s `http://localhost:5289` was winning over the compose `ASPNETCORE_URLS=http://+:5002`, so the published port was unreachable from the host.
2. **Migrations never ran.** `/api/auth/test-login` (and any other DB-touching call) 500'd with `relation "Users" does not exist`.
3. **`AuthService` constructor had a circular-DI race.** It synchronously called `/api/users/me`, which flowed through `authInterceptor`'s `inject(AuthService)` while `AuthService` itself was still being constructed. NG0200 caused the subscribe to error synchronously and wipe the freshly-restored token. **Any user refreshing a protected page was kicked to `/login` in production.**
4. **`authInterceptor` stripped the bearer token from every `/api/auth/*` URL**, including the authenticated `/api/auth/password`. **The "Set a password" linking flow always 401'd in production.**
5. Pre-existing E2E specs had strict-mode selector ambiguity that only surfaced once the stack actually served content (`getByText('Settings')` matching both the header link and the h1, etc.).

## Changes

**Dev-stack (`docker-compose.yml`)**
- `api`: `dotnet watch run --no-launch-profile` so `ASPNETCORE_URLS` wins.
- New one-shot `migrations` service that runs `dotnet ef database update` before the API starts.

**App bugs (`src/MentalMetal.Web/ClientApp/src/app/shared/services/`)**
- `auth.service.ts`: defer `loadCurrentUser()` with `queueMicrotask` so the constructor returns before the interceptor re-injects `AuthService`.
- `auth.interceptor.ts`: explicit allow-list of unauthenticated auth endpoints (`/login`, `/register`, `/refresh`, `/logout`, `/test-login`) — all other `/api/auth/*` URLs get the token.

**CI (`.github/workflows/ci.yml`)**
- New `e2e` job: runs after `build-and-test`, installs Playwright + Chromium, spins up the dev-stack, polls readiness, runs tests, uploads HTML report on failure, dumps compose logs on failure, always tears down.

**E2E tests (`tests/MentalMetal.E2E.Tests/smoke-tests/`)**
- `email-password-auth.spec.ts`: target inputs by `name` (PrimeNG `<p-password>`'s `<label for>` points at the host, not the inner input); dismiss strength-meter overlay; seed init-script once so `logout()` sticks.
- `health.spec.ts`: fix stale 404 assertion (was hitting `/api/health` expecting 404, now 200 and correct).
- `settings.spec.ts`, `ai-provider.spec.ts`: use `getByRole('heading', { name: ... })` to disambiguate from other matching text.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — 434/434 pass
- [x] `ng test --watch=false` — 27/27 pass
- [x] Playwright against fresh dev-stack — **44/44 pass**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate end-to-end tests against the Docker dev stack and fix auth and E2E issues uncovered by live browser runs.

Bug Fixes:
- Ensure authenticated /api/auth/* endpoints such as /api/auth/password receive the bearer token while keeping login-style endpoints unauthenticated.
- Break the circular dependency between AuthService construction and the HTTP auth interceptor by deferring the current-user load.
- Correct the API health-check smoke test to assert 404 for unknown routes and 200 for the health endpoint.
- Stabilize Playwright selectors for headings and password fields to avoid ambiguity and PrimeNG-specific quirks.

Enhancements:
- Introduce a dedicated migrations container and adjust the API and frontend dev-stack configuration so the API binds correctly and the Angular dev server installs dependencies reliably.

CI:
- Add a GitHub Actions e2e job that provisions the dev-stack, waits for API and frontend readiness, runs Playwright tests, and captures reports and logs on failure.

Tests:
- Update Playwright smoke tests for auth, settings, AI provider, health, and password flows to work reliably against the running dev stack and seeded auth state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test automation to the CI pipeline with Docker stack integration and health checks.
  * Enhanced smoke tests with improved selectors and PrimeNG component handling for better test reliability.

* **Chores**
  * Improved development environment setup with automated database migrations and enhanced service orchestration.
  * Refined authentication token handling to apply consistently across API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->