### PR TITLE
openspec: propose daily-close-out (Tier 3)

### DIFF
--- a/openspec/changes/daily-close-out/.openspec.yaml
+++ b/openspec/changes/daily-close-out/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/daily-close-out/design.md
+++ b/openspec/changes/daily-close-out/design.md
@@ -1,0 +1,93 @@
+## Context
+
+`capture-text` (Tier 2) lets users dump raw text and `capture-ai-extraction` (Tier 2) processes that text into structured commitments / delegations / observations / decisions. Today, those captures sit in a flat list and the user has no deliberate end-of-day moment to triage what's still raw, what's processed-but-unconfirmed, and what should be discarded. Without a triage ritual, AI extractions go unactioned and the capture inbox grows indefinitely.
+
+The Capture aggregate already has rich behaviour (`BeginProcessing`, `CompleteProcessing`, `ConfirmExtraction`, `DiscardExtraction`, link/unlink person/initiative, retry). The User aggregate already exists with owned-collection patterns established by `ai-provider-abstraction` and other Tier 1 specs. This change is mostly a thin coordination capability over existing primitives.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single endpoint that returns the "things still pending triage today" queue.
+- A small set of triage actions reachable from one screen: confirm extraction, discard extraction, reassign links, quick-discard the whole capture.
+- A persistent record per-user-per-date that the user closed out, with counts.
+- A focused Angular UI that walks the user through the queue.
+
+**Non-Goals:**
+- AI re-processing inside this flow (use existing `/process` and `/retry`).
+- Notifications, scheduling, streaks, or gamification.
+- Cross-day analytics or trend dashboards.
+- Replacing `my-queue` (this is closer to "inbox zero", not prioritisation).
+
+## Decisions
+
+### Decision 1: Mark captures as triaged via a `Triaged` flag, not a new status
+
+**Choice:** Add a boolean `Triaged` (with `TriagedAtUtc` timestamp) to the Capture aggregate, separate from `ProcessingStatus`.
+
+**Rationale:** `ProcessingStatus` describes the AI-processing lifecycle (Raw → Processing → Processed/Failed). Triage is an orthogonal user-intent concept ("I dealt with this"). Conflating them would force ugly status combinations (e.g., a `Failed` capture that the user explicitly chose to discard would lose the failure context).
+
+**Alternatives considered:**
+- Add `TriagedRaw`, `TriagedProcessed`, `TriagedDiscarded` to the status enum — rejected, conflates two axes.
+- Hard-delete quick-discarded captures — rejected, loses content the user may want to revisit.
+
+### Decision 2: `DailyCloseOutLog` as an owned collection on User
+
+**Choice:** Add `DailyCloseOutLog` as an owned-entity collection on the `User` aggregate, keyed by `(UserId, Date)`, with `ClosedAtUtc`, `ConfirmedCount`, `DiscardedCount`, `RemainingCount`. Recording the same date twice overwrites.
+
+**Rationale:** Close-out is a property of the user's daily rhythm; it doesn't have an independent lifecycle. Owned collection follows the same EF pattern used by `AiProviderConfig` on User. Idempotent overwrite keeps the API simple — pressing "Close out" twice in one day shouldn't create duplicate rows.
+
+**EF Core gotcha (per `project_tier2b_plan.md`):** Owned collections backed by a private field need explicit `Metadata.SetPropertyAccessMode(PropertyAccessMode.Field)` and the snapshot change tracker; otherwise additions to the field-backed list aren't detected. Mirror the existing `AiProviderConfigs` configuration verbatim.
+
+**Alternatives considered:**
+- Standalone `DailyCloseOutLog` aggregate — rejected, no invariants of its own and no behaviour outside the user's session.
+- Just stamp `User.LastCloseOutAtUtc` — rejected, loses per-day counts and history.
+
+### Decision 3: "Close-out queue" definition
+
+A capture is in the queue when **all** of:
+- Belongs to the authenticated user.
+- `Triaged == false`.
+- `ProcessingStatus` ∈ { Raw, Processing, Failed, Processed-with-no-confirm-or-discard-yet }.
+
+`Processed-with-no-confirm-or-discard-yet` is detected by a new `ExtractionResolved` flag on the Capture (set true when `ConfirmExtraction` or `DiscardExtraction` runs). Adding this flag is cheaper than re-deriving it from domain events.
+
+**EF query:** Use `List<Guid>.Contains()` for the status filter, never `HashSet.Contains()` (untranslatable). String comparisons use `.ToLower()`, never `.ToLowerInvariant()`.
+
+### Decision 4: Reassign endpoint reuses existing link/unlink methods
+
+`POST /api/daily-close-out/captures/{id}/reassign` accepts a body of `{ personIds: Guid[], initiativeIds: Guid[] }`. The handler diffs against the capture's current linked IDs and calls `LinkPerson` / `UnlinkPerson` / `LinkInitiative` / `UnlinkInitiative` on the aggregate. Avoids inventing a new "set links wholesale" method on the aggregate.
+
+### Decision 5: Frontend feature module structure
+
+`src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/`:
+- `daily-close-out.routes.ts`
+- `daily-close-out-page.component.ts/html` — main page with queue list + close-out button
+- `triage-card.component.ts/html` — per-capture card with action buttons
+- `daily-close-out.service.ts` — typed HTTP client wrapping the API
+- `daily-close-out.signals.ts` — root signal store for queue + counts
+- All control flow uses `@if` / `@for`. All colours come from PrimeNG tokens via `tailwindcss-primeui` utilities (`bg-surface-*`, `text-primary`, etc.). Signal Forms for the reassign multi-select.
+
+## Risks / Trade-offs
+
+- **[Risk] `ExtractionResolved` flag duplicates state already implicit in domain events** → Mitigation: it's a derived-but-cached flag on the aggregate; cheap to keep in sync because the only writers are `ConfirmExtraction` and `DiscardExtraction`. Worth the cost vs. event-replay queries.
+- **[Risk] User close-out date timezone confusion** → Mitigation: API takes an optional `date` query param (ISO date) and defaults to "today in UTC". Frontend passes the user's local date so what the user sees as "today" matches what gets logged. Storing `Date` as a `DateOnly` keeps it timezone-stable.
+- **[Risk] Quick-discard hides content the user later wants** → Mitigation: triaged captures are still retrievable via `GET /api/captures/{id}`; only the default list view filters them out. Existing `?triaged=true` filter could be added later if needed; out of scope here.
+- **[Risk] Owned-collection EF gotcha** → Mitigation: copy the exact configuration used for `AiProviderConfig` (snapshot change tracker, property access mode field) and add an integration test that adds two close-out logs and reloads.
+
+## Migration Plan
+
+- One EF migration: `AddDailyCloseOut`
+  - Adds `Triaged`, `TriagedAtUtc`, `ExtractionResolved` columns to `Captures`.
+  - Adds `DailyCloseOutLogs` owned-collection table referencing `Users(Id)`.
+- Backfill: existing captures default `Triaged = false`; `ExtractionResolved` set true for any capture whose status is not `Processed` (only `Processed` captures have an unresolved extraction). Single SQL `UPDATE` in the migration's `Up`.
+- Rollback: standard EF `Down`.
+
+## Open Questions
+
+None blocking. (Whether to add notifications / streak coaching is deferred to a future spec.)
+
+## Dependencies
+
+- `capture-text` (shipped)
+- `capture-ai-extraction` (shipped)
+- `user-auth-tenancy` (shipped)

--- a/openspec/changes/daily-close-out/design.md
+++ b/openspec/changes/daily-close-out/design.md
@@ -70,7 +70,7 @@ A capture is in the queue when **all** of:
 ## Risks / Trade-offs
 
 - **[Risk] `ExtractionResolved` flag duplicates state already implicit in domain events** → Mitigation: it's a derived-but-cached flag on the aggregate; cheap to keep in sync because the only writers are `ConfirmExtraction` and `DiscardExtraction`. Worth the cost vs. event-replay queries.
-- **[Risk] User close-out date timezone confusion** → Mitigation: API takes an optional `date` query param (ISO date) and defaults to "today in UTC". Frontend passes the user's local date so what the user sees as "today" matches what gets logged. Storing `Date` as a `DateOnly` keeps it timezone-stable.
+- **[Risk] User close-out date timezone confusion** → Mitigation: API takes an optional `date` field in the JSON request body (ISO date) and defaults to "today in UTC". Frontend passes the user's local date so what the user sees as "today" matches what gets logged. Storing `Date` as a `DateOnly` keeps it timezone-stable.
 - **[Risk] Quick-discard hides content the user later wants** → Mitigation: triaged captures are still retrievable via `GET /api/captures/{id}`; only the default list view filters them out. Existing `?triaged=true` filter could be added later if needed; out of scope here.
 - **[Risk] Owned-collection EF gotcha** → Mitigation: copy the exact configuration used for `AiProviderConfig` (snapshot change tracker, property access mode field) and add an integration test that adds two close-out logs and reloads.
 

--- a/openspec/changes/daily-close-out/proposal.md
+++ b/openspec/changes/daily-close-out/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Engineering managers accumulate captures throughout the day (quick notes, transcripts, meeting notes). Without a deliberate end-of-day triage flow, raw and processed-but-unconfirmed captures pile up and AI extractions go unactioned, defeating the purpose of `capture-ai-extraction`. A daily close-out ritual gives the user a focused queue to confirm/discard/reassign each pending capture and a recorded "I closed out today" timestamp so streaks and rhythm coaching can build on it later.
+
+## What Changes
+
+- New backend endpoints under `/api/daily-close-out/`:
+  - `GET /api/daily-close-out/queue` — returns the user's current close-out queue: captures with status `Raw`, `Processing`, `Failed`, or `Processed-but-not-confirmed-or-discarded`, plus aggregate counts.
+  - `POST /api/daily-close-out/captures/{id}/quick-discard` — soft-discard a capture entirely (no spawn, marks the capture as triaged/discarded).
+  - `POST /api/daily-close-out/captures/{id}/reassign` — reassign linked people/initiatives on a capture as part of triage (delegates to existing link/unlink methods on the Capture aggregate).
+  - `POST /api/daily-close-out/close` — record that the user closed out today; returns a summary (confirmed/discarded/remaining counts).
+  - `GET /api/daily-close-out/log` — list recent close-out log entries (most-recent-first, paginated/limited).
+- Domain additions on the `User` aggregate:
+  - A small `DailyCloseOutLog` owned-collection entry per user/date with `Date`, `ClosedAtUtc`, `ConfirmedCount`, `DiscardedCount`, `RemainingCount`.
+  - One `User.RecordDailyCloseOut(date, counts)` method (idempotent for the same date — overwrites the day's entry with the latest snapshot).
+- Domain additions on the `Capture` aggregate:
+  - A `Triaged` boolean (or status flag) so quick-discard can mark a capture as out-of-queue without losing its content.
+  - `Capture.QuickDiscard()` method that sets the triaged flag and raises `CaptureQuickDiscarded`.
+- Frontend Angular feature module `daily-close-out`:
+  - Triage list view at `/close-out` that shows each pending capture (PrimeNG card/list), its AI extraction summary if processed, and per-card actions: Confirm, Discard extraction, Reassign, Quick-discard.
+  - Progress indicator (X of Y triaged) and a "Close out the day" button that calls the close endpoint and shows the summary.
+  - Uses `@if`/`@for`, signals, signal forms, `tailwindcss-primeui` color tokens — no hardcoded colors, no `*ngIf`.
+
+## Capabilities
+
+### New Capabilities
+- `daily-close-out`: End-of-day triage flow over unprocessed captures with quick confirm/reassign/discard actions and a recorded close-out log per day.
+
+### Modified Capabilities
+- `capture-text`: Add a `Triaged` flag and `QuickDiscard` method on the Capture aggregate so the close-out flow can remove a capture from the queue without deleting it. List/get endpoints expose `triaged` and the list endpoint excludes triaged items by default.
+- `user-auth-tenancy`: Add `DailyCloseOutLog` owned collection on the User aggregate with `RecordDailyCloseOut` method to track close-out history.
+
+## Impact
+
+- New aggregates: none (extensions to `User` and `Capture`).
+- New domain events: `CaptureQuickDiscarded`, `DailyCloseOutRecorded`.
+- DB migration: add `Triaged` column to Captures; add `DailyCloseOutLogs` owned-collection table for the User aggregate.
+- New vertical slice handlers in `MentalMetal.Application/Features/DailyCloseOut/`.
+- New Angular feature in `src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/`.
+- Tier: 3. Depends on already-shipped Tier 2 specs `capture-text` and `capture-ai-extraction`.
+
+## Non-goals
+
+- No scheduled reminders or push notifications.
+- No weekly rollup or streak gamification (separate spec).
+- No queue prioritisation logic (covered by `my-queue`).
+- No AI re-processing inside the close-out flow (user can still trigger Process / Retry via existing capture endpoints).

--- a/openspec/changes/daily-close-out/proposal.md
+++ b/openspec/changes/daily-close-out/proposal.md
@@ -6,7 +6,7 @@ Engineering managers accumulate captures throughout the day (quick notes, transc
 
 - New backend endpoints under `/api/daily-close-out/`:
   - `GET /api/daily-close-out/queue` — returns the user's current close-out queue: captures with status `Raw`, `Processing`, `Failed`, or `Processed-but-not-confirmed-or-discarded`, plus aggregate counts.
-  - `POST /api/daily-close-out/captures/{id}/quick-discard` — soft-discard a capture entirely (no spawn, marks the capture as triaged/discarded).
+  - `POST /api/daily-close-out/captures/{id}/quick-discard` — remove a capture from the queue without processing its extraction. Implemented by marking the capture `Triaged = true` (the same flag set by any confirm/discard action); the "discard" in the name refers to the user intent ("skip this one") and the domain event (`CaptureQuickDiscarded`), not a separate storage state.
   - `POST /api/daily-close-out/captures/{id}/reassign` — reassign linked people/initiatives on a capture as part of triage (delegates to existing link/unlink methods on the Capture aggregate).
   - `POST /api/daily-close-out/close` — record that the user closed out today; returns a summary (confirmed/discarded/remaining counts).
   - `GET /api/daily-close-out/log` — list recent close-out log entries (most-recent-first, paginated/limited).

--- a/openspec/changes/daily-close-out/specs/capture-text/spec.md
+++ b/openspec/changes/daily-close-out/specs/capture-text/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Capture triage flag
+
+The Capture aggregate SHALL expose a boolean `Triaged` flag (default false) and a nullable `TriagedAtUtc` timestamp. The aggregate SHALL provide a `QuickDiscard()` method that, when called on a non-triaged capture, sets `Triaged = true`, sets `TriagedAtUtc = DateTime.UtcNow`, and raises a `CaptureQuickDiscarded` domain event. Calling `QuickDiscard()` on an already-triaged capture SHALL be a no-op (idempotent, no second event raised).
+
+#### Scenario: Quick-discard a non-triaged capture
+
+- **WHEN** QuickDiscard() is called on a Capture where Triaged is false
+- **THEN** Triaged is set to true, TriagedAtUtc is set to the current UTC time, and a CaptureQuickDiscarded event is raised
+
+#### Scenario: Quick-discard idempotent
+
+- **WHEN** QuickDiscard() is called on a Capture where Triaged is already true
+- **THEN** the aggregate state is unchanged and no event is raised
+
+### Requirement: Capture extraction-resolved flag
+
+The Capture aggregate SHALL expose a boolean `ExtractionResolved` flag (default false) that is set to true when `ConfirmExtraction()` or `DiscardExtraction()` is called, and remains false otherwise. The flag SHALL be persisted on the Captures table.
+
+#### Scenario: Confirming extraction sets flag
+
+- **WHEN** ConfirmExtraction() is called on a Processed capture
+- **THEN** ExtractionResolved is true after the call
+
+#### Scenario: Discarding extraction sets flag
+
+- **WHEN** DiscardExtraction() is called on a Processed capture
+- **THEN** ExtractionResolved is true after the call
+
+#### Scenario: Flag false on Raw / Processing / Failed
+
+- **WHEN** a Capture has status Raw, Processing, or Failed
+- **THEN** ExtractionResolved is false
+
+## MODIFIED Requirements
+
+### Requirement: List captures
+
+The system SHALL allow an authenticated user to retrieve a paginated list of their captures, ordered by CapturedAt descending (newest first). The list SHALL support optional filtering by capture type and processing status. By default, captures with `Triaged = true` SHALL be excluded from the list. An optional `includeTriaged=true` query parameter SHALL include them.
+
+#### Scenario: List all captures
+
+- **WHEN** an authenticated user sends a GET to `/api/captures`
+- **THEN** the system returns all non-triaged captures belonging to that user, ordered by CapturedAt descending
+
+#### Scenario: Filter by type
+
+- **WHEN** an authenticated user sends a GET to `/api/captures?type=Transcript`
+- **THEN** the system returns only non-triaged captures with type Transcript
+
+#### Scenario: Filter by status
+
+- **WHEN** an authenticated user sends a GET to `/api/captures?status=Raw`
+- **THEN** the system returns only non-triaged captures with status Raw
+
+#### Scenario: Include triaged
+
+- **WHEN** an authenticated user sends a GET to `/api/captures?includeTriaged=true`
+- **THEN** the system returns all of the user's captures including triaged ones
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no captures sends a GET to `/api/captures`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get capture by ID
+
+The system SHALL allow an authenticated user to retrieve a single capture by ID, including all linked IDs and metadata. The response SHALL include the `triaged`, `triagedAtUtc`, and `extractionResolved` fields. Triaged captures SHALL still be retrievable by ID.
+
+#### Scenario: Get existing capture
+
+- **WHEN** an authenticated user sends a GET to `/api/captures/{id}` with a valid capture ID belonging to them
+- **THEN** the system returns the capture with all fields including linkedPersonIds, linkedInitiativeIds, title, source, processing status, triaged, triagedAtUtc, and extractionResolved
+
+#### Scenario: Get triaged capture by ID
+
+- **WHEN** an authenticated user sends a GET to `/api/captures/{id}` for a triaged capture
+- **THEN** the system returns the capture with triaged = true
+
+#### Scenario: Capture not found
+
+- **WHEN** an authenticated user sends a GET to `/api/captures/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404

--- a/openspec/changes/daily-close-out/specs/daily-close-out/spec.md
+++ b/openspec/changes/daily-close-out/specs/daily-close-out/spec.md
@@ -1,0 +1,173 @@
+## ADDED Requirements
+
+### Requirement: Get the close-out queue
+
+The system SHALL expose `GET /api/daily-close-out/queue` returning the authenticated user's pending-triage captures and aggregate counts. A capture is in the queue when it belongs to the user, is not triaged, and is in one of: status `Raw`, `Processing`, `Failed`, or `Processed` with extraction not yet resolved (neither confirmed nor discarded). The response SHALL include an array of queue items (each with capture id, title, type, processing status, captured-at, and the AI extraction summary if processed) and counts grouped by `raw`, `processing`, `failed`, `processedPendingResolution`, and `total`. The list SHALL be ordered by CapturedAt descending.
+
+#### Scenario: Queue with mixed statuses
+
+- **WHEN** an authenticated user with one Raw capture, one Failed capture, and one Processed-but-unresolved capture sends GET /api/daily-close-out/queue
+- **THEN** the response includes all three captures and counts { raw: 1, processing: 0, failed: 1, processedPendingResolution: 1, total: 3 }
+
+#### Scenario: Triaged captures excluded
+
+- **WHEN** an authenticated user has one capture marked Triaged and one Raw capture
+- **THEN** the queue response includes only the Raw capture
+
+#### Scenario: Confirmed-or-discarded extractions excluded
+
+- **WHEN** an authenticated user has a Processed capture whose extraction was confirmed
+- **THEN** the queue response does not include that capture
+
+#### Scenario: Empty queue
+
+- **WHEN** an authenticated user with no pending captures sends GET /api/daily-close-out/queue
+- **THEN** the system returns an empty items array and all counts equal zero
+
+#### Scenario: User isolation
+
+- **WHEN** User A and User B each have pending captures
+- **THEN** each user's queue contains only their own captures
+
+### Requirement: Quick-discard a capture
+
+The system SHALL expose `POST /api/daily-close-out/captures/{id}/quick-discard` that calls `Capture.QuickDiscard()` on the aggregate, marking the capture as triaged with TriagedAtUtc set to now, and raising a `CaptureQuickDiscarded` domain event. The capture SHALL no longer appear in the close-out queue. The endpoint SHALL be idempotent: calling it on an already-triaged capture returns HTTP 200 without error.
+
+#### Scenario: Quick-discard a raw capture
+
+- **WHEN** an authenticated user POSTs to /api/daily-close-out/captures/{id}/quick-discard for a Raw capture
+- **THEN** the capture is marked Triaged with TriagedAtUtc set, a CaptureQuickDiscarded event is raised, and the system returns HTTP 200
+
+#### Scenario: Quick-discard already-triaged capture
+
+- **WHEN** an authenticated user POSTs quick-discard on a capture that is already triaged
+- **THEN** the system returns HTTP 200 and does not raise a duplicate event
+
+#### Scenario: Quick-discard not-found
+
+- **WHEN** an authenticated user POSTs quick-discard for a capture id that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Reassign capture links during triage
+
+The system SHALL expose `POST /api/daily-close-out/captures/{id}/reassign` accepting `{ personIds: Guid[], initiativeIds: Guid[] }`. The handler SHALL diff the supplied IDs against the capture's current `LinkedPersonIds` and `LinkedInitiativeIds` and call the existing `LinkPerson`, `UnlinkPerson`, `LinkInitiative`, `UnlinkInitiative` methods on the Capture aggregate to converge to the supplied set. The response SHALL be HTTP 200 with the updated capture summary.
+
+#### Scenario: Add and remove links in one call
+
+- **WHEN** an authenticated user reassigns a capture currently linked to PersonA and InitiativeX, sending personIds [PersonB] and initiativeIds [InitiativeX, InitiativeY]
+- **THEN** the capture is unlinked from PersonA, linked to PersonB, kept linked to InitiativeX, and linked to InitiativeY
+
+#### Scenario: Reassign with empty arrays clears links
+
+- **WHEN** an authenticated user reassigns a capture with personIds [] and initiativeIds []
+- **THEN** the capture has no linked people or initiatives
+
+#### Scenario: Reassign not-found
+
+- **WHEN** an authenticated user reassigns a capture id that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404
+
+#### Scenario: Reassign with unknown person id
+
+- **WHEN** an authenticated user reassigns a capture with a personId that does not match any of their People
+- **THEN** the system returns HTTP 400 with a validation error and no changes are persisted
+
+### Requirement: Record daily close-out
+
+The system SHALL expose `POST /api/daily-close-out/close` accepting an optional `{ date: ISODate }` body (defaulting to today in UTC) that calls `User.RecordDailyCloseOut(date, counts)` where counts are computed at the time of the call: confirmed = number of triaged captures whose extraction was confirmed today, discarded = number of triaged-via-quick-discard or extraction-discarded captures today, remaining = current queue size. The response SHALL be HTTP 200 with the recorded log entry. Calling close twice for the same date SHALL overwrite the prior entry (idempotent).
+
+#### Scenario: First close-out of the day
+
+- **WHEN** an authenticated user POSTs /api/daily-close-out/close with no body and the queue has 0 remaining items
+- **THEN** the system records a DailyCloseOutLog for today with computed counts and returns HTTP 200 with the entry
+
+#### Scenario: Close-out twice in one day
+
+- **WHEN** an authenticated user POSTs close, triages another capture, then POSTs close again on the same day
+- **THEN** the second call overwrites the day's log entry with the latest counts and ClosedAtUtc
+
+#### Scenario: Close-out with explicit date
+
+- **WHEN** an authenticated user POSTs close with body { date: "2026-04-13" }
+- **THEN** the log entry is recorded against 2026-04-13
+
+#### Scenario: User isolation
+
+- **WHEN** User A closes out their day
+- **THEN** User B's close-out log is unaffected
+
+### Requirement: Get close-out log history
+
+The system SHALL expose `GET /api/daily-close-out/log?limit=N` returning the authenticated user's most recent close-out log entries ordered by Date descending. Default limit is 30, max 90. Each entry SHALL include date, closedAtUtc, confirmedCount, discardedCount, and remainingCount.
+
+#### Scenario: List recent close-outs
+
+- **WHEN** an authenticated user with five close-out log entries sends GET /api/daily-close-out/log
+- **THEN** the system returns all five entries ordered newest-date first
+
+#### Scenario: Limit parameter
+
+- **WHEN** an authenticated user sends GET /api/daily-close-out/log?limit=2 and has five entries
+- **THEN** the system returns the two newest entries
+
+#### Scenario: Limit clamped to maximum
+
+- **WHEN** an authenticated user sends GET /api/daily-close-out/log?limit=500
+- **THEN** the system returns at most 90 entries
+
+#### Scenario: Empty log
+
+- **WHEN** an authenticated user who has never closed out sends GET /api/daily-close-out/log
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Triage UI page
+
+The frontend SHALL provide a `/close-out` route rendering a page that shows the close-out queue. Each queue item SHALL be rendered as a PrimeNG card showing the capture's title (or first line of content), type, processing-status badge, captured-at timestamp, and — when extraction is available — the AI summary plus extracted-item counts (commitments, delegations, observations). Each card SHALL expose action buttons: Confirm extraction (visible only when extraction is unresolved Processed), Discard extraction (same visibility), Reassign, Quick-discard. The page SHALL use `@if` and `@for` control flow, signals for state, and PrimeNG/`tailwindcss-primeui` colour tokens only — no `*ngIf`, no `*ngFor`, no hardcoded Tailwind colour utilities, no `dark:` prefixes.
+
+#### Scenario: Render queue with mixed items
+
+- **WHEN** the user navigates to /close-out and the queue has three items
+- **THEN** the page renders three cards in CapturedAt-descending order with the appropriate action buttons per item state
+
+#### Scenario: Empty-state
+
+- **WHEN** the user navigates to /close-out and the queue is empty
+- **THEN** the page shows an empty-state message inviting the user to close out the day
+
+#### Scenario: Confirm extraction from card
+
+- **WHEN** the user clicks Confirm on a Processed-pending-resolution card
+- **THEN** the frontend calls POST /api/captures/{id}/confirm-extraction, removes the card from the queue on success, and updates the progress indicator
+
+#### Scenario: Quick-discard from card
+
+- **WHEN** the user clicks Quick-discard on any card
+- **THEN** the frontend calls POST /api/daily-close-out/captures/{id}/quick-discard, removes the card from the queue on success, and updates the progress indicator
+
+### Requirement: Close-out the day action
+
+The frontend close-out page SHALL provide a "Close out the day" button that calls `POST /api/daily-close-out/close` and displays the returned summary (confirmed, discarded, remaining counts) in a PrimeNG dialog or toast. The button SHALL be enabled regardless of remaining queue size.
+
+#### Scenario: Close out with empty queue
+
+- **WHEN** the user clicks "Close out the day" and the queue is empty
+- **THEN** the frontend calls the close endpoint and displays a summary showing remaining: 0
+
+#### Scenario: Close out with items still in queue
+
+- **WHEN** the user clicks "Close out the day" while three items remain
+- **THEN** the frontend calls the close endpoint and displays a summary showing remaining: 3, with the items still visible on the page
+
+### Requirement: Reassign UI dialog
+
+The frontend SHALL provide a reassign dialog opened from the Reassign action button on a triage card. The dialog SHALL render a multi-select for People and a multi-select for Initiatives (both populated from the user's existing data) using PrimeNG and Signal Forms. Submitting the dialog SHALL call `POST /api/daily-close-out/captures/{id}/reassign` with the selected IDs and update the card on success.
+
+#### Scenario: Open and submit reassign dialog
+
+- **WHEN** the user opens the reassign dialog, selects two people and one initiative, and submits
+- **THEN** the frontend calls the reassign endpoint with those IDs and the card updates to show the new links
+
+#### Scenario: Cancel reassign dialog
+
+- **WHEN** the user opens the reassign dialog and clicks cancel
+- **THEN** no API call is made and the card is unchanged

--- a/openspec/changes/daily-close-out/specs/user-auth-tenancy/spec.md
+++ b/openspec/changes/daily-close-out/specs/user-auth-tenancy/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: User aggregate supports daily close-out log
+
+The `User` aggregate SHALL expose an owned collection `DailyCloseOutLogs` of `DailyCloseOutLog` entries. Each entry SHALL contain `Date` (DateOnly, unique per user), `ClosedAtUtc` (DateTime), `ConfirmedCount` (int), `DiscardedCount` (int), and `RemainingCount` (int). The aggregate SHALL provide a `RecordDailyCloseOut(DateOnly date, int confirmed, int discarded, int remaining)` method that creates or overwrites the entry for the given date with the supplied counts and `ClosedAtUtc = DateTime.UtcNow`, and raises a `DailyCloseOutRecorded` domain event. The aggregate SHALL provide a read-only accessor `IReadOnlyList<DailyCloseOutLog> DailyCloseOutLogs` and a `GetCloseOutLog(DateOnly date)` lookup. Counts MUST be non-negative.
+
+#### Scenario: Record close-out for a new date
+
+- **WHEN** RecordDailyCloseOut(date: 2026-04-14, confirmed: 3, discarded: 1, remaining: 0) is called on a User with no prior log entry for that date
+- **THEN** a new DailyCloseOutLog entry is added with the supplied counts and ClosedAtUtc set to now, and a DailyCloseOutRecorded event is raised
+
+#### Scenario: Idempotent overwrite for the same date
+
+- **WHEN** RecordDailyCloseOut is called twice for the same date with different counts
+- **THEN** the existing entry's counts and ClosedAtUtc are overwritten with the latest values, and only one entry exists for that date
+
+#### Scenario: Negative count rejected
+
+- **WHEN** RecordDailyCloseOut is called with a negative confirmed, discarded, or remaining count
+- **THEN** the method throws a domain validation exception and no entry is created
+
+#### Scenario: Logs scoped to user
+
+- **WHEN** User A and User B each record close-outs for the same date
+- **THEN** each user's DailyCloseOutLogs collection contains only their own entry
+
+### Requirement: User profile response includes most-recent close-out
+
+The `GET /api/me` endpoint response SHALL include a `lastCloseOutAtUtc` field set to the `ClosedAtUtc` of the most-recent `DailyCloseOutLog` entry, or null if the user has never closed out.
+
+#### Scenario: User has prior close-outs
+
+- **WHEN** an authenticated user with at least one DailyCloseOutLog entry sends GET /api/me
+- **THEN** the response includes lastCloseOutAtUtc equal to the most-recent entry's ClosedAtUtc
+
+#### Scenario: User has never closed out
+
+- **WHEN** an authenticated user with no DailyCloseOutLog entries sends GET /api/me
+- **THEN** the response includes lastCloseOutAtUtc as null

--- a/openspec/changes/daily-close-out/tasks.md
+++ b/openspec/changes/daily-close-out/tasks.md
@@ -1,0 +1,82 @@
+## 1. Domain — Capture aggregate
+
+- [ ] 1.1 Add `Triaged` (bool) and `TriagedAtUtc` (DateTime?) properties to `Capture`
+- [ ] 1.2 Add `ExtractionResolved` (bool) property to `Capture`; set true in existing `ConfirmExtraction()` and `DiscardExtraction()` methods
+- [ ] 1.3 Add `Capture.QuickDiscard()` method (idempotent) raising `CaptureQuickDiscarded` domain event
+- [ ] 1.4 Add `CaptureQuickDiscarded` domain event record
+- [ ] 1.5 Unit tests: QuickDiscard on non-triaged sets flags + raises event; QuickDiscard on already-triaged is no-op; Confirm/Discard set ExtractionResolved
+
+## 2. Domain — User aggregate
+
+- [ ] 2.1 Add `DailyCloseOutLog` owned entity (Date DateOnly, ClosedAtUtc, ConfirmedCount, DiscardedCount, RemainingCount)
+- [ ] 2.2 Add `DailyCloseOutLogs` owned-collection backing field on `User` with read-only accessor
+- [ ] 2.3 Add `User.RecordDailyCloseOut(date, confirmed, discarded, remaining)` method (idempotent overwrite, validates non-negative counts)
+- [ ] 2.4 Add `User.GetCloseOutLog(DateOnly date)` lookup method
+- [ ] 2.5 Add `DailyCloseOutRecorded` domain event record
+- [ ] 2.6 Unit tests: new-date append; same-date overwrite; negative count throws; multi-user isolation
+
+## 3. Infrastructure — EF Core
+
+- [ ] 3.1 Update `CaptureConfiguration` to map `Triaged`, `TriagedAtUtc`, `ExtractionResolved`
+- [ ] 3.2 Add `DailyCloseOutLogConfiguration` as owned-collection of `User` (mirror `AiProviderConfig` pattern: snapshot change tracker, `PropertyAccessMode.Field`)
+- [ ] 3.3 Generate EF migration `AddDailyCloseOut` adding columns + table; backfill `ExtractionResolved = (status != Processed)` for existing captures
+- [ ] 3.4 Verify migration runs cleanly on the dev database
+
+## 4. Application — vertical slices
+
+- [ ] 4.1 Create `Application/Features/DailyCloseOut/` folder
+- [ ] 4.2 `GetCloseOutQueue` query handler — returns queue items + counts, filters Triaged=false and (status in {Raw,Processing,Failed} or (Processed && !ExtractionResolved)), uses `List<T>.Contains` not `HashSet`
+- [ ] 4.3 `QuickDiscardCapture` command handler — loads capture, calls `QuickDiscard`, persists, returns 200/404
+- [ ] 4.4 `ReassignCapture` command handler — diffs supplied IDs vs current links, calls `Link/Unlink Person/Initiative`, validates referenced person/initiative IDs belong to user
+- [ ] 4.5 `CloseOutDay` command handler — computes today's counts (confirmed/discarded/remaining), calls `User.RecordDailyCloseOut`, persists, returns log entry
+- [ ] 4.6 `GetCloseOutLog` query handler — reads `DailyCloseOutLogs`, applies limit (default 30, max 90), descending date
+- [ ] 4.7 DTOs in the same folder (`CloseOutQueueResponse`, `CloseOutQueueItem`, `ReassignCaptureRequest`, `CloseOutDayRequest`, `DailyCloseOutLogDto`)
+
+## 5. Web — minimal API endpoints
+
+- [ ] 5.1 Add `DailyCloseOutEndpoints.MapDailyCloseOutEndpoints(this IEndpointRouteBuilder)` extension
+- [ ] 5.2 Wire `GET /api/daily-close-out/queue`
+- [ ] 5.3 Wire `POST /api/daily-close-out/captures/{id}/quick-discard`
+- [ ] 5.4 Wire `POST /api/daily-close-out/captures/{id}/reassign`
+- [ ] 5.5 Wire `POST /api/daily-close-out/close`
+- [ ] 5.6 Wire `GET /api/daily-close-out/log`
+- [ ] 5.7 Register endpoints in `Program.cs`
+
+## 6. Web — modify capture endpoints
+
+- [ ] 6.1 Update `ListCaptures` query/handler to filter `Triaged = false` by default and accept `includeTriaged=true`
+- [ ] 6.2 Update capture detail DTO to expose `triaged`, `triagedAtUtc`, `extractionResolved`
+- [ ] 6.3 Update `GetCurrentUser` (`/api/me`) response to include `lastCloseOutAtUtc` (max of `DailyCloseOutLogs.ClosedAtUtc` or null)
+
+## 7. Web.IntegrationTests
+
+- [ ] 7.1 GetCloseOutQueue: mixed-status user returns expected items + counts; user isolation
+- [ ] 7.2 QuickDiscard endpoint: 200 + capture excluded from queue; idempotent; 404 for foreign capture
+- [ ] 7.3 Reassign endpoint: add/remove links converge; empty arrays clear; 400 for unknown person id
+- [ ] 7.4 CloseOutDay endpoint: first-call records entry; second-call same date overwrites; explicit date param works
+- [ ] 7.5 GetCloseOutLog endpoint: ordering, limit clamping, empty case
+- [ ] 7.6 ListCaptures default-excludes triaged; `includeTriaged=true` includes them
+- [ ] 7.7 GetCurrentUser includes `lastCloseOutAtUtc` after a recorded close-out
+
+## 8. Frontend — feature module
+
+- [ ] 8.1 Create `src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/` folder
+- [ ] 8.2 `daily-close-out.routes.ts` exporting `/close-out` route
+- [ ] 8.3 `daily-close-out.service.ts` with typed methods for all 5 endpoints
+- [ ] 8.4 `daily-close-out.signals.ts` — root signal store (queue, counts, isLoading, lastSummary)
+- [ ] 8.5 `daily-close-out-page.component.ts/html` — page shell with header, progress indicator, queue list, "Close out the day" button, summary toast/dialog
+- [ ] 8.6 `triage-card.component.ts/html` — per-capture card with action buttons (Confirm/Discard/Reassign/Quick-discard); uses `@if`/`@for`, signals, `tailwindcss-primeui` colour utilities only
+- [ ] 8.7 `reassign-dialog.component.ts/html` — PrimeNG dialog with people + initiative multi-selects (Signal Forms)
+- [ ] 8.8 Wire route into the app router and add nav item to the side menu
+
+## 9. Frontend — tests
+
+- [ ] 9.1 `daily-close-out-page.component.spec.ts` — renders queue, empty state, progress count
+- [ ] 9.2 `triage-card.component.spec.ts` — emits the right action; hides Confirm/Discard for non-Processed captures
+- [ ] 9.3 `daily-close-out.service.spec.ts` — verifies HTTP shapes for all 5 endpoints
+
+## 10. Verification
+
+- [ ] 10.1 `dotnet test src/MentalMetal.slnx` — all green
+- [ ] 10.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — all green
+- [ ] 10.3 Manually run `openspec validate daily-close-out --strict`


### PR DESCRIPTION
## Summary

Tier 3 OpenSpec proposal for the `daily-close-out` capability — an end-of-day triage flow over unprocessed captures with quick confirm/reassign/discard actions and a recorded close-out log per day. Docs only — no implementation in this PR.

**Spec**: [daily-close-out](openspec/changes/daily-close-out/specs/daily-close-out/spec.md)

## Changes

- `proposal.md`, `design.md`, `tasks.md` for `daily-close-out`
- New capability spec: `daily-close-out` (queue, quick-discard, reassign, close, log endpoints + UI)
- Modified `capture-text`: `Triaged` + `ExtractionResolved` flags, `QuickDiscard()` method, default-exclude triaged from list
- Modified `user-auth-tenancy`: `DailyCloseOutLogs` owned collection on `User` with `RecordDailyCloseOut`; `lastCloseOutAtUtc` on `/api/me`

Depends on already-shipped `capture-text` and `capture-ai-extraction` (Tier 2).

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (493 tests)
- [x] `openspec validate daily-close-out --strict` passes
- [ ] CI green

---
Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an OpenSpec Tier 3 proposal defining a daily close-out triage capability over captures, including backend API, domain model, and frontend UI requirements, plus related capture and user model extensions.

New Features:
- Specify a new daily close-out capability that provides a per-user triage queue, quick-discard and reassign actions, daily close logging, and a dedicated Angular close-out page and dialogs.

Enhancements:
- Extend the capture-text spec with triage and extraction-resolved flags, quick-discard behaviour, and updated listing/getting rules for triaged captures.
- Extend the user-auth-tenancy spec with a per-user DailyCloseOutLog owned collection, close-out recording behaviour, and exposure of the most recent close-out timestamp via /api/me.
- Document implementation tasks, design decisions, and OpenSpec metadata for the daily-close-out capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced daily close-out workflow enabling end-of-day triage coordination
  * Added new `/close-out` page displaying pending captures organized by status
  * Enabled quick-discard and reassignment operations during triage review
  * Added close-out recording with triage count summaries (confirmed, discarded, remaining)
  * Updated capture listing to exclude triaged items by default with optional filtering
  * Added close-out history logs with recent activity tracking

* **Documentation**
  * Added comprehensive design specifications and API contracts for the feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->