### PR TITLE
chore(openspec): propose my-queue change

### DIFF
--- a/openspec/changes/my-queue/.openspec.yaml
+++ b/openspec/changes/my-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/my-queue/design.md
+++ b/openspec/changes/my-queue/design.md
@@ -1,0 +1,202 @@
+# Design — My Queue
+
+## Context
+
+Three Tier-2 capabilities already ship their own list endpoints and UI: `commitment-tracking`, `delegation-tracking`, and `capture-ai-extraction` (via the raw `Capture` aggregate and the recently-shipped `daily-close-out` queue). Users today have to visit three screens to see "what's pulling on me right now" — overdue commitments they owe, stale delegations waiting on someone else, and captures that were dropped in but never processed.
+
+This change is **purely read-side**. No aggregates are modified, no events are added, no migrations run. We introduce an Application-layer `QueuePrioritizationService` that reads the three aggregates via their existing repositories and returns a unified, scored, filterable `QueueItem` projection. The Angular frontend gets a new route rendering it.
+
+Per `design/spec-plan.md` line 34, the service placeholder for Tier-3 `my-queue` is `(QueuePrioritizationService)` — parenthesised because it is a domain/application service, not an aggregate.
+
+## Dependencies
+
+- `commitment-tracking` (shipped, archived) — reads `Commitment` aggregate
+- `delegation-tracking` (shipped, archived) — reads `Delegation` aggregate
+- `capture-ai-extraction` (shipped, archived) — reads `Capture` aggregate, including `Status`, `TriagedAtUtc`, `ExtractionConfirmed`/`ExtractionDiscarded` state
+- `user-auth-tenancy` (shipped) — `ICurrentUserService` to scope all queries by `UserId`
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Single endpoint `GET /api/my-queue` that returns a user-scoped, sorted, filterable list of items needing attention
+- Deterministic, testable priority scoring that produces stable sort order
+- Surface a "delegate this" suggestion on commitments where a reasonable heuristic fires, without persisting any new state
+- Frontend feature slice mirroring existing patterns (commitments/delegations lists) using signals, PrimeNG, and `tailwindcss-primeui` tokens only
+
+**Non-Goals:**
+
+- No new persisted state, no new aggregate, no domain events
+- No AI calls on the hot path — priority is a deterministic formula. (Future: layer LLM re-ranking on top.)
+- No push/notification/reminder surface — that lives in the future `nudges-rhythms` spec
+- No cross-user aggregation
+- No mutating actions directly on `/api/my-queue` — all state changes still go through the existing commitment / delegation / capture endpoints. The queue returns IDs and enough context to dispatch actions via those existing APIs.
+
+## Decisions
+
+### D1. Query-side composition, not a new aggregate
+
+**Decision:** Implement as an Application-layer `QueuePrioritizationService` + a single `GetMyQueue` handler. Union data across existing repositories.
+
+**Alternatives considered:**
+
+- *Materialised view table updated by domain events.* Rejected — creates schema churn, needs backfill, adds eventual-consistency window for a low-traffic single-user view. Not worth it.
+- *Client-side aggregation by fanning out to `/api/commitments`, `/api/delegations`, `/api/captures`.* Rejected — three round-trips, duplicated priority logic in TS, and the "delegate-this" heuristic needs a cross-entity query (find delegations linked to same person) that is cleaner on the server.
+
+**Rationale:** The read volume is tiny (one user, tens to low-hundreds of open items). Postgres can trivially serve three filtered queries per request. Keeping the logic server-side centralises scoring and isolates future changes from the frontend.
+
+### D2. Priority scoring formula
+
+**Decision:** A deterministic additive score computed per item. Higher score = higher priority. Rounded to an int for display stability.
+
+For **commitments** (open, direction `MineToThem`):
+
+```
+score = 0
+if IsOverdue: score += 100 + min(daysOverdue * 5, 100)          // caps contribution at +200
+else if DueDate within CommitmentDueSoonDays:
+    score += max(0, 50 - (daysUntilDue * 5))                    // 50 today, 0 at window edge
+if DueDate is null: score += 10                                 // low-signal nudge
+```
+
+For **delegations** (status `Assigned`|`InProgress`|`Blocked`):
+
+```
+priorityWeight = { Urgent: 60, High: 40, Medium: 20, Low: 5 }[delegation.Priority]
+score = priorityWeight
+if IsOverdue: score += 80 + min(daysOverdue * 4, 80)
+daysSinceTouch = (now - (LastFollowedUpAt ?? CreatedAt)).Days
+if daysSinceTouch >= DelegationStalenessDays:
+    score += min((daysSinceTouch - DelegationStalenessDays) * 3 + 20, 80)
+if status == Blocked: score += 25                                // surface blockers
+```
+
+For **captures** (not triaged AND status in {Raw, Failed} OR status=Processed with extraction unresolved):
+
+```
+daysSinceCaptured = (now - CapturedAtUtc).Days
+if daysSinceCaptured < CaptureStalenessDays: skip                // not in queue yet
+score = 30 + min((daysSinceCaptured - CaptureStalenessDays) * 4, 60)
+if status == Failed: score += 20                                 // failures are sticky
+```
+
+Secondary sort (ties): `DueDate asc, CapturedAt desc, Id asc` — deterministic.
+
+**Alternatives considered:**
+
+- *Weighted multiplicative formula.* Harder to reason about and to unit-test.
+- *LLM-based priority.* Latency, cost, non-determinism; unsuitable for v1.
+
+**Rationale:** Trivially unit-testable, documented, user-tunable later.
+
+### D3. "Delegate this" suggestion heuristic
+
+**Decision:** Transient, per-request, computed in `QueuePrioritizationService`.
+
+A commitment queue item has `suggestDelegate = true` iff **all** hold:
+
+1. Item is a commitment with direction `MineToThem` and status `Open`
+2. Commitment has a non-null `PersonId`
+3. The user has ≥ 1 existing delegation to that same `PersonId` whose status is not `Cancelled`/`Completed` OR any delegation (including completed) to that same person — we pick "any non-cancelled delegation ever" as the established-relationship signal
+4. There is no existing open delegation whose `Notes` or `Description` references this commitment's ID (we don't persist a link; this is just "we haven't already acted on it"). **V1 simplification:** skip check 4 — we emit the hint regardless and rely on the user to ignore duplicates. Reconsider in v2 if it's noisy.
+
+Implementation: preload a `HashSet<Guid>` of `PersonIds` with active delegations for the user in one query, then membership-check per commitment item in memory. Because this HashSet lives purely in memory for scoring (never in EF LINQ), it does NOT trip the EF `HashSet.Contains` translation pitfall.
+
+### D4. Filtering
+
+**Decision:** Query-string filters applied server-side:
+
+- `scope`: `overdue` (only items whose `IsOverdue` is true, or captures past staleness) | `today` (due today or overdue; captures always included) | `thisWeek` (due within 7 calendar days or overdue) | `all` (default)
+- `itemType`: repeated query param, e.g. `?itemType=commitment&itemType=delegation`; defaults to all three
+- `personId`: a single Guid. Matches commitment.PersonId, delegation.DelegatePersonId, capture.LinkedPersonIds containment
+- `initiativeId`: a single Guid. Matches commitment.InitiativeId, delegation.InitiativeId, capture.LinkedInitiativeIds containment
+
+All filters are composable. Unknown enum values return HTTP 400.
+
+### D5. EF Core LINQ
+
+**Decision:** Three independent `IQueryable`s (one per aggregate), each applying user-scope and applicable filters at the database level. Materialise, then union, score, sort, and page in memory.
+
+**CLAUDE.md compliance:**
+
+- Use `List<T>.Contains(x)` for Guid set membership inside `Where` — never `HashSet.Contains` (untranslatable)
+- No `.ToLowerInvariant()` — we don't do any string comparison in predicates, but keep the rule in mind if filters ever expand
+- Return DTOs (`QueueItemResponse`), never domain entities
+
+### D6. Endpoint shape
+
+`GET /api/my-queue?scope={scope}&itemType={type}&itemType={type}&personId={guid}&initiativeId={guid}`
+
+Response:
+
+```
+{
+  items: [
+    {
+      itemType: "commitment" | "delegation" | "capture",
+      id: Guid,                     // source aggregate ID
+      title: string,                // description or title
+      status: string,               // source aggregate status
+      dueDate: string? (ISO),       // commitments / delegations only
+      isOverdue: bool,
+      personId: Guid?,
+      personName: string?,
+      initiativeId: Guid?,
+      initiativeName: string?,
+      daysSinceCaptured: int?,      // captures only
+      lastFollowedUpAt: string?,    // delegations only
+      priorityScore: int,
+      suggestDelegate: bool         // commitments only; always false otherwise
+    },
+    ...
+  ],
+  counts: {
+    overdue: int,
+    dueSoon: int,
+    staleCaptures: int,
+    staleDelegations: int,
+    total: int
+  },
+  filters: {
+    scope: "all",
+    itemType: ["commitment", "delegation", "capture"],
+    personId: null,
+    initiativeId: null
+  }
+}
+```
+
+Sorted by `priorityScore desc` with D2's tiebreakers. No pagination in v1 — the list is expected to be short.
+
+### D7. Config
+
+Three `IOptions<MyQueueOptions>` values with defaults: `CommitmentDueSoonDays=7`, `DelegationStalenessDays=7`, `CaptureStalenessDays=3`. Bound from `appsettings.json` section `MyQueue`. Defaults baked in so the default build is fully functional without config changes.
+
+### D8. Frontend structure
+
+- `src/MentalMetal.Web/ClientApp/src/app/features/my-queue/`
+  - `my-queue.page.ts` — standalone page component, injects `MyQueueService`, holds filter signals
+  - `my-queue.service.ts` — `HttpClient` + `signal()` state for queue response
+  - `my-queue-item.component.ts` — renders a single row, type-aware badges/buttons
+  - `my-queue.routes.ts` — lazy-loaded route
+- Navigation entry added to the existing shell layout
+- Use PrimeNG `Card`, `Tag`, `Button`, `SelectButton`/`Chip` for scope filter; `tailwindcss-primeui` utilities (`bg-surface-0`, `text-muted-color`, `bg-primary`) for colours
+- No `*ngIf`/`*ngFor` — exclusively `@if`/`@for`; no `dark:` prefixes; no hardcoded hex
+
+Inline "Delegate this" button on commitment rows where `suggestDelegate` is true navigates to `/delegations/new?description=...&personId=...&sourceCommitmentId=...` (the delegation-create form already accepts pre-filled query params per its existing route).
+
+## Risks / Trade-offs
+
+- **[In-memory scoring on potentially growing lists]** → Cap the per-type query: in the handler, fetch at most (say) 200 candidate items per type from the database, sorted by due/captured date, so the post-union memory work stays bounded. 200 is far above typical usage; if a user exceeds it we'll extend paging.
+- **[Priority formula feels arbitrary]** → Pure functions, fully unit-tested per branch; tunable via options later. Users can still use the filters to focus manually.
+- **[Delegate-this hint may be noisy]** → V1 ships with the simplified heuristic. Include telemetry/log when hint fires. If friction is reported in dogfooding, upgrade to D3's stricter check 4 by persisting a `SuggestedDelegationSource` link on the `Delegation` aggregate — separate future change.
+- **[Three queries per request]** → Fine at this scale. If it becomes hot, a Postgres materialised view is the natural next step (D1 alternative).
+- **[Time-zone for "today" / "this week"]** → Use UTC day boundaries in v1, consistent with the rest of the codebase. Document in the endpoint summary. `nudges-rhythms` will likely introduce per-user TZ; we revisit then.
+
+## Migration Plan
+
+No database migration. Deployment is a standard application release. Rollback = redeploy previous image; no data to undo.
+
+## Open Questions
+
+- None blocking. Time-zone handling and stricter delegate-hint heuristic are flagged as known v2 follow-ups above.

--- a/openspec/changes/my-queue/proposal.md
+++ b/openspec/changes/my-queue/proposal.md
@@ -1,0 +1,52 @@
+# My Queue — Prioritised Attention View
+
+## Why
+
+Engineering managers juggle open commitments they owe, delegations they're waiting on, and captures they haven't yet triaged. Today these live on three separate screens with three independent filters; nothing surfaces "what deserves your attention right now". This Tier 3 feature unifies those existing data sources into a single prioritised view so the user can act from one place instead of context-switching through three lists.
+
+## What Changes
+
+- Add a new **My Queue** read model that unions data from already-shipped aggregates into a single list of queue items:
+  - Open **commitments** owed by the user (direction `MineToThem`) that are overdue or due within a configurable window (default: 7 days)
+  - Open **delegations** (`Assigned`, `InProgress`, `Blocked`) that are overdue OR have not been followed up on within a staleness threshold (default: 7 days since `LastFollowedUpAt` or `CreatedAt` if never followed up)
+  - **Captures** that are still awaiting triage after a configurable threshold (default: 3 days) — i.e. status `Raw` / `Failed` / `Processed`-but-unresolved beyond that window
+- Compute a numeric `priorityScore` per queue item from factors: overdue magnitude, delegation priority, days-until-due, capture staleness. Items are returned sorted by priority descending.
+- Add server-side filtering on the queue endpoint:
+  - `scope`: `overdue` | `today` | `thisWeek` | `all` (default `all`)
+  - `itemType`: `commitment` | `delegation` | `capture` (multi-select; default all)
+  - `personId` and `initiativeId` link filters (intersect against each item's linked person/initiative IDs)
+- Emit a `suggestDelegate: true` hint on commitment queue items where the heuristic fires: commitment is open, direction `MineToThem`, linked to a `PersonId` that the user has at least one existing (non-cancelled) delegation with, AND not already linked to an open delegation. This is a transient suggestion computed at query time — no persisted state.
+- Add a new **My Queue** Angular view (signals, zoneless, `@if`/`@for`, PrimeNG + `tailwindcss-primeui` tokens) as a top-level navigation entry. The view renders grouped queue items, scope/type filter chips, and an inline "Delegate this" action on commitments where `suggestDelegate` is true (navigates to the delegation create form pre-filled with description, linked person and `sourceCaptureId` carried through if present).
+- No new aggregate, no schema migration. All data derives from existing `Commitment`, `Delegation`, and `Capture` tables via a new `QueuePrioritizationService` in the Application layer.
+
+## Capabilities
+
+### New Capabilities
+- `my-queue`: Prioritised unified attention view that aggregates commitments, delegations, and pending captures into a single scored, filterable list with a contextual delegate-suggestion hint.
+
+### Modified Capabilities
+<!-- None — existing specs retain their behaviour. The new capability is strictly query-side over their data. -->
+
+## Non-goals
+
+- No changes to the `Commitment`, `Delegation`, or `Capture` aggregates, events, or persistence
+- No new background jobs, notifications, or push surfaces (that's `nudges-rhythms`, Tier 3)
+- No briefing generation or daily/weekly summarisation (that's `daily-weekly-briefing`, Tier 3)
+- No accept-and-create flow for the delegate suggestion beyond a pre-filled navigation — user still confirms in the existing delegation form
+- No AI-driven prioritisation in v1; priority is a deterministic formula. AI re-ranking can be layered later.
+- No persistence of the computed priority score or suggestions — each request recomputes
+
+## Affected Aggregates & Dependencies
+
+- **Tier**: 3 (Enhancement)
+- **Depends on**: `commitment-tracking`, `delegation-tracking`, `capture-ai-extraction` (all shipped and archived)
+- **Domain model aggregates read from**: `Commitment`, `Delegation`, `Capture` — all read-only. No behaviour added to existing aggregates.
+- **Service introduced**: `QueuePrioritizationService` (Application layer, stateless, per the `design/spec-plan.md` line-34 aggregate-column entry `(QueuePrioritizationService)`)
+
+## Impact
+
+- **Backend**: one new vertical-slice folder `src/MentalMetal.Application/Features/MyQueue/` with `GetMyQueue.cs` handler, supporting DTOs, and a `QueuePrioritizationService`. One new Minimal API endpoint group `/api/my-queue`. No migrations.
+- **Frontend**: one new feature folder under `src/MentalMetal.Web/ClientApp/src/app/features/my-queue/` with the queue list page component, signal-based service, filter controls, and route registration. New nav entry in the primary shell.
+- **Tests**: unit tests for `QueuePrioritizationService` scoring and suggestion heuristics, handler test (unioning + filtering + user isolation), Angular component test, and an integration test over the endpoint using seeded commitments/delegations/captures.
+- **Config**: two app-settings knobs (with sensible defaults baked in): `MyQueue:CommitmentDueSoonDays` (7), `MyQueue:CaptureStalenessDays` (3), `MyQueue:DelegationStalenessDays` (7). No secrets.
+- **API consumers**: none today beyond the Angular app. No versioning concerns.

--- a/openspec/changes/my-queue/specs/my-queue/spec.md
+++ b/openspec/changes/my-queue/specs/my-queue/spec.md
@@ -1,0 +1,269 @@
+# My Queue
+
+## ADDED Requirements
+
+### Requirement: Get the prioritised queue
+
+The system SHALL expose `GET /api/my-queue` returning the authenticated user's prioritised attention queue. The queue SHALL contain items derived from three sources, all scoped to the authenticated user's UserId:
+
+1. **Commitment items** — every Commitment belonging to the user with `Status = Open` AND (`IsOverdue = true` OR `DueDate` is null OR `DueDate` is within `CommitmentDueSoonDays` (default 7) calendar days from now).
+2. **Delegation items** — every Delegation belonging to the user with `Status` in `{Assigned, InProgress, Blocked}` AND (`IsOverdue = true` OR `(now - (LastFollowedUpAt ?? CreatedAt)).Days >= DelegationStalenessDays` (default 7) OR `Priority` in `{High, Urgent}`).
+3. **Capture items** — every Capture belonging to the user that is NOT triaged AND is in one of: `Status = Raw`, `Status = Failed`, or `Status = Processed` with its extraction neither confirmed nor discarded, AND `(now - CapturedAtUtc).Days >= CaptureStalenessDays` (default 3).
+
+Each item SHALL have a deterministically computed `priorityScore` (integer) per the scoring rules, and items SHALL be returned sorted by `priorityScore` descending, with ties broken by (dueDate ascending, then capturedAt descending, then id ascending).
+
+#### Scenario: Empty queue
+
+- **WHEN** an authenticated user with no qualifying commitments, delegations, or captures sends GET /api/my-queue
+- **THEN** the system returns HTTP 200 with an empty items array and all counts equal to 0
+
+#### Scenario: Mixed queue across all three sources
+
+- **WHEN** an authenticated user has one overdue open MineToThem commitment, one In-Progress delegation last followed up 10 days ago, and one Raw capture from 5 days ago
+- **THEN** the response contains three items of types `commitment`, `delegation`, and `capture`
+- **AND** each has a positive priorityScore
+
+#### Scenario: User isolation
+
+- **WHEN** User A and User B each have qualifying items
+- **THEN** each user's queue contains only their own items
+
+#### Scenario: Non-qualifying items excluded
+
+- **WHEN** an authenticated user has a Completed commitment, a Completed delegation, and a triaged capture
+- **THEN** none of those items appear in the queue
+
+#### Scenario: Commitment without due date qualifies
+
+- **WHEN** an authenticated user has an Open MineToThem commitment with no DueDate
+- **THEN** the commitment appears in the queue with a positive priorityScore
+
+### Requirement: Priority score is deterministic
+
+The system SHALL compute `priorityScore` via a pure deterministic function of the item's current state and the configured thresholds. Two identical queries against identical data at the same wall-clock day SHALL return identical scores and identical ordering.
+
+#### Scenario: Overdue commitment scores higher than due-soon commitment
+
+- **WHEN** the queue contains one commitment 3 days overdue and one commitment due in 3 days, all else equal
+- **THEN** the overdue commitment has a higher priorityScore and appears first
+
+#### Scenario: Urgent delegation scores higher than Low delegation
+
+- **WHEN** the queue contains two in-progress delegations, one Urgent and one Low, with identical ages and no due dates
+- **THEN** the Urgent delegation has a higher priorityScore and appears first
+
+#### Scenario: Blocked delegation receives a blocker bump
+
+- **WHEN** the queue contains two otherwise-identical delegations, one InProgress and one Blocked
+- **THEN** the Blocked delegation has a strictly higher priorityScore than the InProgress one
+
+#### Scenario: Failed capture scores higher than an equally-old Raw capture
+
+- **WHEN** the queue contains two captures of equal age past the staleness threshold, one Raw and one Failed
+- **THEN** the Failed capture has a strictly higher priorityScore
+
+### Requirement: Filter by scope
+
+The endpoint SHALL accept a `scope` query parameter with allowed values `overdue`, `today`, `thisWeek`, `all`. Default is `all`.
+
+- `overdue` — include only items whose `isOverdue` is true OR captures that qualify on staleness
+- `today` — include items due today or overdue; captures always included if they otherwise qualify
+- `thisWeek` — include items due within 7 calendar days (inclusive of overdue); captures always included
+- `all` — no additional filtering beyond base qualification
+
+Unknown values SHALL return HTTP 400.
+
+#### Scenario: Overdue scope filters out future-due items
+
+- **WHEN** an authenticated user has one overdue commitment and one commitment due in 3 days and sends GET /api/my-queue?scope=overdue
+- **THEN** only the overdue commitment appears in the response
+
+#### Scenario: ThisWeek scope includes items due within 7 days
+
+- **WHEN** the queue has commitments due in 2, 5, and 10 days and the user requests scope=thisWeek
+- **THEN** only the commitments due in 2 and 5 days appear
+
+#### Scenario: Invalid scope rejected
+
+- **WHEN** an authenticated user sends GET /api/my-queue?scope=someday
+- **THEN** the system returns HTTP 400
+
+### Requirement: Filter by item type
+
+The endpoint SHALL accept a repeated `itemType` query parameter with allowed values `commitment`, `delegation`, `capture`. When the parameter is absent, all three types are included. Unknown values SHALL return HTTP 400.
+
+#### Scenario: Single type filter
+
+- **WHEN** an authenticated user with mixed items sends GET /api/my-queue?itemType=commitment
+- **THEN** the response contains only items with itemType=commitment
+
+#### Scenario: Multiple type filter
+
+- **WHEN** an authenticated user sends GET /api/my-queue?itemType=commitment&itemType=delegation
+- **THEN** the response contains items with itemType commitment or delegation, but no captures
+
+#### Scenario: Unknown item type rejected
+
+- **WHEN** an authenticated user sends GET /api/my-queue?itemType=other
+- **THEN** the system returns HTTP 400
+
+### Requirement: Filter by linked person and initiative
+
+The endpoint SHALL accept optional `personId` and `initiativeId` query parameters (Guid). When supplied:
+
+- `personId` matches commitment.PersonId, delegation.DelegatePersonId, and captures whose LinkedPersonIds contain the value.
+- `initiativeId` matches commitment.InitiativeId, delegation.InitiativeId, and captures whose LinkedInitiativeIds contain the value.
+
+Filters SHALL combine conjunctively with scope and itemType filters.
+
+#### Scenario: Filter by person
+
+- **WHEN** an authenticated user sends GET /api/my-queue?personId={SarahId} and has one commitment with Sarah and one commitment with Alex
+- **THEN** the response contains only the commitment linked to Sarah
+
+#### Scenario: Filter by initiative
+
+- **WHEN** an authenticated user sends GET /api/my-queue?initiativeId={PlatformId}
+- **THEN** the response contains only items whose initiativeId equals PlatformId, or captures whose LinkedInitiativeIds contain PlatformId
+
+#### Scenario: Combined filters
+
+- **WHEN** an authenticated user sends GET /api/my-queue?scope=overdue&itemType=delegation&personId={AlexId}
+- **THEN** the response contains only overdue delegations assigned to Alex
+
+### Requirement: Suggest delegate hint on commitments
+
+The system SHALL, for each commitment queue item, set `suggestDelegate = true` when all of the following hold:
+
+1. The item type is `commitment`
+2. The Commitment has `Status = Open` AND `Direction = MineToThem`
+3. The Commitment has a non-null `PersonId`
+4. The user has at least one Delegation whose `DelegatePersonId` equals the Commitment's `PersonId` and whose `Status` is not `Cancelled`
+
+For all other items (including delegations, captures, and commitments that fail any check), `suggestDelegate` SHALL be `false`.
+
+#### Scenario: Commitment with established delegation relationship
+
+- **WHEN** the user has an open MineToThem commitment with PersonId=Sarah AND has an InProgress delegation to Sarah
+- **THEN** the commitment queue item has suggestDelegate=true
+
+#### Scenario: Commitment with no established delegation relationship
+
+- **WHEN** the user has an open MineToThem commitment with PersonId=Alex and no delegations to Alex
+- **THEN** the commitment queue item has suggestDelegate=false
+
+#### Scenario: TheirsToMe commitment never suggests delegate
+
+- **WHEN** the user has an open TheirsToMe commitment with PersonId=Sarah and an InProgress delegation to Sarah
+- **THEN** the commitment queue item has suggestDelegate=false
+
+#### Scenario: Delegation items never suggest delegate
+
+- **WHEN** a delegation appears in the queue
+- **THEN** its suggestDelegate field is false
+
+#### Scenario: Capture items never suggest delegate
+
+- **WHEN** a capture appears in the queue
+- **THEN** its suggestDelegate field is false
+
+### Requirement: Queue response includes counts
+
+The response SHALL include a `counts` object with fields:
+
+- `overdue` — number of items where `isOverdue = true` (captures never count here)
+- `dueSoon` — number of commitment/delegation items due within `CommitmentDueSoonDays` and not overdue
+- `staleCaptures` — number of capture items in the queue
+- `staleDelegations` — number of delegation items whose days-since-touch equals or exceeds `DelegationStalenessDays`
+- `total` — total number of items after filtering
+
+Counts SHALL reflect the items returned AFTER filters are applied.
+
+#### Scenario: Counts reflect filters
+
+- **WHEN** a user has 2 overdue commitments and 3 captures and sends GET /api/my-queue?itemType=commitment
+- **THEN** the response counts show total=2 and staleCaptures=0
+
+#### Scenario: Counts on empty queue
+
+- **WHEN** a user with no items sends GET /api/my-queue
+- **THEN** every count is 0
+
+### Requirement: Queue item fields
+
+Each queue item SHALL expose the following fields. Fields not applicable to a given item type SHALL be null:
+
+- `itemType`: `commitment` | `delegation` | `capture`
+- `id`: the source aggregate id (Guid)
+- `title`: the commitment description, delegation description, or capture title
+- `status`: the source aggregate's status enum value as a string
+- `dueDate`: ISO date string (commitments and delegations only)
+- `isOverdue`: boolean (commitments and delegations only; always false for captures)
+- `personId` / `personName`: linked person (commitment.PersonId, delegation.DelegatePersonId, or first capture.LinkedPersonIds — otherwise null)
+- `initiativeId` / `initiativeName`: linked initiative (commitment.InitiativeId, delegation.InitiativeId, or first capture.LinkedInitiativeIds — otherwise null)
+- `daysSinceCaptured`: integer (captures only; null otherwise)
+- `lastFollowedUpAt`: ISO timestamp (delegations only; null otherwise)
+- `priorityScore`: integer
+- `suggestDelegate`: boolean
+
+#### Scenario: Commitment item fields populated
+
+- **WHEN** a commitment queue item is returned
+- **THEN** itemType=commitment, title equals the commitment description, dueDate, isOverdue, personId, personName are populated from the commitment, and daysSinceCaptured, lastFollowedUpAt are null
+
+#### Scenario: Capture item fields populated
+
+- **WHEN** a capture queue item is returned
+- **THEN** itemType=capture, daysSinceCaptured is a non-negative integer, dueDate and isOverdue are null/false, and lastFollowedUpAt is null
+
+#### Scenario: Delegation item fields populated
+
+- **WHEN** a delegation queue item is returned
+- **THEN** itemType=delegation, lastFollowedUpAt reflects the delegation's value, dueDate and isOverdue reflect the delegation, and daysSinceCaptured is null
+
+### Requirement: Configurable thresholds
+
+The system SHALL expose a `MyQueue` options section with three integer knobs: `CommitmentDueSoonDays` (default 7), `DelegationStalenessDays` (default 7), `CaptureStalenessDays` (default 3). The thresholds SHALL influence both inclusion in the queue and priority scoring.
+
+#### Scenario: Defaults apply when unconfigured
+
+- **WHEN** the application starts with no `MyQueue` configuration section
+- **THEN** the effective thresholds are 7, 7, and 3 respectively
+
+#### Scenario: Configured override takes effect
+
+- **WHEN** appsettings configures `MyQueue:CaptureStalenessDays=1`
+- **THEN** captures at least 1 day old qualify for the queue
+
+### Requirement: Queue view UI
+
+The frontend SHALL provide a top-level **My Queue** route that fetches `GET /api/my-queue` via a signal-based service and renders a list of queue items with itemType indicator, title, linked person/initiative, status/priority badges, due date or days-since-captured, and the numeric priority. The page SHALL render scope filter controls (overdue/today/thisWeek/all) and item-type toggles that re-issue the query. The page SHALL NOT use `*ngIf`, `*ngFor`, `*ngSwitch`, or `[ngClass]` directives; it SHALL use `@if`, `@for`, `@switch`, and `[class.x]` signal-aware syntax. Colours SHALL use PrimeNG / `tailwindcss-primeui` tokens only (no hardcoded Tailwind colour utilities, no `dark:` prefix).
+
+#### Scenario: User opens the queue
+
+- **WHEN** an authenticated user navigates to /my-queue
+- **THEN** the app fetches the queue and displays the items ordered by priority
+
+#### Scenario: User changes scope
+
+- **WHEN** the user clicks the "Overdue" scope chip
+- **THEN** the queue re-fetches with scope=overdue and the list updates
+
+#### Scenario: Empty state
+
+- **WHEN** the user's queue is empty
+- **THEN** the page shows an empty-state message and no list
+
+### Requirement: Inline delegate suggestion UI
+
+When a commitment queue item's `suggestDelegate` is true, the UI SHALL render an inline "Delegate this" action. Activating the action SHALL navigate to the existing delegation creation route with query parameters pre-filling `description` (from the commitment description), `personId` (from the commitment's PersonId), `initiativeId` (from the commitment's InitiativeId, when set), and `sourceCommitmentId` (the commitment id).
+
+#### Scenario: Delegate hint shown and action dispatched
+
+- **WHEN** the queue includes a commitment with suggestDelegate=true AND the user clicks "Delegate this" on that row
+- **THEN** the app navigates to the delegation create form with description, personId, and sourceCommitmentId pre-filled
+
+#### Scenario: Delegate hint not shown
+
+- **WHEN** a commitment queue item has suggestDelegate=false
+- **THEN** the row does not render the "Delegate this" action

--- a/openspec/changes/my-queue/tasks.md
+++ b/openspec/changes/my-queue/tasks.md
@@ -1,0 +1,47 @@
+## 1. Application layer — MyQueue feature slice
+
+- [ ] 1.1 Create `src/MentalMetal.Application/Features/MyQueue/` folder with `MyQueueOptions.cs` binding `MyQueue:CommitmentDueSoonDays`, `MyQueue:DelegationStalenessDays`, `MyQueue:CaptureStalenessDays` (defaults 7, 7, 3)
+- [ ] 1.2 Register `MyQueueOptions` via `services.Configure<MyQueueOptions>(config.GetSection("MyQueue"))` in the Application DI extension (alongside the other feature-option registrations)
+- [ ] 1.3 Define DTOs in `MyQueue/Contracts/`: `QueueItemResponse`, `QueueCountsResponse`, `QueueFiltersResponse`, `MyQueueResponse`, `QueueItemType` enum (`Commitment`, `Delegation`, `Capture`), `QueueScope` enum (`All`, `Overdue`, `Today`, `ThisWeek`)
+- [ ] 1.4 Implement `QueuePrioritizationService` with pure `ScoreCommitment`, `ScoreDelegation`, `ScoreCapture` methods per design/D2, taking a `DateTimeOffset now` and `MyQueueOptions` — no I/O
+- [ ] 1.5 Implement `GetMyQueueHandler.cs` (record command/query + handler) that: (a) loads user's qualifying commitments, delegations, captures via existing repositories, (b) applies scope/itemType/personId/initiativeId filters, (c) projects to `QueueItemResponse`, (d) computes `suggestDelegate` using in-memory `HashSet<Guid>` of PersonIds from user's non-cancelled delegations, (e) orders by `priorityScore desc` with tiebreakers, (f) computes `counts`
+- [ ] 1.6 Resolve person/initiative display names via existing repos in a single batched lookup (collect Ids, one round-trip each); tolerate missing names (fall back to null)
+- [ ] 1.7 Ensure all EF LINQ predicates use `List<T>.Contains` (not `HashSet.Contains`) and `.ToLower()` (not `.ToLowerInvariant()`); cap per-type candidate fetch at 200 rows
+
+## 2. Web layer — endpoint
+
+- [ ] 2.1 Add `src/MentalMetal.Web/Endpoints/MyQueueEndpoints.cs` with `MapMyQueueEndpoints(this IEndpointRouteBuilder)` mapping `GET /api/my-queue` with required auth
+- [ ] 2.2 Parse query params: `scope` (enum, default `All`), repeated `itemType` (enum list, default all), `personId` (Guid?), `initiativeId` (Guid?); return 400 on invalid enum values
+- [ ] 2.3 Dispatch to `GetMyQueueHandler`, return `Results.Ok(MyQueueResponse)`
+- [ ] 2.4 Wire `app.MapMyQueueEndpoints()` into `Program.cs` alongside the other feature endpoint groups
+
+## 3. Backend tests
+
+- [ ] 3.1 Add `tests/MentalMetal.Application.Tests/Features/MyQueue/QueuePrioritizationServiceTests.cs` covering: overdue commitment > due-soon, urgent delegation > low, blocked delegation bump, failed capture bump, no-due-date commitment, tie-breakers, bounded overdue contribution
+- [ ] 3.2 Add `GetMyQueueHandlerTests.cs` covering: empty queue, mixed queue, user isolation, filter by scope (overdue/today/thisWeek/all), filter by itemType (single + multiple + invalid), filter by personId, filter by initiativeId, combined filters, counts correctness, `suggestDelegate` heuristic (all 4 scenarios from spec), candidate fetch cap
+- [ ] 3.3 Add `tests/MentalMetal.Web.IntegrationTests/MyQueueEndpointTests.cs` covering: 200 happy path, 400 on invalid scope, 400 on invalid itemType, response shape matches spec, auth required, cross-user isolation
+- [ ] 3.4 Run `dotnet test src/MentalMetal.slnx` and confirm green
+
+## 4. Frontend feature slice
+
+- [ ] 4.1 Create `src/MentalMetal.Web/ClientApp/src/app/features/my-queue/my-queue.service.ts` using `inject(HttpClient)`, holding `readonly response = signal<MyQueueResponse | null>(null)` and `readonly loading = signal(false)`, exposing a `load(filters)` method
+- [ ] 4.2 Create `my-queue.page.ts` standalone component that injects the service, holds filter signals (`scope`, `itemType[]`, `personId`, `initiativeId`), triggers `load()` on filter change, and renders the list
+- [ ] 4.3 Create `my-queue-item.component.ts` standalone component rendering one queue item with type-aware badge, title, person/initiative name, due or days-since-captured, priority score, and the inline "Delegate this" action when `suggestDelegate` is true
+- [ ] 4.4 Use only `@if`/`@for`/`@switch` for control flow. Use only PrimeNG / `tailwindcss-primeui` tokens for colours (`bg-primary`, `text-muted-color`, `bg-surface-0`, PrimeNG `Tag`/`Badge` severities). No `*ngIf`/`*ngFor`, no `dark:`, no hardcoded Tailwind colour utilities
+- [ ] 4.5 Add lazy route at `/my-queue` in the app routes. Add a "My Queue" entry to the primary navigation shell
+- [ ] 4.6 On "Delegate this" click, `router.navigate` to the delegation create route with query params `description`, `personId`, `initiativeId?`, `sourceCommitmentId`
+- [ ] 4.7 Verify the existing delegation create page reads those query params on init; if it does not already, extend it to pre-fill from those params (minimal Boy-Scout edit, scoped to lines being modified)
+
+## 5. Frontend tests
+
+- [ ] 5.1 Add `my-queue.service.spec.ts` covering success, filter-param serialisation (especially repeated `itemType`), and error
+- [ ] 5.2 Add `my-queue.page.spec.ts` covering: renders items, scope chip change triggers reload, empty state, loading state, delegate-this navigation
+- [ ] 5.3 Run `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` and confirm green
+
+## 6. Wiring & verification
+
+- [ ] 6.1 Add minimal appsettings documentation (comment block in appsettings.Development.json if present, otherwise rely on defaults) — do not add secrets
+- [ ] 6.2 Run `dotnet build src/MentalMetal.slnx` and `dotnet test src/MentalMetal.slnx`
+- [ ] 6.3 Run the Angular test suite
+- [ ] 6.4 Manual smoke: start dev stack, seed a commitment, delegation, and stale capture; hit `/api/my-queue` and the `/my-queue` page to verify round-trip
+- [ ] 6.5 Run `openspec verify --change my-queue` if available; otherwise spot-check that every spec scenario maps to at least one test


### PR DESCRIPTION
## Summary

Propose the Tier 3 `my-queue` OpenSpec change. This PR contains artifacts only (proposal, design, specs, tasks) — no code changes. Implementation follows in a separate `/opsx:apply` PR.

**Spec**: [my-queue](openspec/changes/my-queue/specs/my-queue/spec.md)

## Changes

- `openspec/changes/my-queue/proposal.md` — why, what changes, capabilities, impact, non-goals
- `openspec/changes/my-queue/design.md` — scoring formula, filtering, delegate-hint heuristic, EF Core notes, frontend structure
- `openspec/changes/my-queue/specs/my-queue/spec.md` — 10 ADDED requirements covering the endpoint, scoring, filters, suggest-delegate hint, counts, config, and UI
- `openspec/changes/my-queue/tasks.md` — implementation checklist grouped into Application, Web, tests, frontend, wiring
- `openspec/changes/my-queue/.openspec.yaml` — change scaffold

My Queue is a purely read-side feature: unions qualifying commitments, delegations, and stale captures into a single scored, filterable list, and emits a "delegate this" hint on commitments linked to a person the user has an established delegation relationship with. No new aggregate, no migration. Depends on already-shipped `commitment-tracking`, `delegation-tracking`, and `capture-ai-extraction`.

## Test Plan

- [x] Artifacts-only PR — no test suites apply
- [x] `openspec status --change my-queue` reports 4/4 artifacts complete
- [ ] Review artifacts for consistency between proposal, design, spec, and tasks

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)