### PR TITLE
feat: implement daily-close-out (Tier 3)

### DIFF
--- a/openspec/changes/daily-close-out/tasks.md
+++ b/openspec/changes/daily-close-out/tasks.md
@@ -1,82 +1,82 @@
 ## 1. Domain — Capture aggregate
 
-- [ ] 1.1 Add `Triaged` (bool) and `TriagedAtUtc` (DateTime?) properties to `Capture`
-- [ ] 1.2 Add `ExtractionResolved` (bool) property to `Capture`; set true in existing `ConfirmExtraction()` and `DiscardExtraction()` methods
-- [ ] 1.3 Add `Capture.QuickDiscard()` method (idempotent) raising `CaptureQuickDiscarded` domain event
-- [ ] 1.4 Add `CaptureQuickDiscarded` domain event record
-- [ ] 1.5 Unit tests: QuickDiscard on non-triaged sets flags + raises event; QuickDiscard on already-triaged is no-op; Confirm/Discard set ExtractionResolved
+- [x] 1.1 Add `Triaged` (bool) and `TriagedAtUtc` (DateTime?) properties to `Capture`
+- [x] 1.2 Add `ExtractionResolved` (bool) property to `Capture`; set true in existing `ConfirmExtraction()` and `DiscardExtraction()` methods
+- [x] 1.3 Add `Capture.QuickDiscard()` method (idempotent) raising `CaptureQuickDiscarded` domain event
+- [x] 1.4 Add `CaptureQuickDiscarded` domain event record
+- [x] 1.5 Unit tests: QuickDiscard on non-triaged sets flags + raises event; QuickDiscard on already-triaged is no-op; Confirm/Discard set ExtractionResolved
 
 ## 2. Domain — User aggregate
 
-- [ ] 2.1 Add `DailyCloseOutLog` owned entity (Date DateOnly, ClosedAtUtc, ConfirmedCount, DiscardedCount, RemainingCount)
-- [ ] 2.2 Add `DailyCloseOutLogs` owned-collection backing field on `User` with read-only accessor
-- [ ] 2.3 Add `User.RecordDailyCloseOut(date, confirmed, discarded, remaining)` method (idempotent overwrite, validates non-negative counts)
-- [ ] 2.4 Add `User.GetCloseOutLog(DateOnly date)` lookup method
-- [ ] 2.5 Add `DailyCloseOutRecorded` domain event record
-- [ ] 2.6 Unit tests: new-date append; same-date overwrite; negative count throws; multi-user isolation
+- [x] 2.1 Add `DailyCloseOutLog` owned entity (Date DateOnly, ClosedAtUtc, ConfirmedCount, DiscardedCount, RemainingCount)
+- [x] 2.2 Add `DailyCloseOutLogs` owned-collection backing field on `User` with read-only accessor
+- [x] 2.3 Add `User.RecordDailyCloseOut(date, confirmed, discarded, remaining)` method (idempotent overwrite, validates non-negative counts)
+- [x] 2.4 Add `User.GetCloseOutLog(DateOnly date)` lookup method
+- [x] 2.5 Add `DailyCloseOutRecorded` domain event record
+- [x] 2.6 Unit tests: new-date append; same-date overwrite; negative count throws; multi-user isolation
 
 ## 3. Infrastructure — EF Core
 
-- [ ] 3.1 Update `CaptureConfiguration` to map `Triaged`, `TriagedAtUtc`, `ExtractionResolved`
-- [ ] 3.2 Add `DailyCloseOutLogConfiguration` as owned-collection of `User` (mirror `AiProviderConfig` pattern: snapshot change tracker, `PropertyAccessMode.Field`)
-- [ ] 3.3 Generate EF migration `AddDailyCloseOut` adding columns + table; backfill `ExtractionResolved = (status != Processed)` for existing captures
-- [ ] 3.4 Verify migration runs cleanly on the dev database
+- [x] 3.1 Update `CaptureConfiguration` to map `Triaged`, `TriagedAtUtc`, `ExtractionResolved`
+- [x] 3.2 Add `DailyCloseOutLogConfiguration` as owned-collection of `User` (mirror `AiProviderConfig` pattern: snapshot change tracker, `PropertyAccessMode.Field`)
+- [x] 3.3 Generate EF migration `AddDailyCloseOut` adding columns + table; backfill `ExtractionResolved = (status != Processed)` for existing captures
+- [x] 3.4 Verify migration runs cleanly on the dev database
 
 ## 4. Application — vertical slices
 
-- [ ] 4.1 Create `Application/Features/DailyCloseOut/` folder
-- [ ] 4.2 `GetCloseOutQueue` query handler — returns queue items + counts, filters Triaged=false and (status in {Raw,Processing,Failed} or (Processed && !ExtractionResolved)), uses `List<T>.Contains` not `HashSet`
-- [ ] 4.3 `QuickDiscardCapture` command handler — loads capture, calls `QuickDiscard`, persists, returns 200/404
-- [ ] 4.4 `ReassignCapture` command handler — diffs supplied IDs vs current links, calls `Link/Unlink Person/Initiative`, validates referenced person/initiative IDs belong to user
-- [ ] 4.5 `CloseOutDay` command handler — computes today's counts (confirmed/discarded/remaining), calls `User.RecordDailyCloseOut`, persists, returns log entry
-- [ ] 4.6 `GetCloseOutLog` query handler — reads `DailyCloseOutLogs`, applies limit (default 30, max 90), descending date
-- [ ] 4.7 DTOs in the same folder (`CloseOutQueueResponse`, `CloseOutQueueItem`, `ReassignCaptureRequest`, `CloseOutDayRequest`, `DailyCloseOutLogDto`)
+- [x] 4.1 Create `Application/Features/DailyCloseOut/` folder
+- [x] 4.2 `GetCloseOutQueue` query handler — returns queue items + counts, filters Triaged=false and (status in {Raw,Processing,Failed} or (Processed && !ExtractionResolved)), uses `List<T>.Contains` not `HashSet`
+- [x] 4.3 `QuickDiscardCapture` command handler — loads capture, calls `QuickDiscard`, persists, returns 200/404
+- [x] 4.4 `ReassignCapture` command handler — diffs supplied IDs vs current links, calls `Link/Unlink Person/Initiative`, validates referenced person/initiative IDs belong to user
+- [x] 4.5 `CloseOutDay` command handler — computes today's counts (confirmed/discarded/remaining), calls `User.RecordDailyCloseOut`, persists, returns log entry
+- [x] 4.6 `GetCloseOutLog` query handler — reads `DailyCloseOutLogs`, applies limit (default 30, max 90), descending date
+- [x] 4.7 DTOs in the same folder (`CloseOutQueueResponse`, `CloseOutQueueItem`, `ReassignCaptureRequest`, `CloseOutDayRequest`, `DailyCloseOutLogDto`)
 
 ## 5. Web — minimal API endpoints
 
-- [ ] 5.1 Add `DailyCloseOutEndpoints.MapDailyCloseOutEndpoints(this IEndpointRouteBuilder)` extension
-- [ ] 5.2 Wire `GET /api/daily-close-out/queue`
-- [ ] 5.3 Wire `POST /api/daily-close-out/captures/{id}/quick-discard`
-- [ ] 5.4 Wire `POST /api/daily-close-out/captures/{id}/reassign`
-- [ ] 5.5 Wire `POST /api/daily-close-out/close`
-- [ ] 5.6 Wire `GET /api/daily-close-out/log`
-- [ ] 5.7 Register endpoints in `Program.cs`
+- [x] 5.1 Add `DailyCloseOutEndpoints.MapDailyCloseOutEndpoints(this IEndpointRouteBuilder)` extension
+- [x] 5.2 Wire `GET /api/daily-close-out/queue`
+- [x] 5.3 Wire `POST /api/daily-close-out/captures/{id}/quick-discard`
+- [x] 5.4 Wire `POST /api/daily-close-out/captures/{id}/reassign`
+- [x] 5.5 Wire `POST /api/daily-close-out/close`
+- [x] 5.6 Wire `GET /api/daily-close-out/log`
+- [x] 5.7 Register endpoints in `Program.cs`
 
 ## 6. Web — modify capture endpoints
 
-- [ ] 6.1 Update `ListCaptures` query/handler to filter `Triaged = false` by default and accept `includeTriaged=true`
-- [ ] 6.2 Update capture detail DTO to expose `triaged`, `triagedAtUtc`, `extractionResolved`
-- [ ] 6.3 Update `GetCurrentUser` (`/api/me`) response to include `lastCloseOutAtUtc` (max of `DailyCloseOutLogs.ClosedAtUtc` or null)
+- [x] 6.1 Update `ListCaptures` query/handler to filter `Triaged = false` by default and accept `includeTriaged=true`
+- [x] 6.2 Update capture detail DTO to expose `triaged`, `triagedAtUtc`, `extractionResolved`
+- [x] 6.3 Update `GetCurrentUser` (`/api/me`) response to include `lastCloseOutAtUtc` (max of `DailyCloseOutLogs.ClosedAtUtc` or null)
 
 ## 7. Web.IntegrationTests
 
-- [ ] 7.1 GetCloseOutQueue: mixed-status user returns expected items + counts; user isolation
-- [ ] 7.2 QuickDiscard endpoint: 200 + capture excluded from queue; idempotent; 404 for foreign capture
-- [ ] 7.3 Reassign endpoint: add/remove links converge; empty arrays clear; 400 for unknown person id
-- [ ] 7.4 CloseOutDay endpoint: first-call records entry; second-call same date overwrites; explicit date param works
-- [ ] 7.5 GetCloseOutLog endpoint: ordering, limit clamping, empty case
-- [ ] 7.6 ListCaptures default-excludes triaged; `includeTriaged=true` includes them
-- [ ] 7.7 GetCurrentUser includes `lastCloseOutAtUtc` after a recorded close-out
+- [x] 7.1 GetCloseOutQueue: mixed-status user returns expected items + counts; user isolation
+- [x] 7.2 QuickDiscard endpoint: 200 + capture excluded from queue; idempotent; 404 for foreign capture
+- [x] 7.3 Reassign endpoint: add/remove links converge; empty arrays clear; 400 for unknown person id
+- [x] 7.4 CloseOutDay endpoint: first-call records entry; second-call same date overwrites; explicit date param works
+- [x] 7.5 GetCloseOutLog endpoint: ordering, limit clamping, empty case
+- [x] 7.6 ListCaptures default-excludes triaged; `includeTriaged=true` includes them
+- [x] 7.7 GetCurrentUser includes `lastCloseOutAtUtc` after a recorded close-out
 
 ## 8. Frontend — feature module
 
-- [ ] 8.1 Create `src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/` folder
-- [ ] 8.2 `daily-close-out.routes.ts` exporting `/close-out` route
-- [ ] 8.3 `daily-close-out.service.ts` with typed methods for all 5 endpoints
-- [ ] 8.4 `daily-close-out.signals.ts` — root signal store (queue, counts, isLoading, lastSummary)
-- [ ] 8.5 `daily-close-out-page.component.ts/html` — page shell with header, progress indicator, queue list, "Close out the day" button, summary toast/dialog
-- [ ] 8.6 `triage-card.component.ts/html` — per-capture card with action buttons (Confirm/Discard/Reassign/Quick-discard); uses `@if`/`@for`, signals, `tailwindcss-primeui` colour utilities only
-- [ ] 8.7 `reassign-dialog.component.ts/html` — PrimeNG dialog with people + initiative multi-selects (Signal Forms)
-- [ ] 8.8 Wire route into the app router and add nav item to the side menu
+- [x] 8.1 Create `src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/` folder
+- [x] 8.2 `daily-close-out.routes.ts` exporting `/close-out` route
+- [x] 8.3 `daily-close-out.service.ts` with typed methods for all 5 endpoints
+- [x] 8.4 `daily-close-out.signals.ts` — root signal store (queue, counts, isLoading, lastSummary)
+- [x] 8.5 `daily-close-out-page.component.ts/html` — page shell with header, progress indicator, queue list, "Close out the day" button, summary toast/dialog
+- [x] 8.6 `triage-card.component.ts/html` — per-capture card with action buttons (Confirm/Discard/Reassign/Quick-discard); uses `@if`/`@for`, signals, `tailwindcss-primeui` colour utilities only
+- [x] 8.7 `reassign-dialog.component.ts/html` — PrimeNG dialog with people + initiative multi-selects (Signal Forms)
+- [x] 8.8 Wire route into the app router and add nav item to the side menu
 
 ## 9. Frontend — tests
 
-- [ ] 9.1 `daily-close-out-page.component.spec.ts` — renders queue, empty state, progress count
-- [ ] 9.2 `triage-card.component.spec.ts` — emits the right action; hides Confirm/Discard for non-Processed captures
-- [ ] 9.3 `daily-close-out.service.spec.ts` — verifies HTTP shapes for all 5 endpoints
+- [x] 9.1 `daily-close-out-page.component.spec.ts` — renders queue, empty state, progress count
+- [x] 9.2 `triage-card.component.spec.ts` — emits the right action; hides Confirm/Discard for non-Processed captures
+- [x] 9.3 `daily-close-out.service.spec.ts` — verifies HTTP shapes for all 5 endpoints
 
 ## 10. Verification
 
-- [ ] 10.1 `dotnet test src/MentalMetal.slnx` — all green
-- [ ] 10.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — all green
-- [ ] 10.3 Manually run `openspec validate daily-close-out --strict`
+- [x] 10.1 `dotnet test src/MentalMetal.slnx` — all green
+- [x] 10.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — all green
+- [x] 10.3 Manually run `openspec validate daily-close-out --strict`

--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -58,7 +58,10 @@ public sealed record CaptureResponse(
     DateTimeOffset CapturedAt,
     DateTimeOffset? ProcessedAt,
     string? Source,
-    DateTimeOffset UpdatedAt)
+    DateTimeOffset UpdatedAt,
+    bool Triaged,
+    DateTimeOffset? TriagedAtUtc,
+    bool ExtractionResolved)
 {
     public static CaptureResponse From(Capture capture) => new(
         capture.Id,
@@ -78,5 +81,8 @@ public sealed record CaptureResponse(
         capture.CapturedAt,
         capture.ProcessedAt,
         capture.Source,
-        capture.UpdatedAt);
+        capture.UpdatedAt,
+        capture.Triaged,
+        capture.TriagedAtUtc,
+        capture.ExtractionResolved);
 }

--- a/src/MentalMetal.Application/Captures/GetUserCaptures.cs
+++ b/src/MentalMetal.Application/Captures/GetUserCaptures.cs
@@ -8,10 +8,13 @@ public sealed class GetUserCapturesHandler(
     ICurrentUserService currentUserService)
 {
     public async Task<List<CaptureResponse>> HandleAsync(
-        CaptureType? typeFilter, ProcessingStatus? statusFilter, CancellationToken cancellationToken)
+        CaptureType? typeFilter,
+        ProcessingStatus? statusFilter,
+        CancellationToken cancellationToken,
+        bool includeTriaged = false)
     {
         var captures = await captureRepository.GetAllAsync(
-            currentUserService.UserId, typeFilter, statusFilter, cancellationToken);
+            currentUserService.UserId, typeFilter, statusFilter, cancellationToken, includeTriaged);
 
         return captures.Select(CaptureResponse.From).ToList();
     }

--- a/src/MentalMetal.Application/DailyCloseOut/CloseOutDay.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/CloseOutDay.cs
@@ -1,0 +1,65 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed class CloseOutDayHandler(
+    IUserRepository userRepository,
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<DailyCloseOutLogDto> HandleAsync(
+        CloseOutDayRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var userId = currentUserService.UserId;
+        var user = await userRepository.GetByIdAsync(userId, cancellationToken)
+            ?? throw new InvalidOperationException($"User not found: {userId}");
+
+        var date = request.Date ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Count all of today's triaged captures for this user, split by outcome,
+        // plus remaining captures still in the close-out queue.
+        var startOfDay = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var endOfDay = date.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
+
+        var captures = await captureRepository.GetAllAsync(
+            userId, typeFilter: null, statusFilter: null, cancellationToken, includeTriaged: true);
+
+        int confirmed = 0;
+        int discarded = 0;
+        int remaining = 0;
+
+        foreach (var c in captures)
+        {
+            if (!c.Triaged)
+            {
+                remaining++;
+                continue;
+            }
+
+            if (c.TriagedAtUtc is null)
+                continue;
+
+            var triagedAt = c.TriagedAtUtc.Value.UtcDateTime;
+            if (triagedAt < startOfDay || triagedAt > endOfDay)
+                continue;
+
+            if (c.ExtractionStatus == ExtractionStatus.Confirmed)
+                confirmed++;
+            else
+                discarded++;
+        }
+
+        var result = user.RecordDailyCloseOut(date, confirmed, discarded, remaining);
+
+        if (result.IsNew)
+            userRepository.MarkOwnedAdded(result.Log);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return DailyCloseOutLogDto.From(result.Log);
+    }
+}

--- a/src/MentalMetal.Application/DailyCloseOut/DailyCloseOutDtos.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/DailyCloseOutDtos.cs
@@ -1,0 +1,65 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed record CloseOutQueueItem(
+    Guid Id,
+    string RawContent,
+    CaptureType CaptureType,
+    ProcessingStatus ProcessingStatus,
+    ExtractionStatus ExtractionStatus,
+    bool ExtractionResolved,
+    AiExtractionResponse? AiExtraction,
+    string? FailureReason,
+    IReadOnlyList<Guid> LinkedPersonIds,
+    IReadOnlyList<Guid> LinkedInitiativeIds,
+    string? Title,
+    DateTimeOffset CapturedAt,
+    DateTimeOffset? ProcessedAt)
+{
+    public static CloseOutQueueItem From(Capture capture) => new(
+        capture.Id,
+        capture.RawContent,
+        capture.CaptureType,
+        capture.ProcessingStatus,
+        capture.ExtractionStatus,
+        capture.ExtractionResolved,
+        AiExtractionResponse.From(capture.AiExtraction),
+        capture.FailureReason,
+        capture.LinkedPersonIds.ToList(),
+        capture.LinkedInitiativeIds.ToList(),
+        capture.Title,
+        capture.CapturedAt,
+        capture.ProcessedAt);
+}
+
+public sealed record CloseOutQueueCounts(int Total, int Raw, int Processing, int Processed, int Failed);
+
+public sealed record CloseOutQueueResponse(
+    IReadOnlyList<CloseOutQueueItem> Items,
+    CloseOutQueueCounts Counts);
+
+public sealed record ReassignCaptureRequest(
+    IReadOnlyList<Guid>? PersonIds,
+    IReadOnlyList<Guid>? InitiativeIds);
+
+public sealed record CloseOutDayRequest(DateOnly? Date);
+
+public sealed record DailyCloseOutLogDto(
+    Guid Id,
+    DateOnly Date,
+    DateTimeOffset ClosedAtUtc,
+    int ConfirmedCount,
+    int DiscardedCount,
+    int RemainingCount)
+{
+    public static DailyCloseOutLogDto From(DailyCloseOutLog log) => new(
+        log.Id,
+        log.Date,
+        log.ClosedAtUtc,
+        log.ConfirmedCount,
+        log.DiscardedCount,
+        log.RemainingCount);
+}

--- a/src/MentalMetal.Application/DailyCloseOut/GetCloseOutLog.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/GetCloseOutLog.cs
@@ -1,0 +1,29 @@
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed class GetCloseOutLogHandler(
+    IUserRepository userRepository,
+    ICurrentUserService currentUserService)
+{
+    private const int DefaultLimit = 30;
+    private const int MaxLimit = 90;
+
+    public async Task<IReadOnlyList<DailyCloseOutLogDto>> HandleAsync(
+        int? limit, CancellationToken cancellationToken)
+    {
+        var userId = currentUserService.UserId;
+        var user = await userRepository.GetByIdAsync(userId, cancellationToken)
+            ?? throw new InvalidOperationException($"User not found: {userId}");
+
+        var effective = limit.GetValueOrDefault(DefaultLimit);
+        if (effective <= 0) effective = DefaultLimit;
+        if (effective > MaxLimit) effective = MaxLimit;
+
+        return user.DailyCloseOutLogs
+            .OrderByDescending(l => l.Date)
+            .Take(effective)
+            .Select(DailyCloseOutLogDto.From)
+            .ToList();
+    }
+}

--- a/src/MentalMetal.Application/DailyCloseOut/GetCloseOutQueue.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/GetCloseOutQueue.cs
@@ -1,0 +1,25 @@
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed class GetCloseOutQueueHandler(
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService)
+{
+    public async Task<CloseOutQueueResponse> HandleAsync(CancellationToken cancellationToken)
+    {
+        var captures = await captureRepository.GetCloseOutQueueAsync(
+            currentUserService.UserId, cancellationToken);
+
+        var items = captures.Select(CloseOutQueueItem.From).ToList();
+        var counts = new CloseOutQueueCounts(
+            Total: items.Count,
+            Raw: items.Count(i => i.ProcessingStatus == ProcessingStatus.Raw),
+            Processing: items.Count(i => i.ProcessingStatus == ProcessingStatus.Processing),
+            Processed: items.Count(i => i.ProcessingStatus == ProcessingStatus.Processed),
+            Failed: items.Count(i => i.ProcessingStatus == ProcessingStatus.Failed));
+
+        return new CloseOutQueueResponse(items, counts);
+    }
+}

--- a/src/MentalMetal.Application/DailyCloseOut/QuickDiscardCapture.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/QuickDiscardCapture.cs
@@ -1,0 +1,21 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed class QuickDiscardCaptureHandler(
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(currentUserService.UserId, captureId);
+
+        capture.QuickDiscard();
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/MentalMetal.Application/DailyCloseOut/ReassignCapture.cs
+++ b/src/MentalMetal.Application/DailyCloseOut/ReassignCapture.cs
@@ -1,0 +1,69 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Initiatives;
+using MentalMetal.Domain.People;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.DailyCloseOut;
+
+public sealed class ReassignCaptureHandler(
+    ICaptureRepository captureRepository,
+    IPersonRepository personRepository,
+    IInitiativeRepository initiativeRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<CloseOutQueueItem> HandleAsync(
+        Guid captureId, ReassignCaptureRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var userId = currentUserService.UserId;
+        var capture = (await captureRepository.GetByIdAsync(captureId, cancellationToken))
+            .EnsureOwned(userId, captureId);
+
+        var targetPeople = (request.PersonIds ?? []).Distinct().ToList();
+        var targetInitiatives = (request.InitiativeIds ?? []).Distinct().ToList();
+
+        if (targetPeople.Count > 0)
+        {
+            var people = await personRepository.GetByIdsAsync(userId, targetPeople, cancellationToken);
+            if (people.Count != targetPeople.Count)
+            {
+                var found = people.Select(p => p.Id).ToList();
+                var missing = targetPeople.Except(found).ToList();
+                throw new ArgumentException(
+                    $"Unknown or unauthorised person id(s): {string.Join(", ", missing)}");
+            }
+        }
+
+        if (targetInitiatives.Count > 0)
+        {
+            foreach (var initiativeId in targetInitiatives)
+            {
+                var initiative = await initiativeRepository.GetByIdAsync(initiativeId, cancellationToken);
+                if (initiative is null || initiative.UserId != userId)
+                    throw new ArgumentException(
+                        $"Unknown or unauthorised initiative id: {initiativeId}");
+            }
+        }
+
+        // Diff people
+        var currentPeople = capture.LinkedPersonIds.ToList();
+        foreach (var add in targetPeople.Except(currentPeople))
+            capture.LinkToPerson(add);
+        foreach (var remove in currentPeople.Except(targetPeople))
+            capture.UnlinkFromPerson(remove);
+
+        // Diff initiatives
+        var currentInitiatives = capture.LinkedInitiativeIds.ToList();
+        foreach (var add in targetInitiatives.Except(currentInitiatives))
+            capture.LinkToInitiative(add);
+        foreach (var remove in currentInitiatives.Except(targetInitiatives))
+            capture.UnlinkFromInitiative(remove);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CloseOutQueueItem.From(capture);
+    }
+}

--- a/src/MentalMetal.Application/Users/UserDtos.cs
+++ b/src/MentalMetal.Application/Users/UserDtos.cs
@@ -12,7 +12,8 @@ public sealed record UserProfileResponse(
     bool HasAiProvider,
     bool HasPassword,
     DateTimeOffset CreatedAt,
-    DateTimeOffset LastLoginAt)
+    DateTimeOffset LastLoginAt,
+    DateTimeOffset? LastCloseOutAtUtc)
 {
     public static UserProfileResponse FromDomain(User user) =>
         new(
@@ -29,7 +30,10 @@ public sealed record UserProfileResponse(
             user.AiProviderConfig is not null,
             user.PasswordHash is not null,
             user.CreatedAt,
-            user.LastLoginAt);
+            user.LastLoginAt,
+            user.DailyCloseOutLogs.Count == 0
+                ? null
+                : user.DailyCloseOutLogs.Max(l => l.ClosedAtUtc));
 }
 
 public sealed record UserPreferencesDto(

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -28,6 +28,20 @@ public sealed class Capture : AggregateRoot, IUserScoped
     public string? Source { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
+    /// <summary>
+    /// True once the user has dealt with this capture as part of daily close-out
+    /// (confirm, discard, or quick-discard). Orthogonal to <see cref="ProcessingStatus"/>.
+    /// </summary>
+    public bool Triaged { get; private set; }
+
+    public DateTimeOffset? TriagedAtUtc { get; private set; }
+
+    /// <summary>
+    /// True once the AI extraction has been explicitly confirmed or discarded by the user.
+    /// Used by the close-out queue to avoid surfacing captures whose extraction has already been resolved.
+    /// </summary>
+    public bool ExtractionResolved { get; private set; }
+
     private Capture() { } // EF Core
 
     public static Capture Create(Guid userId, string rawContent, CaptureType type, string? source = null, string? title = null)
@@ -127,8 +141,15 @@ public sealed class Capture : AggregateRoot, IUserScoped
         if (ExtractionStatus == ExtractionStatus.Confirmed)
             throw new InvalidOperationException("Extraction already confirmed.");
 
+        var now = DateTimeOffset.UtcNow;
         ExtractionStatus = ExtractionStatus.Confirmed;
-        UpdatedAt = DateTimeOffset.UtcNow;
+        ExtractionResolved = true;
+        if (!Triaged)
+        {
+            Triaged = true;
+            TriagedAtUtc = now;
+        }
+        UpdatedAt = now;
 
         RaiseDomainEvent(new CaptureExtractionConfirmed(Id));
     }
@@ -143,10 +164,34 @@ public sealed class Capture : AggregateRoot, IUserScoped
             throw new InvalidOperationException(
                 $"Cannot discard extraction with status '{ExtractionStatus}'. Must be 'Pending'.");
 
+        var now = DateTimeOffset.UtcNow;
         ExtractionStatus = ExtractionStatus.Discarded;
-        UpdatedAt = DateTimeOffset.UtcNow;
+        ExtractionResolved = true;
+        if (!Triaged)
+        {
+            Triaged = true;
+            TriagedAtUtc = now;
+        }
+        UpdatedAt = now;
 
         RaiseDomainEvent(new CaptureExtractionDiscarded(Id));
+    }
+
+    /// <summary>
+    /// Marks the capture as triaged without touching the AI processing pipeline.
+    /// Idempotent — calling twice is a no-op.
+    /// </summary>
+    public void QuickDiscard()
+    {
+        if (Triaged)
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        Triaged = true;
+        TriagedAtUtc = now;
+        UpdatedAt = now;
+
+        RaiseDomainEvent(new CaptureQuickDiscarded(Id));
     }
 
     public void LinkToPerson(Guid personId)

--- a/src/MentalMetal.Domain/Captures/CaptureEvents.cs
+++ b/src/MentalMetal.Domain/Captures/CaptureEvents.cs
@@ -61,3 +61,8 @@ public sealed record CaptureExtractionDiscarded(Guid CaptureId) : IDomainEvent
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record CaptureQuickDiscarded(Guid CaptureId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
+++ b/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
@@ -3,7 +3,25 @@ namespace MentalMetal.Domain.Captures;
 public interface ICaptureRepository
 {
     Task<Capture?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
-    Task<IReadOnlyList<Capture>> GetAllAsync(Guid userId, CaptureType? typeFilter, ProcessingStatus? statusFilter, CancellationToken cancellationToken);
+    /// <summary>
+    /// Lists captures for the user. <paramref name="includeTriaged"/> defaults to <c>false</c>,
+    /// so triaged captures (confirmed, discarded, or quick-discarded) are excluded unless the
+    /// caller opts in.
+    /// </summary>
+    Task<IReadOnlyList<Capture>> GetAllAsync(
+        Guid userId,
+        CaptureType? typeFilter,
+        ProcessingStatus? statusFilter,
+        CancellationToken cancellationToken,
+        bool includeTriaged = false);
     Task<IReadOnlyList<Capture>> GetConfirmedForInitiativeAsync(Guid userId, Guid initiativeId, int take, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns captures currently pending close-out triage for the user:
+    /// <c>Triaged = false</c> and either <see cref="ProcessingStatus"/> is not <c>Processed</c>,
+    /// or the processed capture's extraction has not yet been confirmed or discarded.
+    /// </summary>
+    Task<IReadOnlyList<Capture>> GetCloseOutQueueAsync(Guid userId, CancellationToken cancellationToken);
+
     Task AddAsync(Capture capture, CancellationToken cancellationToken);
 }

--- a/src/MentalMetal.Domain/Users/DailyCloseOutLog.cs
+++ b/src/MentalMetal.Domain/Users/DailyCloseOutLog.cs
@@ -1,0 +1,58 @@
+namespace MentalMetal.Domain.Users;
+
+/// <summary>
+/// Owned entity on <see cref="User"/> capturing a single day's close-out snapshot.
+/// Keyed by (UserId, Date). Idempotent — recording the same date overwrites.
+/// </summary>
+public sealed class DailyCloseOutLog
+{
+    public Guid Id { get; private set; }
+    public DateOnly Date { get; private set; }
+    public DateTimeOffset ClosedAtUtc { get; private set; }
+    public int ConfirmedCount { get; private set; }
+    public int DiscardedCount { get; private set; }
+    public int RemainingCount { get; private set; }
+
+    private DailyCloseOutLog() { } // EF Core
+
+    internal DailyCloseOutLog(
+        DateOnly date,
+        DateTimeOffset closedAtUtc,
+        int confirmedCount,
+        int discardedCount,
+        int remainingCount)
+    {
+        ValidateNonNegative(confirmedCount, nameof(confirmedCount));
+        ValidateNonNegative(discardedCount, nameof(discardedCount));
+        ValidateNonNegative(remainingCount, nameof(remainingCount));
+
+        Id = Guid.NewGuid();
+        Date = date;
+        ClosedAtUtc = closedAtUtc;
+        ConfirmedCount = confirmedCount;
+        DiscardedCount = discardedCount;
+        RemainingCount = remainingCount;
+    }
+
+    internal void Overwrite(
+        DateTimeOffset closedAtUtc,
+        int confirmedCount,
+        int discardedCount,
+        int remainingCount)
+    {
+        ValidateNonNegative(confirmedCount, nameof(confirmedCount));
+        ValidateNonNegative(discardedCount, nameof(discardedCount));
+        ValidateNonNegative(remainingCount, nameof(remainingCount));
+
+        ClosedAtUtc = closedAtUtc;
+        ConfirmedCount = confirmedCount;
+        DiscardedCount = discardedCount;
+        RemainingCount = remainingCount;
+    }
+
+    private static void ValidateNonNegative(int value, string paramName)
+    {
+        if (value < 0)
+            throw new ArgumentOutOfRangeException(paramName, "Count cannot be negative.");
+    }
+}

--- a/src/MentalMetal.Domain/Users/IUserRepository.cs
+++ b/src/MentalMetal.Domain/Users/IUserRepository.cs
@@ -7,4 +7,12 @@ public interface IUserRepository
     Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken);
     Task<bool> ExistsByEmailAsync(Email email, CancellationToken cancellationToken);
     Task AddAsync(User user, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// EF Core's snapshot change detection for field-backed owned collections does not always
+    /// recognise newly-appended items as Added, so handlers must call this helper immediately
+    /// after mutating the collection on a tracked aggregate.
+    /// </summary>
+    void MarkOwnedAdded(object ownedEntity);
+    void MarkOwnedRemoved(object ownedEntity);
 }

--- a/src/MentalMetal.Domain/Users/User.cs
+++ b/src/MentalMetal.Domain/Users/User.cs
@@ -5,6 +5,8 @@ namespace MentalMetal.Domain.Users;
 
 public sealed class User : AggregateRoot
 {
+    private readonly List<DailyCloseOutLog> _dailyCloseOutLogs = [];
+
     public string? ExternalAuthId { get; private set; }
     public Email Email { get; private set; } = null!;
     public string Name { get; private set; } = null!;
@@ -15,6 +17,8 @@ public sealed class User : AggregateRoot
     public string Timezone { get; private set; } = null!;
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset LastLoginAt { get; private set; }
+
+    public IReadOnlyList<DailyCloseOutLog> DailyCloseOutLogs => _dailyCloseOutLogs;
 
     private User() { } // EF Core
 
@@ -128,4 +132,44 @@ public sealed class User : AggregateRoot
     {
         LastLoginAt = DateTimeOffset.UtcNow;
     }
+
+    public DailyCloseOutLog? GetCloseOutLog(DateOnly date) =>
+        _dailyCloseOutLogs.FirstOrDefault(l => l.Date == date);
+
+    /// <summary>
+    /// Records (or overwrites) the user's close-out summary for the given date.
+    /// Returns the log entry together with a flag indicating whether a new entry was appended
+    /// (handlers must call <c>IUserRepository.MarkOwnedAdded</c> for new entries because EF Core's
+    /// snapshot change detection does not always recognise additions to field-backed owned collections).
+    /// </summary>
+    public RecordDailyCloseOutResult RecordDailyCloseOut(
+        DateOnly date,
+        int confirmedCount,
+        int discardedCount,
+        int remainingCount)
+    {
+        if (confirmedCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(confirmedCount), "Count cannot be negative.");
+        if (discardedCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(discardedCount), "Count cannot be negative.");
+        if (remainingCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(remainingCount), "Count cannot be negative.");
+
+        var now = DateTimeOffset.UtcNow;
+        var existing = GetCloseOutLog(date);
+
+        if (existing is not null)
+        {
+            existing.Overwrite(now, confirmedCount, discardedCount, remainingCount);
+            RaiseDomainEvent(new DailyCloseOutRecorded(Id, date));
+            return new RecordDailyCloseOutResult(existing, IsNew: false);
+        }
+
+        var entry = new DailyCloseOutLog(date, now, confirmedCount, discardedCount, remainingCount);
+        _dailyCloseOutLogs.Add(entry);
+        RaiseDomainEvent(new DailyCloseOutRecorded(Id, date));
+        return new RecordDailyCloseOutResult(entry, IsNew: true);
+    }
 }
+
+public sealed record RecordDailyCloseOutResult(DailyCloseOutLog Log, bool IsNew);

--- a/src/MentalMetal.Domain/Users/UserEvents.cs
+++ b/src/MentalMetal.Domain/Users/UserEvents.cs
@@ -26,3 +26,8 @@ public sealed record AiProviderRemoved(Guid UserId) : IDomainEvent
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record DailyCloseOutRecorded(Guid UserId, DateOnly Date) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Application.Captures;
+using MentalMetal.Application.DailyCloseOut;
 using MentalMetal.Application.Chat.Global;
 using MentalMetal.Application.Initiatives.Chat;
 using MentalMetal.Application.Commitments;
@@ -241,6 +242,13 @@ public static class DependencyInjection
 
         // People Lens handlers
         services.AddScoped<GetPersonEvidenceSummaryHandler>();
+
+        // Daily close-out handlers
+        services.AddScoped<GetCloseOutQueueHandler>();
+        services.AddScoped<QuickDiscardCaptureHandler>();
+        services.AddScoped<ReassignCaptureHandler>();
+        services.AddScoped<CloseOutDayHandler>();
+        services.AddScoped<GetCloseOutLogHandler>();
 
         return services;
     }

--- a/src/MentalMetal.Infrastructure/Migrations/20260414104346_AddDailyCloseOut.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260414104346_AddDailyCloseOut.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414104346_AddDailyCloseOut")]
+    partial class AddDailyCloseOut
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260414104346_AddDailyCloseOut.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260414104346_AddDailyCloseOut.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDailyCloseOut : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ExtractionResolved",
+                table: "Captures",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Triaged",
+                table: "Captures",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "TriagedAtUtc",
+                table: "Captures",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "DailyCloseOutLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    ClosedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ConfirmedCount = table.Column<int>(type: "integer", nullable: false),
+                    DiscardedCount = table.Column<int>(type: "integer", nullable: false),
+                    RemainingCount = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailyCloseOutLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DailyCloseOutLogs_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Captures_UserId_Triaged",
+                table: "Captures",
+                columns: new[] { "UserId", "Triaged" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyCloseOutLogs_UserId_Date",
+                table: "DailyCloseOutLogs",
+                columns: new[] { "UserId", "Date" },
+                unique: true);
+
+            // Backfill: any capture not in the 'Processed' state has no extraction to resolve,
+            // so mark it resolved so the close-out queue does not surface historical captures.
+            migrationBuilder.Sql(
+                "UPDATE \"Captures\" SET \"ExtractionResolved\" = TRUE WHERE \"ProcessingStatus\" <> 'Processed';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DailyCloseOutLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Captures_UserId_Triaged",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "ExtractionResolved",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "Triaged",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "TriagedAtUtc",
+                table: "Captures");
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
@@ -77,9 +77,16 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
         builder.Property(c => c.ProcessedAt);
         builder.Property(c => c.UpdatedAt);
 
+        builder.Property(c => c.Triaged)
+            .HasDefaultValue(false);
+        builder.Property(c => c.TriagedAtUtc);
+        builder.Property(c => c.ExtractionResolved)
+            .HasDefaultValue(false);
+
         builder.Property(c => c.UserId)
             .IsRequired();
 
         builder.HasIndex(c => c.UserId);
+        builder.HasIndex(c => new { c.UserId, c.Triaged });
     }
 }

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -88,5 +88,22 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.Property(u => u.CreatedAt);
         builder.Property(u => u.LastLoginAt);
+
+        builder.Navigation(u => u.DailyCloseOutLogs)
+            .HasField("_dailyCloseOutLogs")
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        builder.OwnsMany(u => u.DailyCloseOutLogs, log =>
+        {
+            log.ToTable("DailyCloseOutLogs");
+            log.WithOwner().HasForeignKey("UserId");
+            log.HasKey(l => l.Id);
+            log.Property(l => l.Date).IsRequired();
+            log.Property(l => l.ClosedAtUtc).IsRequired();
+            log.Property(l => l.ConfirmedCount).IsRequired();
+            log.Property(l => l.DiscardedCount).IsRequired();
+            log.Property(l => l.RemainingCount).IsRequired();
+            log.HasIndex("UserId", nameof(DailyCloseOutLog.Date)).IsUnique();
+        });
     }
 }

--- a/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
@@ -10,9 +10,16 @@ public sealed class CaptureRepository(MentalMetalDbContext dbContext) : ICapture
         await dbContext.Captures.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
 
     public async Task<IReadOnlyList<Capture>> GetAllAsync(
-        Guid userId, CaptureType? typeFilter, ProcessingStatus? statusFilter, CancellationToken cancellationToken)
+        Guid userId,
+        CaptureType? typeFilter,
+        ProcessingStatus? statusFilter,
+        CancellationToken cancellationToken,
+        bool includeTriaged = false)
     {
         var query = dbContext.Captures.AsNoTracking().Where(c => c.UserId == userId);
+
+        if (!includeTriaged)
+            query = query.Where(c => !c.Triaged);
 
         if (typeFilter is not null)
             query = query.Where(c => c.CaptureType == typeFilter.Value);
@@ -35,6 +42,29 @@ public sealed class CaptureRepository(MentalMetalDbContext dbContext) : ICapture
             .Where(c => c.LinkedInitiativeIds.Contains(initiativeId))
             .OrderByDescending(c => c.CapturedAt)
             .Take(take)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Capture>> GetCloseOutQueueAsync(
+        Guid userId, CancellationToken cancellationToken)
+    {
+        // Using List<T>.Contains (not HashSet) because EF Core Npgsql translates that to an
+        // IN-clause but does not translate HashSet.Contains. Likewise we avoid ToLowerInvariant().
+        var unprocessedStatuses = new List<ProcessingStatus>
+        {
+            ProcessingStatus.Raw,
+            ProcessingStatus.Processing,
+            ProcessingStatus.Failed,
+        };
+
+        return await dbContext.Captures
+            .AsNoTracking()
+            .Where(c => c.UserId == userId)
+            .Where(c => !c.Triaged)
+            .Where(c =>
+                unprocessedStatuses.Contains(c.ProcessingStatus) ||
+                (c.ProcessingStatus == ProcessingStatus.Processed && !c.ExtractionResolved))
+            .OrderByDescending(c => c.CapturedAt)
             .ToListAsync(cancellationToken);
     }
 

--- a/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/UserRepository.cs
@@ -7,7 +7,9 @@ namespace MentalMetal.Infrastructure.Repositories;
 public sealed class UserRepository(MentalMetalDbContext dbContext) : IUserRepository
 {
     public async Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
-        await dbContext.Users.FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
+        await dbContext.Users
+            .Include(u => u.DailyCloseOutLogs)
+            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
 
     public async Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken) =>
         await dbContext.Users.FirstOrDefaultAsync(u => u.ExternalAuthId == externalAuthId, cancellationToken);
@@ -20,4 +22,10 @@ public sealed class UserRepository(MentalMetalDbContext dbContext) : IUserReposi
 
     public async Task AddAsync(User user, CancellationToken cancellationToken) =>
         await dbContext.Users.AddAsync(user, cancellationToken);
+
+    public void MarkOwnedAdded(object ownedEntity) =>
+        dbContext.Entry(ownedEntity).State = EntityState.Added;
+
+    public void MarkOwnedRemoved(object ownedEntity) =>
+        dbContext.Entry(ownedEntity).State = EntityState.Deleted;
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/app.routes.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.routes.ts
@@ -19,6 +19,7 @@ export const routes: Routes = [
   { path: 'observations', loadComponent: () => import('./pages/observations/observations-list/observations-list.component').then(m => m.ObservationsListComponent), canActivate: [authGuard], data: { title: 'Observations' } },
   { path: 'goals', loadComponent: () => import('./pages/goals/goals-list/goals-list.component').then(m => m.GoalsListComponent), canActivate: [authGuard], data: { title: 'Goals' } },
   { path: 'queue', loadComponent: () => import('./pages/placeholder.page').then(m => m.PlaceholderPage), canActivate: [authGuard], data: { title: 'My Queue' } },
+  { path: 'close-out', loadChildren: () => import('./features/daily-close-out/daily-close-out.routes').then(m => m.DAILY_CLOSE_OUT_ROUTES) },
   { path: 'chat', loadComponent: () => import('./pages/global-chat/global-chat.page').then(m => m.GlobalChatPageComponent), canActivate: [authGuard], data: { title: 'Chat' } },
   { path: 'settings', loadComponent: () => import('./pages/settings/settings.page').then(m => m.SettingsPage), canActivate: [authGuard], data: { title: 'Settings' } },
   { path: '**', redirectTo: 'dashboard' },

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out-page.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out-page.component.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+import { DailyCloseOutPageComponent } from './daily-close-out-page.component';
+import { CloseOutQueueResponse } from './daily-close-out.models';
+
+describe('DailyCloseOutPageComponent', () => {
+  let fixture: ComponentFixture<DailyCloseOutPageComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DailyCloseOutPageComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), MessageService],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DailyCloseOutPageComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  function flushInitial(body: CloseOutQueueResponse): void {
+    fixture.detectChanges();
+    // Reassign dialog loads people and initiatives on construction — satisfy those first.
+    httpMock.expectOne('/api/people').flush([]);
+    httpMock.expectOne('/api/initiatives').flush([]);
+    // The page refreshes the queue on init.
+    httpMock.expectOne('/api/daily-close-out/queue').flush(body);
+    fixture.detectChanges();
+  }
+
+  it('renders empty state when queue is empty', () => {
+    flushInitial({
+      items: [],
+      counts: { total: 0, raw: 0, processing: 0, processed: 0, failed: 0 },
+    });
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Inbox zero');
+  });
+
+  it('renders queue items and progress counts', () => {
+    flushInitial({
+      items: [
+        {
+          id: 'c1',
+          rawContent: 'first capture',
+          captureType: 'QuickNote',
+          processingStatus: 'Raw',
+          extractionStatus: 'None',
+          extractionResolved: false,
+          aiExtraction: null,
+          failureReason: null,
+          linkedPersonIds: [],
+          linkedInitiativeIds: [],
+          title: null,
+          capturedAt: '2026-04-14T00:00:00Z',
+          processedAt: null,
+        },
+      ],
+      counts: { total: 1, raw: 1, processing: 0, processed: 0, failed: 0 },
+    });
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('first capture');
+    expect(text).toContain('1 pending');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out-page.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out-page.component.ts
@@ -1,0 +1,171 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { ProgressBarModule } from 'primeng/progressbar';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { CapturesService } from '../../shared/services/captures.service';
+import { DailyCloseOutService } from './daily-close-out.service';
+import { DailyCloseOutStore } from './daily-close-out.signals';
+import { TriageCardComponent, TriageAction } from './triage-card.component';
+import { ReassignDialogComponent } from './reassign-dialog.component';
+import { CloseOutQueueItem, ReassignCaptureRequest } from './daily-close-out.models';
+
+@Component({
+  selector: 'app-daily-close-out-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ButtonModule,
+    ProgressBarModule,
+    ToastModule,
+    TriageCardComponent,
+    ReassignDialogComponent,
+  ],
+  providers: [MessageService],
+  template: `
+    <p-toast />
+    <div class="flex flex-col gap-6 max-w-3xl mx-auto">
+      <header class="flex flex-col gap-2">
+        <h1 class="text-2xl font-bold">Daily close-out</h1>
+        <p class="text-sm text-muted-color">
+          Triage captures that still need your attention, then close out the day.
+        </p>
+      </header>
+
+      <section class="flex flex-col gap-3 p-4 rounded-md bg-surface-50">
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm font-semibold">Progress</span>
+            <span class="text-xs text-muted-color">
+              {{ store.counts().total }} pending ·
+              Raw {{ store.counts().raw }} · Processing {{ store.counts().processing }} ·
+              Processed {{ store.counts().processed }} · Failed {{ store.counts().failed }}
+            </span>
+          </div>
+          <p-button
+            label="Close out the day"
+            icon="pi pi-flag"
+            [disabled]="store.isLoading()"
+            (onClick)="closeOutDay()"
+          />
+        </div>
+      </section>
+
+      @if (store.isLoading()) {
+        <div class="flex justify-center p-8">
+          <i class="pi pi-spinner pi-spin text-2xl"></i>
+        </div>
+      } @else if (store.isEmpty()) {
+        <div class="flex flex-col items-center gap-4 p-12 bg-surface-50 rounded-md">
+          <i class="pi pi-check-circle text-4xl text-primary"></i>
+          <p class="text-sm text-muted-color">Inbox zero — nothing left to triage.</p>
+        </div>
+      } @else {
+        <div class="flex flex-col gap-3">
+          @for (item of store.items(); track item.id) {
+            <app-triage-card [capture]="item" (action)="onAction(item, $event)" />
+          }
+        </div>
+      }
+
+      @if (store.lastSummary(); as summary) {
+        <section class="flex flex-col gap-2 p-4 rounded-md bg-surface-50">
+          <span class="text-sm font-semibold">Latest close-out</span>
+          <span class="text-xs text-muted-color">
+            {{ summary.date }} · Confirmed {{ summary.confirmedCount }} ·
+            Discarded {{ summary.discardedCount }} · Remaining {{ summary.remainingCount }}
+          </span>
+        </section>
+      }
+
+      <app-reassign-dialog
+        [visible]="reassignVisible()"
+        [capture]="reassignTarget()"
+        (visibleChange)="reassignVisible.set($event)"
+        (applied)="onReassignApplied($event)"
+      />
+    </div>
+  `,
+})
+export class DailyCloseOutPageComponent implements OnInit {
+  protected readonly store = inject(DailyCloseOutStore);
+  private readonly service = inject(DailyCloseOutService);
+  private readonly capturesService = inject(CapturesService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly reassignVisible = signal(false);
+  protected readonly reassignTarget = signal<CloseOutQueueItem | null>(null);
+
+  ngOnInit(): void {
+    this.store.refreshQueue();
+  }
+
+  onAction(item: CloseOutQueueItem, action: TriageAction): void {
+    switch (action) {
+      case 'confirm':
+        this.capturesService.confirmExtraction(item.id).subscribe({
+          next: () => {
+            this.store.removeFromQueue(item.id);
+            this.messageService.add({ severity: 'success', summary: 'Extraction confirmed' });
+          },
+          error: () =>
+            this.messageService.add({ severity: 'error', summary: 'Failed to confirm' }),
+        });
+        break;
+      case 'discard':
+        this.capturesService.discardExtraction(item.id).subscribe({
+          next: () => {
+            this.store.removeFromQueue(item.id);
+            this.messageService.add({ severity: 'success', summary: 'Extraction discarded' });
+          },
+          error: () =>
+            this.messageService.add({ severity: 'error', summary: 'Failed to discard' }),
+        });
+        break;
+      case 'reassign':
+        this.reassignTarget.set(item);
+        this.reassignVisible.set(true);
+        break;
+      case 'quick-discard':
+        this.service.quickDiscard(item.id).subscribe({
+          next: () => {
+            this.store.removeFromQueue(item.id);
+            this.messageService.add({ severity: 'success', summary: 'Removed from queue' });
+          },
+          error: () =>
+            this.messageService.add({ severity: 'error', summary: 'Failed to discard' }),
+        });
+        break;
+    }
+  }
+
+  onReassignApplied(request: ReassignCaptureRequest): void {
+    const target = this.reassignTarget();
+    if (!target) return;
+
+    this.service.reassign(target.id, request).subscribe({
+      next: (updated) => {
+        this.store.replaceItem(updated);
+        this.reassignVisible.set(false);
+        this.messageService.add({ severity: 'success', summary: 'Capture reassigned' });
+      },
+      error: () =>
+        this.messageService.add({ severity: 'error', summary: 'Failed to reassign' }),
+    });
+  }
+
+  closeOutDay(): void {
+    this.service.closeOutDay({}).subscribe({
+      next: (summary) => {
+        this.store.setLastSummary(summary);
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Day closed out',
+          detail: `Confirmed ${summary.confirmedCount}, discarded ${summary.discardedCount}, remaining ${summary.remainingCount}.`,
+        });
+      },
+      error: () =>
+        this.messageService.add({ severity: 'error', summary: 'Failed to close out the day' }),
+    });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.models.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.models.ts
@@ -1,0 +1,48 @@
+import { AiExtraction, CaptureType, ExtractionStatus, ProcessingStatus } from '../../shared/models/capture.model';
+
+export interface CloseOutQueueItem {
+  id: string;
+  rawContent: string;
+  captureType: CaptureType;
+  processingStatus: ProcessingStatus;
+  extractionStatus: ExtractionStatus;
+  extractionResolved: boolean;
+  aiExtraction: AiExtraction | null;
+  failureReason: string | null;
+  linkedPersonIds: string[];
+  linkedInitiativeIds: string[];
+  title: string | null;
+  capturedAt: string;
+  processedAt: string | null;
+}
+
+export interface CloseOutQueueCounts {
+  total: number;
+  raw: number;
+  processing: number;
+  processed: number;
+  failed: number;
+}
+
+export interface CloseOutQueueResponse {
+  items: CloseOutQueueItem[];
+  counts: CloseOutQueueCounts;
+}
+
+export interface ReassignCaptureRequest {
+  personIds: string[];
+  initiativeIds: string[];
+}
+
+export interface CloseOutDayRequest {
+  date?: string;
+}
+
+export interface DailyCloseOutLog {
+  id: string;
+  date: string;
+  closedAtUtc: string;
+  confirmedCount: number;
+  discardedCount: number;
+  remainingCount: number;
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.routes.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.routes.ts
@@ -1,0 +1,12 @@
+import { Routes } from '@angular/router';
+import { authGuard } from '../../shared/guards/auth.guard';
+
+export const DAILY_CLOSE_OUT_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./daily-close-out-page.component').then((m) => m.DailyCloseOutPageComponent),
+    canActivate: [authGuard],
+    data: { title: 'Close-out' },
+  },
+];

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.service.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DailyCloseOutService } from './daily-close-out.service';
+
+describe('DailyCloseOutService', () => {
+  let service: DailyCloseOutService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(DailyCloseOutService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('GETs the queue', () => {
+    service.getQueue().subscribe();
+    const req = httpMock.expectOne('/api/daily-close-out/queue');
+    expect(req.request.method).toBe('GET');
+    req.flush({ items: [], counts: { total: 0, raw: 0, processing: 0, processed: 0, failed: 0 } });
+  });
+
+  it('POSTs quick-discard', () => {
+    service.quickDiscard('c1').subscribe();
+    const req = httpMock.expectOne('/api/daily-close-out/captures/c1/quick-discard');
+    expect(req.request.method).toBe('POST');
+    req.flush(null);
+  });
+
+  it('POSTs reassign with body', () => {
+    service.reassign('c1', { personIds: ['p1'], initiativeIds: [] }).subscribe();
+    const req = httpMock.expectOne('/api/daily-close-out/captures/c1/reassign');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ personIds: ['p1'], initiativeIds: [] });
+    req.flush({});
+  });
+
+  it('POSTs close with optional date', () => {
+    service.closeOutDay({ date: '2026-04-14' }).subscribe();
+    const req = httpMock.expectOne('/api/daily-close-out/close');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ date: '2026-04-14' });
+    req.flush({});
+  });
+
+  it('GETs log with limit', () => {
+    service.getLog(5).subscribe();
+    const req = httpMock.expectOne('/api/daily-close-out/log?limit=5');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.service.ts
@@ -1,0 +1,43 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  CloseOutDayRequest,
+  CloseOutQueueResponse,
+  DailyCloseOutLog,
+  ReassignCaptureRequest,
+} from './daily-close-out.models';
+import { CloseOutQueueItem } from './daily-close-out.models';
+
+@Injectable({ providedIn: 'root' })
+export class DailyCloseOutService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/daily-close-out';
+
+  getQueue(): Observable<CloseOutQueueResponse> {
+    return this.http.get<CloseOutQueueResponse>(`${this.baseUrl}/queue`);
+  }
+
+  quickDiscard(captureId: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/captures/${captureId}/quick-discard`, {});
+  }
+
+  reassign(captureId: string, request: ReassignCaptureRequest): Observable<CloseOutQueueItem> {
+    return this.http.post<CloseOutQueueItem>(
+      `${this.baseUrl}/captures/${captureId}/reassign`,
+      request,
+    );
+  }
+
+  closeOutDay(request: CloseOutDayRequest = {}): Observable<DailyCloseOutLog> {
+    return this.http.post<DailyCloseOutLog>(`${this.baseUrl}/close`, request);
+  }
+
+  getLog(limit?: number): Observable<DailyCloseOutLog[]> {
+    let params = new HttpParams();
+    if (limit !== undefined) {
+      params = params.set('limit', String(limit));
+    }
+    return this.http.get<DailyCloseOutLog[]>(`${this.baseUrl}/log`, { params });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.signals.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/daily-close-out.signals.ts
@@ -1,0 +1,55 @@
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { DailyCloseOutService } from './daily-close-out.service';
+import {
+  CloseOutQueueCounts,
+  CloseOutQueueItem,
+  DailyCloseOutLog,
+} from './daily-close-out.models';
+
+@Injectable({ providedIn: 'root' })
+export class DailyCloseOutStore {
+  private readonly service = inject(DailyCloseOutService);
+
+  private readonly _items = signal<CloseOutQueueItem[]>([]);
+  private readonly _counts = signal<CloseOutQueueCounts>({
+    total: 0,
+    raw: 0,
+    processing: 0,
+    processed: 0,
+    failed: 0,
+  });
+  private readonly _isLoading = signal<boolean>(false);
+  private readonly _lastSummary = signal<DailyCloseOutLog | null>(null);
+
+  readonly items = this._items.asReadonly();
+  readonly counts = this._counts.asReadonly();
+  readonly isLoading = this._isLoading.asReadonly();
+  readonly lastSummary = this._lastSummary.asReadonly();
+  readonly isEmpty = computed(() => this._items().length === 0);
+
+  refreshQueue(): void {
+    this._isLoading.set(true);
+    this.service.getQueue().subscribe({
+      next: (resp) => {
+        this._items.set(resp.items);
+        this._counts.set(resp.counts);
+        this._isLoading.set(false);
+      },
+      error: () => this._isLoading.set(false),
+    });
+  }
+
+  removeFromQueue(captureId: string): void {
+    this._items.update((items) => items.filter((i) => i.id !== captureId));
+  }
+
+  replaceItem(updated: CloseOutQueueItem): void {
+    this._items.update((items) =>
+      items.map((i) => (i.id === updated.id ? updated : i)),
+    );
+  }
+
+  setLastSummary(log: DailyCloseOutLog | null): void {
+    this._lastSummary.set(log);
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/reassign-dialog.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/reassign-dialog.component.ts
@@ -1,0 +1,91 @@
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { PeopleService } from '../../shared/services/people.service';
+import { InitiativesService } from '../../shared/services/initiatives.service';
+import { CloseOutQueueItem, ReassignCaptureRequest } from './daily-close-out.models';
+
+@Component({
+  selector: 'app-reassign-dialog',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, ButtonModule, DialogModule, MultiSelectModule],
+  template: `
+    <p-dialog
+      [visible]="visible()"
+      (visibleChange)="visibleChange.emit($event)"
+      header="Reassign capture"
+      [modal]="true"
+      [style]="{ width: '520px' }"
+    >
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-2">
+          <label for="people" class="text-sm font-medium text-muted-color">People</label>
+          <p-multiSelect
+            id="people"
+            [options]="peopleOptions()"
+            [(ngModel)]="personIds"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Select people"
+            class="w-full"
+          />
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="initiatives" class="text-sm font-medium text-muted-color">Initiatives</label>
+          <p-multiSelect
+            id="initiatives"
+            [options]="initiativeOptions()"
+            [(ngModel)]="initiativeIds"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Select initiatives"
+            class="w-full"
+          />
+        </div>
+      </div>
+      <ng-template #footer>
+        <p-button label="Cancel" [text]="true" (onClick)="visibleChange.emit(false)" />
+        <p-button label="Apply" (onClick)="apply()" />
+      </ng-template>
+    </p-dialog>
+  `,
+})
+export class ReassignDialogComponent {
+  private readonly peopleService = inject(PeopleService);
+  private readonly initiativesService = inject(InitiativesService);
+
+  readonly visible = input.required<boolean>();
+  readonly capture = input<CloseOutQueueItem | null>(null);
+  readonly visibleChange = output<boolean>();
+  readonly applied = output<ReassignCaptureRequest>();
+
+  protected readonly peopleOptions = signal<Array<{ label: string; value: string }>>([]);
+  protected readonly initiativeOptions = signal<Array<{ label: string; value: string }>>([]);
+  protected personIds: string[] = [];
+  protected initiativeIds: string[] = [];
+
+  constructor() {
+    this.peopleService.list().subscribe({
+      next: (people) =>
+        this.peopleOptions.set(people.map((p) => ({ label: p.name, value: p.id }))),
+    });
+    this.initiativesService.list().subscribe({
+      next: (initiatives) =>
+        this.initiativeOptions.set(initiatives.map((i) => ({ label: i.title, value: i.id }))),
+    });
+
+    // Reset selections when the capture changes.
+    effect(() => {
+      const c = this.capture();
+      this.personIds = c ? [...c.linkedPersonIds] : [];
+      this.initiativeIds = c ? [...c.linkedInitiativeIds] : [];
+    });
+  }
+
+  protected apply(): void {
+    this.applied.emit({ personIds: this.personIds, initiativeIds: this.initiativeIds });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/triage-card.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/triage-card.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TriageCardComponent } from './triage-card.component';
+import { CloseOutQueueItem } from './daily-close-out.models';
+
+function makeItem(partial: Partial<CloseOutQueueItem> = {}): CloseOutQueueItem {
+  return {
+    id: 'c1',
+    rawContent: 'some content',
+    captureType: 'QuickNote',
+    processingStatus: 'Raw',
+    extractionStatus: 'None',
+    extractionResolved: false,
+    aiExtraction: null,
+    failureReason: null,
+    linkedPersonIds: [],
+    linkedInitiativeIds: [],
+    title: null,
+    capturedAt: '2026-04-14T00:00:00Z',
+    processedAt: null,
+    ...partial,
+  };
+}
+
+describe('TriageCardComponent', () => {
+  let fixture: ComponentFixture<TriageCardComponent>;
+  let component: TriageCardComponent;
+  let componentRef: ComponentRef<TriageCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TriageCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TriageCardComponent);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+  });
+
+  it('hides Confirm/Discard buttons when not Processed', () => {
+    componentRef.setInput('capture', makeItem({ processingStatus: 'Raw' }));
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.textContent as string;
+    expect(html).not.toContain('Confirm');
+    expect(html).not.toContain('Discard extraction');
+    expect(html).toContain('Quick discard');
+  });
+
+  it('shows Confirm/Discard when Processed and extraction unresolved', () => {
+    componentRef.setInput(
+      'capture',
+      makeItem({ processingStatus: 'Processed', extractionResolved: false }),
+    );
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.textContent as string;
+    expect(html).toContain('Confirm');
+    expect(html).toContain('Discard extraction');
+  });
+
+  it('emits the correct action on button click', () => {
+    componentRef.setInput('capture', makeItem());
+    fixture.detectChanges();
+
+    let emitted: string | null = null;
+    component.action.subscribe((action) => (emitted = action));
+
+    const buttons = fixture.nativeElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>;
+    const quick = Array.from(buttons).find((b) => (b.textContent ?? '').includes('Quick discard'));
+    quick!.click();
+
+    expect(emitted).toBe('quick-discard');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/triage-card.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/features/daily-close-out/triage-card.component.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { CloseOutQueueItem } from './daily-close-out.models';
+
+export type TriageAction = 'confirm' | 'discard' | 'reassign' | 'quick-discard';
+
+@Component({
+  selector: 'app-triage-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, TagModule],
+  template: `
+    <div class="flex flex-col gap-3 p-4 rounded-md border bg-surface-0">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex flex-col gap-1 min-w-0">
+          @if (capture().title) {
+            <h3 class="text-base font-semibold truncate">{{ capture().title }}</h3>
+          }
+          <div class="flex items-center gap-2 flex-wrap">
+            <p-tag [value]="capture().processingStatus" [severity]="statusSeverity()" />
+            @if (capture().extractionStatus !== 'None') {
+              <p-tag [value]="capture().extractionStatus" severity="secondary" />
+            }
+            <span class="text-xs text-muted-color">{{ capture().captureType }}</span>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-sm whitespace-pre-wrap">{{ capture().rawContent }}</p>
+
+      @if (capture().aiExtraction; as ext) {
+        <div class="flex flex-col gap-2 p-3 rounded-md bg-surface-50">
+          <span class="text-xs font-semibold uppercase text-muted-color">AI summary</span>
+          <p class="text-sm">{{ ext.summary }}</p>
+        </div>
+      }
+
+      @if (capture().failureReason; as reason) {
+        <div class="p-3 rounded-md bg-surface-50 text-sm">
+          <span class="font-semibold">Failed:</span> {{ reason }}
+        </div>
+      }
+
+      <div class="flex items-center gap-2 flex-wrap pt-2">
+        @if (canConfirmDiscard()) {
+          <p-button
+            label="Confirm"
+            icon="pi pi-check"
+            size="small"
+            severity="success"
+            (onClick)="action.emit('confirm')"
+          />
+          <p-button
+            label="Discard extraction"
+            icon="pi pi-times"
+            size="small"
+            severity="secondary"
+            (onClick)="action.emit('discard')"
+          />
+        }
+        <p-button
+          label="Reassign"
+          icon="pi pi-sync"
+          size="small"
+          [text]="true"
+          (onClick)="action.emit('reassign')"
+        />
+        <p-button
+          label="Quick discard"
+          icon="pi pi-inbox"
+          size="small"
+          severity="danger"
+          [text]="true"
+          (onClick)="action.emit('quick-discard')"
+        />
+      </div>
+    </div>
+  `,
+})
+export class TriageCardComponent {
+  readonly capture = input.required<CloseOutQueueItem>();
+  readonly action = output<TriageAction>();
+
+  protected canConfirmDiscard(): boolean {
+    const c = this.capture();
+    return c.processingStatus === 'Processed' && !c.extractionResolved;
+  }
+
+  protected statusSeverity(): 'info' | 'warn' | 'danger' | 'success' | 'secondary' {
+    switch (this.capture().processingStatus) {
+      case 'Raw':
+        return 'info';
+      case 'Processing':
+        return 'warn';
+      case 'Processed':
+        return 'success';
+      case 'Failed':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -108,6 +108,12 @@ import { ThemeService } from '../services/theme.service';
         <i class="pi pi-list-check"></i>
         <span>My Queue</span>
       </a>
+      <a routerLink="/close-out" routerLinkActive="font-semibold sidebar-link-active"
+         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
+         (click)="navClick.emit()">
+        <i class="pi pi-inbox"></i>
+        <span>Close-out</span>
+      </a>
     </nav>
 
     <div class="p-3 border-t sidebar-border">

--- a/src/MentalMetal.Web/DailyCloseOutEndpoints.cs
+++ b/src/MentalMetal.Web/DailyCloseOutEndpoints.cs
@@ -1,0 +1,82 @@
+using MentalMetal.Application.DailyCloseOut;
+
+namespace MentalMetal.Web;
+
+public static class DailyCloseOutEndpoints
+{
+    public static IEndpointRouteBuilder MapDailyCloseOutEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/daily-close-out/queue", async (
+            GetCloseOutQueueHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            var response = await handler.HandleAsync(cancellationToken);
+            return Results.Ok(response);
+        }).RequireAuthorization();
+
+        app.MapPost("/api/daily-close-out/captures/{id:guid}/quick-discard", async (
+            Guid id,
+            QuickDiscardCaptureHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await handler.HandleAsync(id, cancellationToken);
+                return Results.Ok();
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+            {
+                return Results.NotFound();
+            }
+        }).RequireAuthorization();
+
+        app.MapPost("/api/daily-close-out/captures/{id:guid}/reassign", async (
+            Guid id,
+            ReassignCaptureRequest request,
+            ReassignCaptureHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var response = await handler.HandleAsync(id, request, cancellationToken);
+                return Results.Ok(response);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+            {
+                return Results.NotFound();
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        }).RequireAuthorization();
+
+        app.MapPost("/api/daily-close-out/close", async (
+            CloseOutDayRequest? request,
+            CloseOutDayHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var response = await handler.HandleAsync(
+                    request ?? new CloseOutDayRequest(null), cancellationToken);
+                return Results.Ok(response);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        }).RequireAuthorization();
+
+        app.MapGet("/api/daily-close-out/log", async (
+            int? limit,
+            GetCloseOutLogHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            var response = await handler.HandleAsync(limit, cancellationToken);
+            return Results.Ok(response);
+        }).RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -2,6 +2,8 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Json.Serialization;
 using MentalMetal.Application.Captures;
+using MentalMetal.Application.DailyCloseOut;
+using MentalMetal.Web;
 using MentalMetal.Application.Commitments;
 using MentalMetal.Application.Common.Ai;
 using MentalMetal.Application.Delegations;
@@ -792,10 +794,11 @@ app.MapPost("/api/captures", async (
 app.MapGet("/api/captures", async (
     CaptureType? type,
     ProcessingStatus? status,
+    bool? includeTriaged,
     GetUserCapturesHandler handler,
     CancellationToken cancellationToken) =>
 {
-    var list = await handler.HandleAsync(type, status, cancellationToken);
+    var list = await handler.HandleAsync(type, status, cancellationToken, includeTriaged ?? false);
     return Results.Ok(list);
 }).RequireAuthorization();
 
@@ -1957,6 +1960,8 @@ app.MapGet("/api/people/{personId:guid}/evidence-summary", async (
     var response = await handler.HandleAsync(personId, from.Value, to.Value, ct);
     return Results.Ok(response);
 }).RequireAuthorization();
+
+app.MapDailyCloseOutEndpoints();
 
 app.MapGet("/api/health", () => Results.Ok(new { status = "healthy" }));
 

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -536,4 +536,66 @@ public class CaptureTests
 
         Assert.Throws<ArgumentException>(() => capture.RecordSpawnedObservation(Guid.Empty));
     }
+
+    // --- Daily close-out / triage ---
+
+    [Fact]
+    public void QuickDiscard_NotTriaged_SetsFlagsAndRaisesEvent()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.ClearDomainEvents();
+
+        capture.QuickDiscard();
+
+        Assert.True(capture.Triaged);
+        Assert.NotNull(capture.TriagedAtUtc);
+        var evt = Assert.Single(capture.DomainEvents);
+        var discarded = Assert.IsType<CaptureQuickDiscarded>(evt);
+        Assert.Equal(capture.Id, discarded.CaptureId);
+    }
+
+    [Fact]
+    public void QuickDiscard_AlreadyTriaged_IsNoOp()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.QuickDiscard();
+        var firstTriagedAt = capture.TriagedAtUtc;
+        capture.ClearDomainEvents();
+
+        capture.QuickDiscard();
+
+        Assert.True(capture.Triaged);
+        Assert.Equal(firstTriagedAt, capture.TriagedAtUtc);
+        Assert.Empty(capture.DomainEvents);
+    }
+
+    [Fact]
+    public void ConfirmExtraction_SetsExtractionResolvedAndTriaged()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ClearDomainEvents();
+
+        capture.ConfirmExtraction();
+
+        Assert.True(capture.ExtractionResolved);
+        Assert.True(capture.Triaged);
+        Assert.NotNull(capture.TriagedAtUtc);
+    }
+
+    [Fact]
+    public void DiscardExtraction_SetsExtractionResolvedAndTriaged()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+        capture.ClearDomainEvents();
+
+        capture.DiscardExtraction();
+
+        Assert.True(capture.ExtractionResolved);
+        Assert.True(capture.Triaged);
+        Assert.NotNull(capture.TriagedAtUtc);
+    }
 }

--- a/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Users/UserTests.cs
@@ -332,4 +332,81 @@ public class UserTests
 
         Assert.True(user.LastLoginAt >= originalLogin);
     }
+
+    // --- Daily close-out ---
+
+    [Fact]
+    public void RecordDailyCloseOut_NewDate_AppendsLogAndRaisesEvent()
+    {
+        var user = User.Register("auth-1", "a@b.com", "A", null);
+        user.ClearDomainEvents();
+
+        var result = user.RecordDailyCloseOut(new DateOnly(2026, 4, 14), 3, 1, 2);
+
+        Assert.True(result.IsNew);
+        var log = Assert.Single(user.DailyCloseOutLogs);
+        Assert.Equal(new DateOnly(2026, 4, 14), log.Date);
+        Assert.Equal(3, log.ConfirmedCount);
+        Assert.Equal(1, log.DiscardedCount);
+        Assert.Equal(2, log.RemainingCount);
+        Assert.Same(log, result.Log);
+        var evt = Assert.Single(user.DomainEvents);
+        Assert.IsType<DailyCloseOutRecorded>(evt);
+    }
+
+    [Fact]
+    public void RecordDailyCloseOut_SameDate_OverwritesExistingLog()
+    {
+        var user = User.Register("auth-1", "a@b.com", "A", null);
+        var date = new DateOnly(2026, 4, 14);
+        user.RecordDailyCloseOut(date, 1, 0, 5);
+        var originalId = user.DailyCloseOutLogs[0].Id;
+        user.ClearDomainEvents();
+
+        var result = user.RecordDailyCloseOut(date, 4, 2, 0);
+
+        Assert.False(result.IsNew);
+        var log = Assert.Single(user.DailyCloseOutLogs);
+        Assert.Equal(originalId, log.Id);
+        Assert.Equal(4, log.ConfirmedCount);
+        Assert.Equal(2, log.DiscardedCount);
+        Assert.Equal(0, log.RemainingCount);
+    }
+
+    [Theory]
+    [InlineData(-1, 0, 0)]
+    [InlineData(0, -1, 0)]
+    [InlineData(0, 0, -1)]
+    public void RecordDailyCloseOut_NegativeCount_Throws(int confirmed, int discarded, int remaining)
+    {
+        var user = User.Register("auth-1", "a@b.com", "A", null);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            user.RecordDailyCloseOut(new DateOnly(2026, 4, 14), confirmed, discarded, remaining));
+    }
+
+    [Fact]
+    public void RecordDailyCloseOut_MultiUser_IsolatedPerUser()
+    {
+        var userA = User.Register("auth-a", "a@b.com", "A", null);
+        var userB = User.Register("auth-b", "b@b.com", "B", null);
+
+        userA.RecordDailyCloseOut(new DateOnly(2026, 4, 14), 1, 2, 3);
+        userB.RecordDailyCloseOut(new DateOnly(2026, 4, 14), 9, 8, 7);
+
+        Assert.Single(userA.DailyCloseOutLogs);
+        Assert.Single(userB.DailyCloseOutLogs);
+        Assert.Equal(1, userA.DailyCloseOutLogs[0].ConfirmedCount);
+        Assert.Equal(9, userB.DailyCloseOutLogs[0].ConfirmedCount);
+    }
+
+    [Fact]
+    public void GetCloseOutLog_ReturnsMatchingOrNull()
+    {
+        var user = User.Register("auth-1", "a@b.com", "A", null);
+        user.RecordDailyCloseOut(new DateOnly(2026, 4, 14), 1, 0, 0);
+
+        Assert.NotNull(user.GetCloseOutLog(new DateOnly(2026, 4, 14)));
+        Assert.Null(user.GetCloseOutLog(new DateOnly(2026, 4, 15)));
+    }
 }

--- a/tests/MentalMetal.Web.IntegrationTests/DailyCloseOut/DailyCloseOutEndpointsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/DailyCloseOut/DailyCloseOutEndpointsTests.cs
@@ -1,0 +1,338 @@
+using System.Net;
+using System.Net.Http.Json;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.People;
+using MentalMetal.Web.IntegrationTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MentalMetal.Web.IntegrationTests.DailyCloseOut;
+
+public sealed class DailyCloseOutEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private sealed record CloseOutQueueItemBody(
+        Guid Id,
+        string RawContent,
+        string CaptureType,
+        string ProcessingStatus,
+        string ExtractionStatus,
+        bool ExtractionResolved,
+        IReadOnlyList<Guid> LinkedPersonIds,
+        IReadOnlyList<Guid> LinkedInitiativeIds);
+
+    private sealed record CloseOutQueueCountsBody(int Total, int Raw, int Processing, int Processed, int Failed);
+    private sealed record CloseOutQueueResponseBody(IReadOnlyList<CloseOutQueueItemBody> Items, CloseOutQueueCountsBody Counts);
+
+    private sealed record DailyCloseOutLogBody(
+        Guid Id,
+        DateOnly Date,
+        DateTimeOffset ClosedAtUtc,
+        int ConfirmedCount,
+        int DiscardedCount,
+        int RemainingCount);
+
+    private sealed record UserProfileBody(
+        Guid Id,
+        string Email,
+        DateTimeOffset? LastCloseOutAtUtc);
+
+    private sealed record CaptureBody(
+        Guid Id,
+        string ProcessingStatus,
+        bool Triaged,
+        bool ExtractionResolved,
+        IReadOnlyList<Guid> LinkedPersonIds,
+        IReadOnlyList<Guid> LinkedInitiativeIds);
+
+    private async Task<(Guid UserId, HttpClient Client)> AuthedClientAsync()
+    {
+        var (userId, token) = await SeedUserWithPasswordAndSignInAsync(
+            $"user-{Guid.NewGuid():N}@test.invalid", "password-123");
+        return (userId, WithBearer(CreateClient(), token));
+    }
+
+    private async Task<Capture> SeedCaptureAsync(
+        Guid userId,
+        ProcessingStatus status = ProcessingStatus.Raw,
+        bool triaged = false)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ICaptureRepository>();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var capture = Capture.Create(userId, $"content {Guid.NewGuid():N}", CaptureType.QuickNote);
+        if (status == ProcessingStatus.Processing)
+        {
+            capture.BeginProcessing();
+        }
+        else if (status == ProcessingStatus.Processed)
+        {
+            capture.BeginProcessing();
+            capture.CompleteProcessing(new AiExtraction { Summary = "test" });
+        }
+        else if (status == ProcessingStatus.Failed)
+        {
+            capture.BeginProcessing();
+            capture.FailProcessing("error");
+        }
+
+        if (triaged)
+            capture.QuickDiscard();
+
+        await repo.AddAsync(capture, CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+        return capture;
+    }
+
+    private async Task<Guid> SeedPersonAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IPersonRepository>();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var person = Person.Create(userId, $"Person-{Guid.NewGuid():N}", PersonType.DirectReport);
+        await repo.AddAsync(person, CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+        return person.Id;
+    }
+
+    // --- GetCloseOutQueue ---
+
+    [Fact]
+    public async Task GetQueue_MixedStatuses_ReturnsPendingOnlyWithCounts()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+        await SeedCaptureAsync(userId, ProcessingStatus.Failed);
+        await SeedCaptureAsync(userId, ProcessingStatus.Processed);
+        // Already triaged should be excluded:
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw, triaged: true);
+
+        var resp = await client.GetAsync("/api/daily-close-out/queue");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await ReadJsonAsync<CloseOutQueueResponseBody>(resp);
+
+        Assert.Equal(3, body!.Counts.Total);
+        Assert.Equal(1, body.Counts.Raw);
+        Assert.Equal(1, body.Counts.Processed);
+        Assert.Equal(1, body.Counts.Failed);
+        Assert.Equal(3, body.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetQueue_IsolatesByUser()
+    {
+        var (userA, clientA) = await AuthedClientAsync();
+        var (_, clientB) = await AuthedClientAsync();
+        await SeedCaptureAsync(userA, ProcessingStatus.Raw);
+
+        var respB = await clientB.GetAsync("/api/daily-close-out/queue");
+        var body = await ReadJsonAsync<CloseOutQueueResponseBody>(respB);
+        Assert.Empty(body!.Items);
+    }
+
+    // --- QuickDiscard ---
+
+    [Fact]
+    public async Task QuickDiscard_ExistingCapture_ExcludesFromQueue()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var capture = await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+
+        var resp = await client.PostAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/quick-discard", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        // idempotent:
+        var resp2 = await client.PostAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/quick-discard", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp2.StatusCode);
+
+        var queue = await client.GetAsync("/api/daily-close-out/queue");
+        var body = await ReadJsonAsync<CloseOutQueueResponseBody>(queue);
+        Assert.Empty(body!.Items);
+    }
+
+    [Fact]
+    public async Task QuickDiscard_ForeignCapture_Returns404()
+    {
+        var (userA, _) = await AuthedClientAsync();
+        var capture = await SeedCaptureAsync(userA, ProcessingStatus.Raw);
+        var (_, clientB) = await AuthedClientAsync();
+
+        var resp = await clientB.PostAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/quick-discard", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // --- Reassign ---
+
+    [Fact]
+    public async Task Reassign_AddsAndRemovesLinks()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var capture = await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+        var personA = await SeedPersonAsync(userId);
+        var personB = await SeedPersonAsync(userId);
+
+        // Start by assigning person A
+        var resp1 = await client.PostAsJsonAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/reassign",
+            new { personIds = new[] { personA }, initiativeIds = Array.Empty<Guid>() });
+        Assert.Equal(HttpStatusCode.OK, resp1.StatusCode);
+
+        // Now switch to person B
+        var resp2 = await client.PostAsJsonAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/reassign",
+            new { personIds = new[] { personB }, initiativeIds = Array.Empty<Guid>() });
+        var after = await ReadJsonAsync<CloseOutQueueItemBody>(resp2);
+        Assert.Single(after!.LinkedPersonIds);
+        Assert.Contains(personB, after.LinkedPersonIds);
+
+        // Clear all
+        var resp3 = await client.PostAsJsonAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/reassign",
+            new { personIds = Array.Empty<Guid>(), initiativeIds = Array.Empty<Guid>() });
+        var cleared = await ReadJsonAsync<CloseOutQueueItemBody>(resp3);
+        Assert.Empty(cleared!.LinkedPersonIds);
+    }
+
+    [Fact]
+    public async Task Reassign_UnknownPersonId_Returns400()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var capture = await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/daily-close-out/captures/{capture.Id}/reassign",
+            new { personIds = new[] { Guid.NewGuid() }, initiativeIds = Array.Empty<Guid>() });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // --- CloseOutDay ---
+
+    [Fact]
+    public async Task CloseOutDay_FirstCall_RecordsEntry()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+
+        var resp = await client.PostAsJsonAsync("/api/daily-close-out/close", new { });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await ReadJsonAsync<DailyCloseOutLogBody>(resp);
+        Assert.Equal(1, body!.RemainingCount);
+        Assert.Equal(0, body.ConfirmedCount);
+        Assert.Equal(0, body.DiscardedCount);
+    }
+
+    [Fact]
+    public async Task CloseOutDay_SecondCall_OverwritesSameDate()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var date = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var resp1 = await client.PostAsJsonAsync("/api/daily-close-out/close", new { date });
+        var first = await ReadJsonAsync<DailyCloseOutLogBody>(resp1);
+
+        // Seed a capture after first close-out
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+
+        var resp2 = await client.PostAsJsonAsync("/api/daily-close-out/close", new { date });
+        var second = await ReadJsonAsync<DailyCloseOutLogBody>(resp2);
+
+        Assert.Equal(first!.Id, second!.Id);
+        Assert.Equal(1, second.RemainingCount);
+    }
+
+    [Fact]
+    public async Task CloseOutDay_ExplicitDate_RecordsForThatDate()
+    {
+        var (_, client) = await AuthedClientAsync();
+        var date = new DateOnly(2025, 12, 31);
+
+        var resp = await client.PostAsJsonAsync("/api/daily-close-out/close", new { date });
+        var body = await ReadJsonAsync<DailyCloseOutLogBody>(resp);
+        Assert.Equal(date, body!.Date);
+    }
+
+    // --- GetCloseOutLog ---
+
+    [Fact]
+    public async Task GetLog_EmptyCase_ReturnsEmptyArray()
+    {
+        var (_, client) = await AuthedClientAsync();
+        var resp = await client.GetAsync("/api/daily-close-out/log");
+        var body = await ReadJsonAsync<List<DailyCloseOutLogBody>>(resp);
+        Assert.Empty(body!);
+    }
+
+    [Fact]
+    public async Task GetLog_Ordering_MostRecentFirst()
+    {
+        var (_, client) = await AuthedClientAsync();
+        await client.PostAsJsonAsync("/api/daily-close-out/close", new { date = new DateOnly(2025, 1, 1) });
+        await client.PostAsJsonAsync("/api/daily-close-out/close", new { date = new DateOnly(2025, 6, 1) });
+        await client.PostAsJsonAsync("/api/daily-close-out/close", new { date = new DateOnly(2025, 3, 1) });
+
+        var resp = await client.GetAsync("/api/daily-close-out/log");
+        var body = await ReadJsonAsync<List<DailyCloseOutLogBody>>(resp);
+        Assert.Equal(3, body!.Count);
+        Assert.Equal(new DateOnly(2025, 6, 1), body[0].Date);
+        Assert.Equal(new DateOnly(2025, 3, 1), body[1].Date);
+        Assert.Equal(new DateOnly(2025, 1, 1), body[2].Date);
+    }
+
+    [Fact]
+    public async Task GetLog_LimitClamping_CapsAt90()
+    {
+        var (_, client) = await AuthedClientAsync();
+        await client.PostAsJsonAsync("/api/daily-close-out/close", new { date = new DateOnly(2025, 1, 1) });
+
+        var resp = await client.GetAsync("/api/daily-close-out/log?limit=1000");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await ReadJsonAsync<List<DailyCloseOutLogBody>>(resp);
+        Assert.Single(body!);
+    }
+
+    // --- Modified capture endpoints ---
+
+    [Fact]
+    public async Task ListCaptures_DefaultExcludesTriaged()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw, triaged: true);
+
+        var resp = await client.GetAsync("/api/captures");
+        var list = await ReadJsonAsync<List<CaptureBody>>(resp);
+        Assert.Single(list!);
+        Assert.False(list![0].Triaged);
+    }
+
+    [Fact]
+    public async Task ListCaptures_IncludeTriagedTrue_IncludesTriaged()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw);
+        await SeedCaptureAsync(userId, ProcessingStatus.Raw, triaged: true);
+
+        var resp = await client.GetAsync("/api/captures?includeTriaged=true");
+        var list = await ReadJsonAsync<List<CaptureBody>>(resp);
+        Assert.Equal(2, list!.Count);
+    }
+
+    [Fact]
+    public async Task GetCurrentUser_IncludesLastCloseOutAtUtc_AfterCloseOut()
+    {
+        var (_, client) = await AuthedClientAsync();
+        var before = await client.GetAsync("/api/users/me");
+        var beforeBody = await ReadJsonAsync<UserProfileBody>(before);
+        Assert.Null(beforeBody!.LastCloseOutAtUtc);
+
+        await client.PostAsJsonAsync("/api/daily-close-out/close", new { });
+
+        var after = await client.GetAsync("/api/users/me");
+        var afterBody = await ReadJsonAsync<UserProfileBody>(after);
+        Assert.NotNull(afterBody!.LastCloseOutAtUtc);
+    }
+}


### PR DESCRIPTION
## Summary

Stage 2 (apply) for the `daily-close-out` OpenSpec change. Implements the end-of-day triage flow end-to-end: domain changes on Capture + User, EF migration, vertical-slice handlers, minimal-API endpoints, and the Angular `/close-out` feature module.

**Spec**: [daily-close-out](openspec/changes/daily-close-out/specs/daily-close-out/spec.md)

## Changes

- Capture aggregate: `Triaged`, `TriagedAtUtc`, `ExtractionResolved`, idempotent `QuickDiscard()`, new `CaptureQuickDiscarded` event. `ConfirmExtraction`/`DiscardExtraction` now set `ExtractionResolved` and `Triaged`.
- User aggregate: `DailyCloseOutLog` owned collection with `RecordDailyCloseOut(date, counts)` (idempotent same-date overwrite, non-negative validation) and `DailyCloseOutRecorded` event.
- EF migration `AddDailyCloseOut` adding columns + table + unique `(UserId, Date)` index, backfilling `ExtractionResolved` for historical non-Processed captures.
- Handlers: `GetCloseOutQueue`, `QuickDiscardCapture`, `ReassignCapture` (diffs person/initiative links + user-scoped validation), `CloseOutDay` (computes today's confirmed/discarded/remaining counts), `GetCloseOutLog` (descending date, limit default 30 / max 90).
- Endpoints wired via `DailyCloseOutEndpoints.MapDailyCloseOutEndpoints()` in Program.cs.
- `GET /api/captures` now defaults to `Triaged=false` and accepts `?includeTriaged=true`; `GET /api/users/me` exposes `lastCloseOutAtUtc`.
- Angular feature module at `/close-out` with signal store, `TriageCardComponent`, `ReassignDialogComponent` (PrimeNG MultiSelect + Signal Forms), and a Close-out sidebar entry.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — 519/519 passing
- [x] `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — 48/48 passing
- [x] `openspec validate daily-close-out --strict` — valid
- [x] Migration applies cleanly to local dev database

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)