### PR TITLE
docs(openspec): propose daily-weekly-briefing change

### DIFF
--- a/openspec/changes/daily-weekly-briefing/.openspec.yaml
+++ b/openspec/changes/daily-weekly-briefing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/daily-weekly-briefing/design.md
+++ b/openspec/changes/daily-weekly-briefing/design.md
@@ -1,0 +1,137 @@
+## Context
+
+Mental Metal has shipped all the building blocks: People, Initiatives, Commitments, Delegations, Captures, Living Briefs, My Queue, People Lens (OneOnOne / Observation / Goal). What users still do manually every morning is open six tabs to assemble context for the day. This spec delivers the integrating layer — a `BriefingService` that reads across aggregates, assembles deterministic facts, and asks the user's configured LLM to turn those facts into a short, readable briefing.
+
+Three briefing shapes cover the daily workflow:
+
+- **Morning** — "what to focus on today"
+- **Weekly** — "what's coming this week and what's slipping"
+- **1:1 Prep** — "context you need before talking to this person"
+
+All data sources already exist via existing repositories. This change adds one read-model aggregate (`Briefing`), one Application slice, one Infrastructure repository + migration, API endpoints, and a thin frontend layer.
+
+## Dependencies
+
+- `user-auth-tenancy` — auth + `IUserContext` used for scoping.
+- `ai-provider-abstraction` — `IAiCompletionService` + the user's `AiProviderConfig` for LLM calls.
+- `person-management` — Person repository, `IPersonRepository`.
+- `initiative-management` — Initiative repository, milestones.
+- `commitment-tracking` — Commitment repository, due dates, direction.
+- `delegation-tracking` — Delegation repository, status, last-followed-up-at.
+- `people-lens` — OneOnOne, Observation, Goal repositories.
+- `initiative-living-brief` — LivingBrief repository.
+- `my-queue` — reuse queue scoring for "top items today" section (not a hard dependency — morning briefing computes its own top list using the same primitives but does not call the queue endpoint directly).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One on-demand API per briefing type that assembles facts deterministically and produces a short markdown narrative.
+- Persist each generated briefing so users can scroll back through their week.
+- Deterministic testability — services take `TimeProvider`; facts assembly is unit-testable without the LLM; a `FakeAiCompletionService` in tests returns canned content.
+- Surface the morning briefing on the dashboard with a "last generated at" timestamp and a regenerate button.
+
+**Non-Goals:**
+- Scheduled generation or email delivery — deferred to `nudges-rhythms`.
+- Streaming token-by-token UI — the endpoint returns the completed briefing.
+- Editing stored briefings — read-only once generated.
+- Cross-user comparison, team roll-ups, manager-of-manager views.
+- Fancy "diff since yesterday" or delta summarisation — future enhancement.
+
+## Decisions
+
+### 1. Briefing as a thin read-model aggregate, not rich domain
+
+**Decision:** `Briefing` is a lightweight user-scoped entity — Id, UserId, Type (enum), ScopeKey (string), GeneratedAtUtc, MarkdownBody, PromptFacts (jsonb — the deterministic inputs used), Model, InputTokens, OutputTokens. It has minimal behaviour (factory creation, nothing mutable after creation).
+
+**Rationale:** Briefings are artefacts of a computation — not aggregates with long-lived invariants. Treating them as rich aggregates adds ceremony without value. This matches the pattern already used for `ChatMessage` append-only records.
+
+**Alternative considered:** Generate-and-throw-away (no persistence). Rejected because history has real value — "what did I tell myself to focus on Monday morning?" — and persisting lets us avoid calling the LLM on every page load.
+
+### 2. ScopeKey scheme
+
+**Decision:** `ScopeKey` is a deterministic string per (type, date-or-person):
+- Morning: `morning:{yyyy-MM-dd}` in the user's local date (derived from `User.Preferences.TimeZone`, or UTC if unset).
+- Weekly: `weekly:{ISO-year}-W{ISO-week}` (e.g., `weekly:2026-W16`).
+- 1:1 prep: `oneonone:{personId:N}` — one current prep per person; regenerating replaces the row semantically by appending a new row with the same scopeKey but newer `GeneratedAtUtc`; the "current" prep is simply max-generatedAt per scopeKey.
+
+**Rationale:** Lets us look up "today's morning briefing" cheaply with `WHERE UserId=X AND Type=Morning AND ScopeKey='morning:2026-04-14'` and return it if recent (< `WeeklyBriefingStaleHours`) without hitting the LLM.
+
+### 3. Facts assembly is deterministic and LLM-free
+
+**Decision:** Each briefing has two phases:
+1. **Facts phase** — pure C# query layer assembles a strongly-typed `MorningBriefingFacts` / `WeeklyBriefingFacts` / `OneOnOnePrepFacts` DTO containing all names/dates/counts/descriptions. No LLM.
+2. **Synthesis phase** — a small prompt formats the facts as JSON and asks the LLM to write a short markdown narrative (~200–400 words for morning, ~400–700 for weekly, ~300–500 for 1:1 prep), a one-sentence "focus" line, and 3–5 bullet talking points (1:1 prep only).
+
+The stored `PromptFacts` column retains the exact facts JSON so we can re-run or audit.
+
+**Rationale:** Deterministic inputs + small, structured prompts keep cost and latency bounded and eliminate a large class of hallucination (the LLM never invents names or dates — it only narrates supplied facts). Same pattern as `BriefMaintenanceService`.
+
+### 4. "Top items today" reuses queue-style scoring primitives, not the queue API
+
+**Decision:** Morning briefing computes its own "top 5 commitments / delegations due or overdue" list inline using the same EF queries as `my-queue` but scoped to due-today-or-overdue. It does not call `GET /api/my-queue` (no inter-service HTTP hops inside the server).
+
+**Rationale:** Keeps the briefing service self-contained; the two features will drift independently and the queue API's scoring is for a different UX (attention sorting) whereas the briefing wants "what must I do today".
+
+### 5. Cache-or-regenerate logic
+
+**Decision:** `POST /api/briefings/morning` semantics:
+- If a Briefing with `(UserId, Morning, morning:{today})` exists AND `GeneratedAtUtc` is within the last `WeeklyBriefingStaleHours` (default 12h), return 200 with that one.
+- Otherwise, generate a new one, persist it, return 201.
+- `?force=true` always regenerates.
+
+Same pattern for weekly and 1:1 prep (1:1 prep default staleness: 12h; override via `OneOnOnePrepStaleHours` option).
+
+### 6. Options + `TimeProvider`
+
+**Decision:** New `BriefingOptions` record with `[Range]` attributes:
+- `MorningBriefingHour` (0–23, default 5) — hour before which "today's" briefing is still considered yesterday's.
+- `WeeklyBriefingStaleHours` (1–72, default 12).
+- `OneOnOnePrepStaleHours` (1–72, default 12).
+- `MaxBriefingTokens` (200–4000, default 1500).
+- `TopItemsPerSection` (1–20, default 5).
+
+Wired via `AddOptions<BriefingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`.
+
+`BriefingService` depends on `TimeProvider` (injected, `TimeProvider.System` in prod). All "now" reads go through it.
+
+### 7. AI prompting strategy
+
+**Decision:** A dedicated `BriefingPromptBuilder` produces:
+- A short system prompt ("You are the user's engineering-management briefing assistant. Be concise. Use markdown. Do not invent facts not present in the input JSON.").
+- A user prompt with the facts JSON and instructions per briefing type. For 1:1 prep, we ask for a specific markdown template (Context / Open items / Talking points / Recent observations).
+
+Max tokens: `MaxBriefingTokens`. Temperature: 0.3 (low — factual). Returns `AiCompletionResult`; we store `Content` as `MarkdownBody` and `InputTokens`/`OutputTokens`/`Model` for cost accounting.
+
+### 8. Frontend surface
+
+**Decision:**
+- A signal-based `BriefingService` (Angular) with `loadMorning()`, `loadWeekly(force?)`, `loadOneOnOnePrep(personId, force?)`, `recent()`.
+- Dashboard already exists (home page); add a `MorningBriefingWidgetComponent` that lazily calls `loadMorning()` on mount, renders the markdown via an existing/new markdown pipe, shows generated-at + regenerate button.
+- New route `/briefings/weekly` with `WeeklyBriefingPageComponent`.
+- On the person detail page, a PrimeNG button "Generate 1:1 prep" opens a dialog/drawer with the 1:1 prep content.
+
+All components use standalone + signals + `@if`/`@for`/`@switch`, PrimeNG + `tailwindcss-primeui` tokens only. No `*ngIf`, no hardcoded Tailwind colours, no `dark:` prefix.
+
+### 9. Markdown rendering
+
+**Decision:** Render via a sanitising markdown pipe. If one does not already exist in the codebase, use `marked` + `DOMPurify` (both are well-vetted, small) or keep a minimal inline renderer. Detailed choice in tasks.
+
+## Risks / Trade-offs
+
+- **[LLM cost per morning] →** Mitigation: cache per day (ScopeKey) + `WeeklyBriefingStaleHours` prevents double-calls on refresh; facts phase is the expensive query but it's a single round-trip to Postgres.
+- **[LLM hallucination inventing names / counts] →** Mitigation: prompt explicitly forbids invention; facts are supplied as JSON; system prompt says "do not invent"; any rendered fact can be cross-checked against `PromptFacts`.
+- **[Time-zone drift — "today" in user's zone vs server]** → Mitigation: read zone from `User.Preferences.TimeZone` (existing field). Fallback: UTC. All date math in the service goes through a helper method `userLocalDate(now)`.
+- **[Large facts payload] →** Mitigation: `TopItemsPerSection` cap; never embed raw capture text, only titles; never embed full observation bodies for 1:1 prep, only summaries or the first 240 chars.
+- **[Race on repeated rapid POSTs] →** Mitigation: the persisted row uses a unique index on `(UserId, Type, ScopeKey, GeneratedAtUtc)`; duplicate-insert on identical timestamp is extremely unlikely (microsecond resolution) — if it happens, retry with new timestamp. Not a correctness issue.
+- **[AI provider not configured] →** If user has no `AiProviderConfig`, endpoint returns HTTP 409 with a clear error message; frontend surfaces "Set up your AI provider to generate briefings".
+
+## Migration Plan
+
+- New EF migration: `AddBriefings` — creates `Briefings` table with index on `(UserId, Type, ScopeKey, GeneratedAtUtc)`.
+- Rollback: `dotnet ef migrations remove` on the PR branch only; after merge, a forward `RemoveBriefings` migration would be required.
+- Feature is strictly additive — no changes to existing tables or read models.
+
+## Open Questions
+
+- Should we expose a "delete this briefing" endpoint? Not in this change — read-only history is fine; we can add later if storage becomes a concern.
+- Should weekly briefing be Monday-anchored or rolling 7 days? Decision: ISO-week (Monday–Sunday) for predictability; scope-key uses ISO week.

--- a/openspec/changes/daily-weekly-briefing/design.md
+++ b/openspec/changes/daily-weekly-briefing/design.md
@@ -50,11 +50,11 @@ All data sources already exist via existing repositories. This change adds one r
 ### 2. ScopeKey scheme
 
 **Decision:** `ScopeKey` is a deterministic string per (type, date-or-person):
-- Morning: `morning:{yyyy-MM-dd}` in the user's local date (derived from `User.Preferences.TimeZone`, or UTC if unset).
+- Morning: `morning:{yyyy-MM-dd}` in the user's local date (derived from `User.Preferences.TimeZone`, or UTC if unset). The local *hour* in the same time zone is also used to apply the `MorningBriefingHour` rollback.
 - Weekly: `weekly:{ISO-year}-W{ISO-week}` (e.g., `weekly:2026-W16`).
 - 1:1 prep: `oneonone:{personId:N}` — one current prep per person; regenerating replaces the row semantically by appending a new row with the same scopeKey but newer `GeneratedAtUtc`; the "current" prep is simply max-generatedAt per scopeKey.
 
-**Rationale:** Lets us look up "today's morning briefing" cheaply with `WHERE UserId=X AND Type=Morning AND ScopeKey='morning:2026-04-14'` and return it if recent (< `WeeklyBriefingStaleHours`) without hitting the LLM.
+**Rationale:** Lets us look up "today's morning briefing" cheaply with `WHERE UserId=X AND Type=Morning AND ScopeKey='morning:2026-04-14'` and return it if recent (< the per-type staleness option, e.g. `MorningBriefingStaleHours`) without hitting the LLM.
 
 ### 3. Facts assembly is deterministic and LLM-free
 
@@ -75,16 +75,17 @@ The stored `PromptFacts` column retains the exact facts JSON so we can re-run or
 ### 5. Cache-or-regenerate logic
 
 **Decision:** `POST /api/briefings/morning` semantics:
-- If a Briefing with `(UserId, Morning, morning:{today})` exists AND `GeneratedAtUtc` is within the last `WeeklyBriefingStaleHours` (default 12h), return 200 with that one.
+- If a Briefing with `(UserId, Morning, morning:{today})` exists AND `GeneratedAtUtc` is within the last `MorningBriefingStaleHours` (default 12h), return 200 with that one.
 - Otherwise, generate a new one, persist it, return 201.
 - `?force=true` always regenerates.
 
-Same pattern for weekly and 1:1 prep (1:1 prep default staleness: 12h; override via `OneOnOnePrepStaleHours` option).
+Same pattern for weekly (`WeeklyBriefingStaleHours`, default 12h) and 1:1 prep (`OneOnOnePrepStaleHours`, default 12h).
 
 ### 6. Options + `TimeProvider`
 
 **Decision:** New `BriefingOptions` record with `[Range]` attributes:
-- `MorningBriefingHour` (0–23, default 5) — hour before which "today's" briefing is still considered yesterday's.
+- `MorningBriefingHour` (0–23, default 5) — hour before which "today's" briefing is still considered yesterday's (in the user's local time zone).
+- `MorningBriefingStaleHours` (1–72, default 12).
 - `WeeklyBriefingStaleHours` (1–72, default 12).
 - `OneOnOnePrepStaleHours` (1–72, default 12).
 - `MaxBriefingTokens` (200–4000, default 1500).

--- a/openspec/changes/daily-weekly-briefing/proposal.md
+++ b/openspec/changes/daily-weekly-briefing/proposal.md
@@ -1,0 +1,51 @@
+# Daily / Weekly Briefing
+
+## Why
+
+Engineering managers spend the first 15–30 minutes of every morning mentally re-loading context: what's on today's calendar, who's waiting on me, what's overdue, what 1:1s are coming up. Mental Metal already has all the raw data — open commitments, delegations, people observations, living briefs, queue items — but nothing assembles it into a ready-to-read briefing. This change ties the core capabilities together into the highest-value daily user experience: one AI-generated page that tells the user "here's what matters today / this week / before your 1:1 with Sarah."
+
+This is Tier 3 per `design/spec-plan.md` and depends on already-shipped `people-lens`, `commitment-tracking`, `delegation-tracking`, `initiative-living-brief`, `my-queue`, plus `ai-provider-abstraction` for LLM generation.
+
+## What Changes
+
+- Introduce a `BriefingService` that generates three briefing types on demand:
+  - **Morning briefing** — today's priority commitments, today's 1:1s, top queue items, overdue delegations, one-sentence "focus for today".
+  - **Weekly briefing** — milestones and due-dates in the next 7 days, overdue items, people who haven't had a 1:1 recently, initiatives needing attention.
+  - **1:1 prep sheet** — per-person context: recent observations, open goals, pending commitments/delegations with that person, last 1:1 summary, AI-suggested talking points.
+- Persist each generated briefing as a read-model row (`Briefing` aggregate) keyed by `(UserId, Type, ScopeKey, GeneratedAtUtc)` so users can see history and avoid regenerating when unchanged.
+- Expose Minimal API endpoints:
+  - `POST /api/briefings/morning` and `POST /api/briefings/weekly` — generate or return cached briefing for today/this-week.
+  - `POST /api/briefings/one-on-one/{personId}` — generate 1:1 prep for a person.
+  - `GET /api/briefings/recent` and `GET /api/briefings/{id}` — read history.
+- AI generation uses the user's configured `AiProviderConfig` via `IAiCompletionService`; facts (dates, counts, names) are assembled deterministically from the database, and the AI only produces the narrative synthesis + talking points.
+- Frontend:
+  - Dashboard widget on the home page renders today's morning briefing (auto-generated once per day on first visit).
+  - New `/briefings/weekly` route with a "Generate" button and latest briefing rendered as markdown.
+  - Person detail page gains a **Generate 1:1 prep** action that opens a drawer/page with the prep sheet.
+
+**Non-goals**
+- Scheduled/emailed briefings (Tier 3 `nudges-rhythms` handles scheduling).
+- Editing or annotating briefings — read-only artefacts.
+- Cross-user or team briefings — single-user scope only.
+- Regenerating a briefing if its inputs haven't changed (simple staleness check: most-recent-per-(type, scope) is served; user can explicitly regenerate).
+
+## Capabilities
+
+### New Capabilities
+- `daily-weekly-briefing`: Morning, weekly, and 1:1 prep briefings generated on demand by a `BriefingService`, persisted as read-model rows, and surfaced in the dashboard, a weekly page, and the person detail page.
+
+### Modified Capabilities
+<!-- None. All inputs (commitments, delegations, people, observations, goals, one-on-ones, living briefs, queue scoring) are already specified; this spec consumes them through existing repositories and does not alter their requirements. -->
+
+## Impact
+
+- **New aggregate**: `Briefing` (lightweight read-model — id, userId, type, scopeKey, generatedAtUtc, markdownBody, tokensUsed, model). Not a rich domain aggregate; enforces only invariants on (userId, type, scopeKey) uniqueness per timestamp.
+- **New Application slice**: `MentalMetal.Application/Briefings/` (BriefingService, GenerateMorningBriefing, GenerateWeeklyBriefing, GenerateOneOnOnePrep, GetRecentBriefings, GetBriefing).
+- **New Infrastructure**: `BriefingRepository`, EF configuration, migration adding `Briefings` table.
+- **New Web endpoints**: `BriefingEndpoints.cs` under `Features/Briefings/`.
+- **AI**: consumes `IAiCompletionService` — no changes to provider abstraction.
+- **Frontend**: new `BriefingService` (Angular signal service), dashboard widget, `/briefings/weekly` route, person-detail action. Follows CLAUDE.md: `@if`/`@for`, PrimeNG/`tailwindcss-primeui` tokens, standalone components, signals, `inject()`.
+- **Options**: new `BriefingOptions` with `MorningBriefingHour` (local hour after which "today" briefing is valid; default 5), `WeeklyBriefingStaleHours` (default 12), `MaxBriefingTokens` (default 1500) — validated via `[Range]` + `ValidateDataAnnotations()` + `ValidateOnStart()`.
+- **Clock**: service takes `TimeProvider` injected (not `DateTime.UtcNow`) for testability.
+- **Dependencies**: consumes repositories for Commitments, Delegations, People, Observations, Goals, OneOnOnes, Initiatives, LivingBriefs, Captures (for queue-style "top items").
+- **Migration**: new EF migration `AddBriefings`.

--- a/openspec/changes/daily-weekly-briefing/specs/daily-weekly-briefing/spec.md
+++ b/openspec/changes/daily-weekly-briefing/specs/daily-weekly-briefing/spec.md
@@ -1,0 +1,254 @@
+## ADDED Requirements
+
+### Requirement: Generate morning briefing
+
+The system SHALL expose `POST /api/briefings/morning` that returns the authenticated user's morning briefing for today. The endpoint SHALL accept an optional `force` query parameter (default `false`).
+
+The response body SHALL be a `BriefingResponse` DTO containing `id`, `type` (`Morning`), `scopeKey`, `generatedAtUtc`, `markdownBody`, `model`, `inputTokens`, `outputTokens`, and `factsSummary` (an object with the deterministic facts used).
+
+Caching and staleness rules:
+
+- `scopeKey` SHALL equal `morning:{yyyy-MM-dd}` computed from the user's local date (derived from `User.Preferences.TimeZone`; fallback UTC). If the server's current local hour is less than `BriefingOptions.MorningBriefingHour`, the previous calendar date SHALL be used.
+- When `force = false` and a persisted briefing exists with the same `(UserId, Type=Morning, ScopeKey)` whose `GeneratedAtUtc` is within `BriefingOptions.WeeklyBriefingStaleHours` of now, the system SHALL return HTTP 200 with that persisted briefing.
+- Otherwise the system SHALL generate a new briefing, persist it, and return HTTP 201.
+
+Facts assembly: the system SHALL assemble `MorningBriefingFacts` deterministically from the user's own data, scoped to UserId:
+
+- `topCommitmentsDueToday` — up to `BriefingOptions.TopItemsPerSection` open commitments with `DueDate` equal to the user-local today OR `IsOverdue = true`, sorted by (overdue desc, dueDate asc, id asc).
+- `onOnOnesToday` — every OneOnOne with `OccurredOnUtc` (or scheduled date equivalent) whose local calendar date equals today.
+- `overdueDelegations` — up to `TopItemsPerSection` delegations with `IsOverdue = true`, sorted by daysOverdue desc.
+- `recentCaptures` — up to `TopItemsPerSection` captures `CapturedAtUtc >= now - 24h`, sorted by CapturedAtUtc desc.
+- `peopleNeedingAttention` — up to `TopItemsPerSection` people whose last OneOnOne was more than 14 days ago (or never) and who have at least one open commitment or delegation.
+
+Synthesis: the system SHALL call `IAiCompletionService` with a system prompt forbidding invention, a user prompt containing the facts JSON, `Temperature = 0.3`, and `MaxTokens = BriefingOptions.MaxBriefingTokens`. The returned markdown SHALL be stored as `MarkdownBody`.
+
+Authorisation: the endpoint SHALL require authentication; unauthenticated requests SHALL return HTTP 401.
+
+Provider precondition: if the user has no `AiProviderConfig` set, the system SHALL return HTTP 409 with an error code `ai_provider_not_configured`.
+
+#### Scenario: First call of the day generates a new briefing
+
+- **WHEN** an authenticated user with a configured AI provider sends `POST /api/briefings/morning` and no briefing exists for today's scopeKey
+- **THEN** the system assembles facts, calls the AI provider, persists a new `Briefing` row, and returns HTTP 201 with the body
+
+#### Scenario: Second call of the day returns cached briefing
+
+- **WHEN** a briefing was generated 30 minutes ago for today's scopeKey and the user calls `POST /api/briefings/morning` again
+- **THEN** the system returns HTTP 200 with the existing briefing and does NOT call the AI provider
+
+#### Scenario: Force regenerates even if cached
+
+- **WHEN** a briefing exists for today's scopeKey and the user calls `POST /api/briefings/morning?force=true`
+- **THEN** the system generates a new briefing, persists a new row, and returns HTTP 201
+
+#### Scenario: User without AI provider configured
+
+- **WHEN** a user with no `AiProviderConfig` sends `POST /api/briefings/morning`
+- **THEN** the system returns HTTP 409 with error code `ai_provider_not_configured` and does not persist a row
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** an unauthenticated client sends `POST /api/briefings/morning`
+- **THEN** the system returns HTTP 401
+
+#### Scenario: Time zone respected for scopeKey
+
+- **WHEN** User A has `Preferences.TimeZone = "Pacific/Auckland"` and calls the endpoint at a UTC time that is early-morning next-day in Auckland
+- **THEN** the scopeKey reflects the Auckland local date
+
+### Requirement: Generate weekly briefing
+
+The system SHALL expose `POST /api/briefings/weekly` that returns the authenticated user's briefing for the current ISO week. The endpoint SHALL accept an optional `force` query parameter.
+
+`scopeKey` SHALL equal `weekly:{ISO-year}-W{ISO-week:D2}` computed from the user's local date. Caching follows the same `WeeklyBriefingStaleHours` rule as morning briefings.
+
+Facts assembly `WeeklyBriefingFacts`:
+
+- `milestonesThisWeek` — up to 2 × `TopItemsPerSection` initiative milestones whose target date falls within Monday–Sunday of the current ISO week.
+- `overdueCommitments` / `overdueDelegations` — all items currently overdue, capped at 2 × `TopItemsPerSection` per type.
+- `initiativesNeedingAttention` — initiatives with status `AtRisk` or whose `LivingBrief.UpdatedAtUtc` is older than 7 days.
+- `peopleWithoutRecent1on1` — people with no OneOnOne in 21 days, capped at `TopItemsPerSection`.
+- `weekNumber` / `weekStartIso` / `weekEndIso` — labels for the prompt.
+
+Synthesis SHALL produce a markdown document with sections (Focus, Milestones, Overdue, Attention) of combined length ≤ `MaxBriefingTokens`.
+
+#### Scenario: Weekly briefing generated for the current ISO week
+
+- **WHEN** an authenticated user with a configured AI provider calls `POST /api/briefings/weekly` on 2026-04-14 (ISO week 16)
+- **THEN** the persisted row has `scopeKey = "weekly:2026-W16"` and HTTP 201 is returned
+
+#### Scenario: Weekly briefing caches within the week
+
+- **WHEN** a weekly briefing was generated 2 hours ago and the user calls the endpoint again
+- **THEN** HTTP 200 is returned and no AI call is made
+
+#### Scenario: Force regenerates
+
+- **WHEN** the user calls `POST /api/briefings/weekly?force=true`
+- **THEN** a new briefing is generated and persisted regardless of staleness
+
+### Requirement: Generate 1:1 prep sheet
+
+The system SHALL expose `POST /api/briefings/one-on-one/{personId}` that returns a prep sheet for the given person. The endpoint SHALL accept an optional `force` query parameter.
+
+`scopeKey` SHALL equal `oneonone:{personId:N}` (lowercase hex, no dashes). Caching uses `BriefingOptions.OneOnOnePrepStaleHours` (default 12).
+
+The endpoint SHALL return HTTP 404 when the person does not exist or does not belong to the authenticated user.
+
+Facts assembly `OneOnOnePrepFacts`:
+
+- `person` — id, display name, type.
+- `lastOneOnOne` — the most recent OneOnOne for this person (occurred date, summary or first 240 chars of notes).
+- `openGoals` — all goals with status `Active` for this person.
+- `recentObservations` — up to `TopItemsPerSection` observations created within 30 days, sorted by CreatedAtUtc desc, bodies truncated to 240 chars.
+- `openCommitmentsWithPerson` — commitments with `PersonId = {personId}` whose `Status = Open`, capped at `TopItemsPerSection`.
+- `openDelegationsToPerson` — delegations with `DelegatePersonId = {personId}` whose `Status` is not `Completed` or `Cancelled`, capped at `TopItemsPerSection`.
+
+Synthesis SHALL produce a markdown document with sections (Context, Open Items, Recent Observations, Suggested Talking Points). The prompt SHALL instruct the model to produce exactly 3 to 5 talking-point bullets.
+
+#### Scenario: Prep sheet generated for a valid person
+
+- **WHEN** an authenticated user with a configured AI provider calls `POST /api/briefings/one-on-one/{personId}` for a person they own
+- **THEN** the system persists a `Briefing` with `Type=OneOnOnePrep`, `ScopeKey="oneonone:{personId:N}"` and returns HTTP 201
+
+#### Scenario: Person not found or not owned
+
+- **WHEN** the user calls the endpoint for a personId that doesn't exist or belongs to another user
+- **THEN** HTTP 404 is returned
+
+#### Scenario: Cached prep sheet returned on second call
+
+- **WHEN** a prep sheet was generated 1 hour ago and the user calls the endpoint again with the same personId
+- **THEN** HTTP 200 is returned with the cached briefing
+
+### Requirement: Get recent briefings
+
+The system SHALL expose `GET /api/briefings/recent` returning up to 20 most-recent briefings for the authenticated user, sorted by `GeneratedAtUtc` descending.
+
+Supported query parameters:
+
+- `type` — optional; when provided MUST be one of `Morning`, `Weekly`, `OneOnOnePrep` (case-insensitive). Unknown values SHALL return HTTP 400.
+- `limit` — integer 1..50 (default 20). Values outside the range SHALL return HTTP 400.
+
+The response SHALL be a list of `BriefingSummary` (no `markdownBody`, no `factsSummary` — just id, type, scopeKey, generatedAtUtc, model, tokens).
+
+#### Scenario: List recent briefings
+
+- **WHEN** an authenticated user with 3 briefings calls `GET /api/briefings/recent`
+- **THEN** HTTP 200 is returned with an array of 3 summaries ordered by generatedAtUtc desc
+
+#### Scenario: Filter by type
+
+- **WHEN** a user calls `GET /api/briefings/recent?type=Weekly`
+- **THEN** only `Weekly` briefings are returned
+
+#### Scenario: Invalid type rejected
+
+- **WHEN** a user calls `GET /api/briefings/recent?type=monthly`
+- **THEN** HTTP 400 is returned
+
+#### Scenario: User isolation
+
+- **WHEN** User A and User B each have briefings
+- **THEN** each sees only their own via this endpoint
+
+### Requirement: Get briefing by id
+
+The system SHALL expose `GET /api/briefings/{id}` returning the full `BriefingResponse` (including `markdownBody` and `factsSummary`) when the briefing exists and belongs to the authenticated user.
+
+#### Scenario: Read own briefing
+
+- **WHEN** a user requests a briefing id they own
+- **THEN** HTTP 200 is returned with full body
+
+#### Scenario: Read unknown or foreign briefing
+
+- **WHEN** a user requests a briefing id that does not exist or belongs to another user
+- **THEN** HTTP 404 is returned
+
+### Requirement: Briefing aggregate and repository
+
+The system SHALL define a `Briefing` aggregate (lightweight read-model) with fields `Id` (Guid), `UserId` (Guid), `Type` (`BriefingType` enum: `Morning`, `Weekly`, `OneOnOnePrep`), `ScopeKey` (string, ≤128 chars), `GeneratedAtUtc` (UTC), `MarkdownBody` (string), `PromptFactsJson` (jsonb), `Model` (string ≤64 chars), `InputTokens` (int ≥ 0), `OutputTokens` (int ≥ 0).
+
+A factory method `Briefing.Create(userId, type, scopeKey, generatedAtUtc, markdownBody, promptFactsJson, model, inputTokens, outputTokens)` SHALL enforce non-null `markdownBody` and non-empty `scopeKey`.
+
+The repository `IBriefingRepository` SHALL expose `AddAsync`, `GetByIdAsync(userId, id)`, `GetLatestAsync(userId, type, scopeKey)`, and `ListRecentAsync(userId, type?, limit)`.
+
+The EF configuration SHALL create an index on `(UserId, Type, ScopeKey, GeneratedAtUtc DESC)`.
+
+#### Scenario: Scope key non-empty invariant
+
+- **WHEN** the factory is called with an empty scopeKey
+- **THEN** it throws an `ArgumentException`
+
+#### Scenario: User scoping enforced in repository reads
+
+- **WHEN** `GetByIdAsync(userId, id)` is called with a userId that does not match the stored row
+- **THEN** the method returns null
+
+### Requirement: Deterministic facts and time provider
+
+The system SHALL inject `TimeProvider` into `BriefingService` and read all current-time values through it. Facts assembly SHALL be a pure function of repository state and the provided `TimeProvider` — two calls within the same clock tick with identical repository state SHALL produce identical facts.
+
+#### Scenario: Two concurrent calls with same clock tick produce identical facts
+
+- **WHEN** the service is invoked twice with a `FakeTimeProvider` fixed at the same instant against the same database state
+- **THEN** the generated `MorningBriefingFacts` objects are equal
+
+### Requirement: Options validation
+
+The system SHALL register `BriefingOptions` via `AddOptions<BriefingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`. The options class SHALL carry `[Range]` attributes: `MorningBriefingHour` (0..23, default 5), `WeeklyBriefingStaleHours` (1..72, default 12), `OneOnOnePrepStaleHours` (1..72, default 12), `MaxBriefingTokens` (200..4000, default 1500), `TopItemsPerSection` (1..20, default 5).
+
+#### Scenario: Out-of-range option rejected at startup
+
+- **WHEN** `appsettings.json` sets `Briefing:MaxBriefingTokens = 99999`
+- **THEN** application startup fails with an options-validation exception
+
+#### Scenario: Defaults apply when unconfigured
+
+- **WHEN** the application starts with no `Briefing` configuration section
+- **THEN** `MorningBriefingHour = 5`, `WeeklyBriefingStaleHours = 12`, `MaxBriefingTokens = 1500`, `TopItemsPerSection = 5`
+
+### Requirement: Morning briefing dashboard widget
+
+The frontend SHALL render a morning briefing widget on the authenticated dashboard home route. The widget SHALL call `POST /api/briefings/morning` on first mount via a signal-based `BriefingService`. The widget SHALL display the rendered markdown, the generated-at timestamp, and a "Regenerate" button that calls the endpoint with `force=true`.
+
+The component SHALL NOT use `*ngIf`, `*ngFor`, `*ngSwitch`, or `[ngClass]`; it SHALL use `@if`, `@for`, `@switch`, `[class.x]` signal-aware syntax. Colours SHALL use PrimeNG / `tailwindcss-primeui` tokens only (no hardcoded Tailwind colour utilities, no `dark:` prefix).
+
+#### Scenario: Widget generates a briefing on first visit
+
+- **WHEN** the user lands on the dashboard and no briefing exists yet for today
+- **THEN** the widget displays a loading state, then renders the generated markdown
+
+#### Scenario: Regenerate reuses force=true
+
+- **WHEN** the user clicks "Regenerate"
+- **THEN** the frontend calls `POST /api/briefings/morning?force=true` and re-renders
+
+#### Scenario: Provider-not-configured state
+
+- **WHEN** the endpoint returns HTTP 409 with `ai_provider_not_configured`
+- **THEN** the widget renders a "Configure your AI provider" empty state with a link to settings
+
+### Requirement: Weekly briefing page
+
+The frontend SHALL provide a route `/briefings/weekly` with a `WeeklyBriefingPageComponent` that fetches the current weekly briefing on mount via `POST /api/briefings/weekly` and renders the markdown. The page SHALL provide a "Regenerate" button that calls the endpoint with `force=true`. It SHALL link back to the recent-briefings list.
+
+#### Scenario: User opens the weekly briefing
+
+- **WHEN** an authenticated user navigates to `/briefings/weekly`
+- **THEN** the app calls the endpoint and renders the returned briefing
+
+### Requirement: 1:1 prep action on person detail
+
+The person detail page SHALL provide a "Generate 1:1 prep" button that, when clicked, calls `POST /api/briefings/one-on-one/{personId}` and displays the returned markdown in a PrimeNG dialog or drawer. The dialog SHALL show the generated-at timestamp and a "Regenerate" action.
+
+#### Scenario: Prep sheet displayed in dialog
+
+- **WHEN** an authenticated user clicks "Generate 1:1 prep" on a person's detail page
+- **THEN** the dialog opens and shows the rendered markdown
+
+#### Scenario: Regenerate prep sheet
+
+- **WHEN** the user clicks "Regenerate" inside the dialog
+- **THEN** the endpoint is called with `force=true` and the dialog content updates

--- a/openspec/changes/daily-weekly-briefing/specs/daily-weekly-briefing/spec.md
+++ b/openspec/changes/daily-weekly-briefing/specs/daily-weekly-briefing/spec.md
@@ -8,14 +8,14 @@ The response body SHALL be a `BriefingResponse` DTO containing `id`, `type` (`Mo
 
 Caching and staleness rules:
 
-- `scopeKey` SHALL equal `morning:{yyyy-MM-dd}` computed from the user's local date (derived from `User.Preferences.TimeZone`; fallback UTC). If the server's current local hour is less than `BriefingOptions.MorningBriefingHour`, the previous calendar date SHALL be used.
-- When `force = false` and a persisted briefing exists with the same `(UserId, Type=Morning, ScopeKey)` whose `GeneratedAtUtc` is within `BriefingOptions.WeeklyBriefingStaleHours` of now, the system SHALL return HTTP 200 with that persisted briefing.
+- `scopeKey` SHALL equal `morning:{yyyy-MM-dd}` computed from the user's local date (derived from `User.Preferences.TimeZone`; fallback UTC). If the user's current local hour (in the same time zone) is less than `BriefingOptions.MorningBriefingHour`, the previous calendar date SHALL be used.
+- When `force = false` and a persisted briefing exists with the same `(UserId, Type=Morning, ScopeKey)` whose `GeneratedAtUtc` is within `BriefingOptions.MorningBriefingStaleHours` of now, the system SHALL return HTTP 200 with that persisted briefing.
 - Otherwise the system SHALL generate a new briefing, persist it, and return HTTP 201.
 
 Facts assembly: the system SHALL assemble `MorningBriefingFacts` deterministically from the user's own data, scoped to UserId:
 
 - `topCommitmentsDueToday` — up to `BriefingOptions.TopItemsPerSection` open commitments with `DueDate` equal to the user-local today OR `IsOverdue = true`, sorted by (overdue desc, dueDate asc, id asc).
-- `onOnOnesToday` — every OneOnOne with `OccurredOnUtc` (or scheduled date equivalent) whose local calendar date equals today.
+- `oneOnOnesToday` — every OneOnOne with `OccurredOnUtc` (or scheduled date equivalent) whose local calendar date equals today.
 - `overdueDelegations` — up to `TopItemsPerSection` delegations with `IsOverdue = true`, sorted by daysOverdue desc.
 - `recentCaptures` — up to `TopItemsPerSection` captures `CapturedAtUtc >= now - 24h`, sorted by CapturedAtUtc desc.
 - `peopleNeedingAttention` — up to `TopItemsPerSection` people whose last OneOnOne was more than 14 days ago (or never) and who have at least one open commitment or delegation.
@@ -60,7 +60,7 @@ Provider precondition: if the user has no `AiProviderConfig` set, the system SHA
 
 The system SHALL expose `POST /api/briefings/weekly` that returns the authenticated user's briefing for the current ISO week. The endpoint SHALL accept an optional `force` query parameter.
 
-`scopeKey` SHALL equal `weekly:{ISO-year}-W{ISO-week:D2}` computed from the user's local date. Caching follows the same `WeeklyBriefingStaleHours` rule as morning briefings.
+`scopeKey` SHALL equal `weekly:{ISO-year}-W{ISO-week:D2}` computed from the user's local date. Caching follows the same cache-or-regenerate pattern as morning briefings using `BriefingOptions.WeeklyBriefingStaleHours`.
 
 Facts assembly `WeeklyBriefingFacts`:
 
@@ -123,7 +123,7 @@ Synthesis SHALL produce a markdown document with sections (Context, Open Items, 
 
 ### Requirement: Get recent briefings
 
-The system SHALL expose `GET /api/briefings/recent` returning up to 20 most-recent briefings for the authenticated user, sorted by `GeneratedAtUtc` descending.
+The system SHALL expose `GET /api/briefings/recent` returning the most-recent briefings for the authenticated user, sorted by `GeneratedAtUtc` descending. The number of items returned SHALL be capped by the `limit` query parameter (default 20, max 50).
 
 Supported query parameters:
 
@@ -174,7 +174,7 @@ A factory method `Briefing.Create(userId, type, scopeKey, generatedAtUtc, markdo
 
 The repository `IBriefingRepository` SHALL expose `AddAsync`, `GetByIdAsync(userId, id)`, `GetLatestAsync(userId, type, scopeKey)`, and `ListRecentAsync(userId, type?, limit)`.
 
-The EF configuration SHALL create an index on `(UserId, Type, ScopeKey, GeneratedAtUtc DESC)`.
+The EF configuration SHALL create a unique index on `(UserId, Type, ScopeKey, GeneratedAtUtc)` to support efficient `GetLatestAsync` lookups and to defend against duplicate-row races on identical timestamps.
 
 #### Scenario: Scope key non-empty invariant
 
@@ -197,7 +197,7 @@ The system SHALL inject `TimeProvider` into `BriefingService` and read all curre
 
 ### Requirement: Options validation
 
-The system SHALL register `BriefingOptions` via `AddOptions<BriefingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`. The options class SHALL carry `[Range]` attributes: `MorningBriefingHour` (0..23, default 5), `WeeklyBriefingStaleHours` (1..72, default 12), `OneOnOnePrepStaleHours` (1..72, default 12), `MaxBriefingTokens` (200..4000, default 1500), `TopItemsPerSection` (1..20, default 5).
+The system SHALL register `BriefingOptions` via `AddOptions<BriefingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`. The options class SHALL carry `[Range]` attributes: `MorningBriefingHour` (0..23, default 5), `MorningBriefingStaleHours` (1..72, default 12), `WeeklyBriefingStaleHours` (1..72, default 12), `OneOnOnePrepStaleHours` (1..72, default 12), `MaxBriefingTokens` (200..4000, default 1500), `TopItemsPerSection` (1..20, default 5).
 
 #### Scenario: Out-of-range option rejected at startup
 
@@ -207,7 +207,7 @@ The system SHALL register `BriefingOptions` via `AddOptions<BriefingOptions>().B
 #### Scenario: Defaults apply when unconfigured
 
 - **WHEN** the application starts with no `Briefing` configuration section
-- **THEN** `MorningBriefingHour = 5`, `WeeklyBriefingStaleHours = 12`, `MaxBriefingTokens = 1500`, `TopItemsPerSection = 5`
+- **THEN** `MorningBriefingHour = 5`, `MorningBriefingStaleHours = 12`, `WeeklyBriefingStaleHours = 12`, `OneOnOnePrepStaleHours = 12`, `MaxBriefingTokens = 1500`, `TopItemsPerSection = 5`
 
 ### Requirement: Morning briefing dashboard widget
 

--- a/openspec/changes/daily-weekly-briefing/tasks.md
+++ b/openspec/changes/daily-weekly-briefing/tasks.md
@@ -7,7 +7,7 @@
 
 ## 2. Application
 
-- [ ] 2.1 Create `src/MentalMetal.Application/Briefings/BriefingOptions.cs` with `[Range]` attrs (`MorningBriefingHour` 0..23 default 5; `WeeklyBriefingStaleHours` 1..72 default 12; `OneOnOnePrepStaleHours` 1..72 default 12; `MaxBriefingTokens` 200..4000 default 1500; `TopItemsPerSection` 1..20 default 5).
+- [ ] 2.1 Create `src/MentalMetal.Application/Briefings/BriefingOptions.cs` with `[Range]` attrs (`MorningBriefingHour` 0..23 default 5; `MorningBriefingStaleHours` 1..72 default 12; `WeeklyBriefingStaleHours` 1..72 default 12; `OneOnOnePrepStaleHours` 1..72 default 12; `MaxBriefingTokens` 200..4000 default 1500; `TopItemsPerSection` 1..20 default 5).
 - [ ] 2.2 Create `src/MentalMetal.Application/Briefings/Facts/*Facts.cs` record types: `MorningBriefingFacts`, `WeeklyBriefingFacts`, `OneOnOnePrepFacts`, and their nested item records (e.g., `FactCommitment`, `FactDelegation`, `FactPerson`, `FactOneOnOne`, `FactMilestone`, `FactObservation`, `FactGoal`, `FactCapture`).
 - [ ] 2.3 Create `src/MentalMetal.Application/Briefings/BriefingFactsAssembler.cs` — injects the required repos + `TimeProvider` + options + `IUserContext`; exposes `BuildMorningAsync`, `BuildWeeklyAsync`, `BuildOneOnOnePrepAsync(personId)`. Use `userLocalDate(now)` helper; apply `MorningBriefingHour` rollback rule. Uses `.ToLower()` (not `ToLowerInvariant`) and `List<T>.Contains()` if filtering with collections.
 - [ ] 2.4 Create `src/MentalMetal.Application/Briefings/BriefingPromptBuilder.cs` — produces `(systemPrompt, userPrompt)` per briefing type from the facts JSON; prompt forbids invention; 1:1-prep requests 3–5 talking points.
@@ -21,7 +21,7 @@
 
 ## 3. Infrastructure
 
-- [ ] 3.1 Create `src/MentalMetal.Infrastructure/Persistence/Configurations/BriefingConfiguration.cs` — map columns, jsonb for `PromptFactsJson`, unique/composite index `(UserId, Type, ScopeKey, GeneratedAtUtc DESC)`.
+- [ ] 3.1 Create `src/MentalMetal.Infrastructure/Persistence/Configurations/BriefingConfiguration.cs` — map columns, jsonb for `PromptFactsJson`, **unique** composite index on `(UserId, Type, ScopeKey, GeneratedAtUtc)`.
 - [ ] 3.2 Add `DbSet<Briefing> Briefings` to `MentalMetalDbContext`.
 - [ ] 3.3 Create `src/MentalMetal.Infrastructure/Repositories/BriefingRepository.cs` implementing `IBriefingRepository`; uses `.ToLower()`, `List<T>.Contains()` where applicable.
 - [ ] 3.4 Register `IBriefingRepository → BriefingRepository` in `Infrastructure/DependencyInjection.cs`.

--- a/openspec/changes/daily-weekly-briefing/tasks.md
+++ b/openspec/changes/daily-weekly-briefing/tasks.md
@@ -1,0 +1,75 @@
+## 1. Domain
+
+- [ ] 1.1 Create `src/MentalMetal.Domain/Briefings/BriefingType.cs` (enum: `Morning`, `Weekly`, `OneOnOnePrep`).
+- [ ] 1.2 Create `src/MentalMetal.Domain/Briefings/Briefing.cs` — aggregate with `Id`, `UserId`, `Type`, `ScopeKey`, `GeneratedAtUtc`, `MarkdownBody`, `PromptFactsJson`, `Model`, `InputTokens`, `OutputTokens`; `Create(...)` factory enforcing non-null body + non-empty scopeKey.
+- [ ] 1.3 Create `src/MentalMetal.Domain/Briefings/IBriefingRepository.cs` with `AddAsync`, `GetByIdAsync(userId,id)`, `GetLatestAsync(userId,type,scopeKey)`, `ListRecentAsync(userId,type?,limit)`.
+- [ ] 1.4 Domain unit tests: `tests/MentalMetal.Domain.Tests/Briefings/BriefingTests.cs` — factory enforces invariants; scopeKey empty throws.
+
+## 2. Application
+
+- [ ] 2.1 Create `src/MentalMetal.Application/Briefings/BriefingOptions.cs` with `[Range]` attrs (`MorningBriefingHour` 0..23 default 5; `WeeklyBriefingStaleHours` 1..72 default 12; `OneOnOnePrepStaleHours` 1..72 default 12; `MaxBriefingTokens` 200..4000 default 1500; `TopItemsPerSection` 1..20 default 5).
+- [ ] 2.2 Create `src/MentalMetal.Application/Briefings/Facts/*Facts.cs` record types: `MorningBriefingFacts`, `WeeklyBriefingFacts`, `OneOnOnePrepFacts`, and their nested item records (e.g., `FactCommitment`, `FactDelegation`, `FactPerson`, `FactOneOnOne`, `FactMilestone`, `FactObservation`, `FactGoal`, `FactCapture`).
+- [ ] 2.3 Create `src/MentalMetal.Application/Briefings/BriefingFactsAssembler.cs` — injects the required repos + `TimeProvider` + options + `IUserContext`; exposes `BuildMorningAsync`, `BuildWeeklyAsync`, `BuildOneOnOnePrepAsync(personId)`. Use `userLocalDate(now)` helper; apply `MorningBriefingHour` rollback rule. Uses `.ToLower()` (not `ToLowerInvariant`) and `List<T>.Contains()` if filtering with collections.
+- [ ] 2.4 Create `src/MentalMetal.Application/Briefings/BriefingPromptBuilder.cs` — produces `(systemPrompt, userPrompt)` per briefing type from the facts JSON; prompt forbids invention; 1:1-prep requests 3–5 talking points.
+- [ ] 2.5 Create `src/MentalMetal.Application/Briefings/BriefingService.cs` — orchestrates assemble → decide cache vs generate → serialize facts → call `IAiCompletionService` → persist → return; `TimeProvider` injected; respects `WeeklyBriefingStaleHours`/`OneOnOnePrepStaleHours`.
+- [ ] 2.6 Create `src/MentalMetal.Application/Briefings/GenerateMorningBriefing.cs`, `GenerateWeeklyBriefing.cs`, `GenerateOneOnOnePrep.cs` — CQRS commands with handlers delegating to `BriefingService`; return DTOs + a `WasCached` bool so the endpoint picks 200 vs 201.
+- [ ] 2.7 Create `src/MentalMetal.Application/Briefings/GetRecentBriefings.cs` — query handler; validates `type`/`limit`.
+- [ ] 2.8 Create `src/MentalMetal.Application/Briefings/GetBriefing.cs` — query handler returning full briefing; enforces user scoping.
+- [ ] 2.9 Create `src/MentalMetal.Application/Briefings/BriefingDtos.cs` — `BriefingResponse`, `BriefingSummary`.
+- [ ] 2.10 Register options + services in `src/MentalMetal.Application/DependencyInjection.cs` with `AddOptions<BriefingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`.
+- [ ] 2.11 Application unit tests: `tests/MentalMetal.Application.Tests/Briefings/` — `BriefingFactsAssemblerTests` (deterministic output for fixed `FakeTimeProvider` + repo fakes), `BriefingServiceTests` (cache hit returns existing, force bypasses cache, 409 without AI config), `GetRecentBriefingsTests` (filter + limit validation).
+
+## 3. Infrastructure
+
+- [ ] 3.1 Create `src/MentalMetal.Infrastructure/Persistence/Configurations/BriefingConfiguration.cs` — map columns, jsonb for `PromptFactsJson`, unique/composite index `(UserId, Type, ScopeKey, GeneratedAtUtc DESC)`.
+- [ ] 3.2 Add `DbSet<Briefing> Briefings` to `MentalMetalDbContext`.
+- [ ] 3.3 Create `src/MentalMetal.Infrastructure/Repositories/BriefingRepository.cs` implementing `IBriefingRepository`; uses `.ToLower()`, `List<T>.Contains()` where applicable.
+- [ ] 3.4 Register `IBriefingRepository → BriefingRepository` in `Infrastructure/DependencyInjection.cs`.
+- [ ] 3.5 Add EF migration `AddBriefings` (run `dotnet build` first, then `dotnet ef migrations add AddBriefings --no-build`).
+- [ ] 3.6 Integration test `tests/MentalMetal.Web.IntegrationTests/Briefings/BriefingRepositoryTests.cs` — AddAsync + GetLatestAsync + user isolation.
+
+## 4. Web (API)
+
+- [ ] 4.1 Create `src/MentalMetal.Web/Features/Briefings/BriefingEndpoints.cs` with Minimal API routes:
+  - `POST /api/briefings/morning` (force?)
+  - `POST /api/briefings/weekly` (force?)
+  - `POST /api/briefings/one-on-one/{personId}` (force?)
+  - `GET /api/briefings/recent` (type?, limit?)
+  - `GET /api/briefings/{id}`
+- [ ] 4.2 Register endpoints in `Program.cs` via `app.MapBriefingEndpoints()`.
+- [ ] 4.3 Handle `ai_provider_not_configured` via a typed exception or result — return 409 JSON error.
+- [ ] 4.4 Integration tests `tests/MentalMetal.Web.IntegrationTests/Briefings/BriefingEndpointsTests.cs` — morning happy path 201, second call 200, force regenerates, 401 unauth, 409 no AI config, 404 person not owned, 400 bad type, 400 bad limit, user isolation on GET.
+
+## 5. Frontend — core
+
+- [ ] 5.1 Create `src/MentalMetal.Web/ClientApp/src/app/shared/services/briefing.service.ts` — signal-based service; methods `loadMorning(force?)`, `loadWeekly(force?)`, `loadOneOnOnePrep(personId, force?)`, `recent(type?, limit?)`, `getById(id)`; expose signals for latest morning/weekly briefings.
+- [ ] 5.2 Create `src/MentalMetal.Web/ClientApp/src/app/shared/models/briefing.model.ts` — matching DTO types.
+- [ ] 5.3 If a markdown pipe doesn't already exist, add `src/MentalMetal.Web/ClientApp/src/app/shared/pipes/markdown.pipe.ts` using `marked` + `DOMPurify`; add to `package.json`.
+
+## 6. Frontend — morning widget
+
+- [ ] 6.1 Create `src/MentalMetal.Web/ClientApp/src/app/pages/home/morning-briefing-widget.component.ts` — standalone signal component using `@if`/`@for`, PrimeNG Card + Button, `tailwindcss-primeui` tokens only.
+- [ ] 6.2 Wire widget into the dashboard home page.
+- [ ] 6.3 Component test: loading → success renders markdown; regenerate calls `force=true`; 409 renders empty-state with settings link.
+
+## 7. Frontend — weekly page
+
+- [ ] 7.1 Create `src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-briefing.page.ts` + route registration at `/briefings/weekly`.
+- [ ] 7.2 Component test: happy path + regenerate + 409 empty state.
+
+## 8. Frontend — 1:1 prep action
+
+- [ ] 8.1 Add "Generate 1:1 prep" PrimeNG Button to person detail page; opens PrimeNG Dialog with `OneOnOnePrepDialogComponent`.
+- [ ] 8.2 Create `src/MentalMetal.Web/ClientApp/src/app/pages/people/one-on-one-prep-dialog.component.ts` — calls `loadOneOnOnePrep(personId)`; shows markdown + generated-at + regenerate button.
+- [ ] 8.3 Component test: dialog opens and renders; regenerate re-calls with `force=true`; 409 state.
+
+## 9. E2E
+
+- [ ] 9.1 Add Playwright scenario in `tests/MentalMetal.E2E.Tests/` covering: dashboard widget renders after login, weekly page renders after clicking "Generate".
+
+## 10. Docs & polish
+
+- [ ] 10.1 Add `Briefing` configuration section stub to `appsettings.json` with defaults + a comment.
+- [ ] 10.2 Verify all backend tests pass (`dotnet test src/MentalMetal.slnx`).
+- [ ] 10.3 Verify frontend tests pass (`(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)`).
+- [ ] 10.4 Run `openspec validate daily-weekly-briefing --strict` before opening the Apply PR.


### PR DESCRIPTION
## Summary

Tier 3 OpenSpec proposal for `daily-weekly-briefing` — an AI-generated morning/weekly/1:1-prep briefing layer that ties together already-shipped capabilities (people-lens, commitment/delegation tracking, living-brief, my-queue) into the highest-value daily UX.

**Spec**: [daily-weekly-briefing](openspec/changes/daily-weekly-briefing/specs/daily-weekly-briefing/spec.md)

## Changes

- New `daily-weekly-briefing` capability spec.
- `proposal.md` — scope, non-goals, capability identification.
- `design.md` — `Briefing` lightweight read-model aggregate, deterministic facts assembly + LLM synthesis split, `ScopeKey` cache scheme, `TimeProvider` injection, options validation, frontend surface plan.
- `specs/daily-weekly-briefing/spec.md` — 13 requirements covering morning / weekly / 1:1 prep generation, cache-or-regenerate semantics, recent + by-id queries, aggregate + repository contract, deterministic facts, options validation, dashboard widget, weekly page, person-detail action.
- `tasks.md` — 10 task groups covering domain → application → infrastructure → web → frontend → E2E.

No source code changes in this PR — proposal only. Implementation lands via `/opsx:apply` in the follow-up PR.

## Test Plan

- [x] `openspec validate daily-weekly-briefing --strict` passes
- [x] All 4 artifacts complete (proposal/design/specs/tasks)
- [ ] CodeRabbit / Copilot review of spec content

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)