### PR TITLE
fix: COPY Web.IntegrationTests csproj in Dockerfile restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY src/MentalMetal.Infrastructure/MentalMetal.Infrastructure.csproj MentalMeta
 COPY src/MentalMetal.Web/MentalMetal.Web.csproj MentalMetal.Web/
 COPY tests/MentalMetal.Domain.Tests/MentalMetal.Domain.Tests.csproj ../tests/MentalMetal.Domain.Tests/
 COPY tests/MentalMetal.Application.Tests/MentalMetal.Application.Tests.csproj ../tests/MentalMetal.Application.Tests/
+COPY tests/MentalMetal.Web.IntegrationTests/MentalMetal.Web.IntegrationTests.csproj ../tests/MentalMetal.Web.IntegrationTests/
 RUN dotnet restore MentalMetal.slnx
 
 # Stage 3: Build and publish .NET app


### PR DESCRIPTION
## Summary

Staging deploy of #82 failed because the prod `Dockerfile`'s restore stage didn't copy the new `MentalMetal.Web.IntegrationTests` csproj, so `dotnet restore MentalMetal.slnx` couldn't resolve it (the project was added to the solution in #80).

## Fix

Add the missing `COPY` line before `RUN dotnet restore`.

## Test Plan

- [x] `docker build .` succeeds locally (previously failed with MSB3202)
- [x] Deploy workflow should now proceed through restore → publish → Cloud Run deploy