### PR TITLE
openspec: propose interview-tracking (Tier 3)

### DIFF
--- a/openspec/changes/interview-tracking/.openspec.yaml
+++ b/openspec/changes/interview-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/interview-tracking/design.md
+++ b/openspec/changes/interview-tracking/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Mental Metal currently models hiring only as a coarse `PipelineStatus` value object on the candidate `Person` (`New → Screening → Interviewing → OfferStage → Hired / Rejected / Withdrawn`). There is no notion of an individual interview round, no place to record scorecards, and no way to paste a transcript for AI-driven analysis. Engineering managers running multiple candidates in parallel need round-level tracking and a quick-read summary of a just-completed loop. The `daily-weekly-briefing` spec (shipped) already established the pattern for wrapping `IAiCompletionService` with a deterministic-facts-in / narration-out service, and `people-lens` established the pattern for aggregates with owned entity collections (scorecards are the counterpart to one-on-one action items). This design applies both patterns to a new `Interview` aggregate.
+
+This is Tier 3 of `design/spec-plan.md`. Dependencies (`person-management`, `ai-provider-abstraction`) are shipped and archived.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce `Interview` as a standalone DDD aggregate rooted in its own lifecycle, reachable from a candidate `Person` by ID only (no direct containment).
+- Support a structured, guarded stage lifecycle with explicit transitions and terminal states; raise domain events for every transition.
+- Model scorecards as an owned entity collection with add / update / remove semantics and per-entry timestamps.
+- Model the transcript as an owned value object holding pasted text plus AI-generated summary / recommendation / risk signals; allow transcript replacement and analysis regeneration without losing the interview row.
+- Expose a minimal API surface under `/api/interviews` scoped strictly to the authenticated user.
+- Provide an Angular pipeline view grouped by stage (kanban-style), a detail page with tabs (overview, scorecards, transcript, AI analysis), and consistent PrimeNG + `tailwindcss-primeui` theming — no hardcoded colours.
+- Reuse `IAiCompletionService` behind a new `IInterviewAnalysisService`, with deterministic prompt construction and `IOptions<InterviewAnalysisOptions>` (validated via `ValidateDataAnnotations` / `ValidateOnStart`).
+
+**Non-Goals:**
+- Calendar / scheduling integration (no iCal, Google Calendar, etc.).
+- Multi-interviewer collaboration — single-user app; `RecordedAtUtc` is the only audit metadata on scorecards.
+- Audio capture or live transcription — that is `capture-audio`'s scope. Transcript must be pasted text.
+- Automatic writes back to `Person.CandidateDetails.PipelineStatus`. The two remain independently editable.
+- Multi-round aggregation analytics (e.g., "show me all onsite loops this quarter with decision split").
+- Email / Slack notifications when stages change.
+
+## Decisions
+
+### D1. `Interview` is its own aggregate rooted in `InterviewId`, referencing `Person` by `CandidatePersonId`
+**Why:** Interviews have their own lifecycle, invariants (stage transitions), and child collections (scorecards). Embedding interviews inside `Person` would bloat the `Person` aggregate, break the "aggregates reference by ID only" principle, and prevent loading interviews independently. Alternative considered: make interviews an owned collection of `Person.CandidateDetails` — rejected because that forces loading all interviews every time a Person is loaded and makes commands cross-aggregate.
+
+### D2. `InterviewStage` enum with a transition map guarded on the aggregate
+**Why:** Mirrors the `CandidateDetails.ValidateTransition` pattern already in the codebase (see `src/MentalMetal.Domain/People/CandidateDetails.cs`). Forward transitions: `Applied → ScreenScheduled → ScreenCompleted → OnsiteScheduled → OnsiteCompleted → OfferExtended → Hired`. Terminal: `Hired`, `Rejected`, `Withdrawn`. `Rejected` and `Withdrawn` reachable from any non-terminal state. Invalid transitions throw a `DomainException`; endpoint maps to HTTP 409. Alternative considered: free-form string stage — rejected for loss of type safety.
+
+### D3. `InterviewScorecard` as an owned entity with a stable `ScorecardId`
+**Why:** Scorecards need to be individually updatable and removable, and we want their IDs in the URL (`/api/interviews/{id}/scorecards/{scorecardId}`). A value-object scorecard collection (equality by content) would break update semantics. Consistent with `OneOnOne.ActionItem` from people-lens.
+
+### D4. `InterviewTranscript` as an owned value object (single-per-interview, replaceable)
+**Why:** There is only ever one current transcript per interview round. Making it a value object expresses that — `SetTranscript(text)` replaces it atomically with a fresh analysis payload. The AI analysis fields (`Summary`, `RecommendedDecision`, `RiskSignals`) live on the transcript VO so clearing a transcript also clears stale analysis. Alternative considered: storing transcript text and analysis as separate scalar columns on `Interview` — rejected because it spreads what is conceptually a single cohesive artefact.
+
+### D5. AI analysis is an explicit endpoint (`POST /api/interviews/{id}/analyze`), not automatic on transcript upload
+**Why:** Follows the `daily-weekly-briefing` pattern where AI generation is explicit and cacheable. Users may paste a transcript, edit it, and only when ready trigger analysis — saves tokens and avoids surprise costs. Transcript storage and analysis are decoupled.
+
+### D6. Deterministic analysis service with `Temperature = 0.3`, strict system prompt
+**Why:** Same pattern as `BriefingService`. The prompt instructs the model to narrate only from supplied facts (scorecards + transcript), forbids invention of names/dates, requires one of the five `InterviewDecision` enum values as `RecommendedDecision`, and caps `MaxTokens` via `InterviewAnalysisOptions.MaxAnalysisTokens`. Input is JSON-serialised facts — user-supplied transcript text SHALL have backtick characters escaped (`\u0060`) before being embedded into the user prompt, mirroring the prior-CodeRabbit-flagged prompt-injection mitigation.
+
+### D7. Clock injection
+**Why:** Services SHALL accept an `ISystemClock` (or `TimeProvider` — project already uses one) and MUST NOT read `DateTime.UtcNow` directly. Avoids the determinism bug flagged on prior AI PRs.
+
+### D8. EF Core persistence
+- `Interviews` table: `Id`, `UserId` (indexed), `CandidatePersonId` (indexed), `RoleTitle`, `Stage`, `ScheduledAtUtc`, `CompletedAtUtc`, `Decision`, `CreatedAtUtc`, `UpdatedAtUtc`, plus owned-type columns `Transcript_RawText`, `Transcript_Summary`, `Transcript_RecommendedDecision`, `Transcript_RiskSignals` (jsonb list), `Transcript_AnalyzedAtUtc`, `Transcript_Model`.
+- `InterviewScorecards` table: `Id`, `InterviewId` (FK, cascade), `Competency`, `Rating`, `Notes`, `RecordedAtUtc`.
+- Owned collection (`_scorecards`) appends will be persisted via `MarkOwnedAdded` / `MarkOwnedRemoved` repo helpers to work around the EF Core snapshot tracker bug documented in `project_tier2b_plan.md` memory.
+
+### D9. API conventions
+- All endpoints under `/api/interviews` require `RequireAuthorization()` and resolve the current `UserId` from the authenticated principal (consistent with existing Minimal API slices).
+- DTOs live in `MentalMetal.Application/Interviews/` — never expose domain entities.
+- Error codes: `candidate_not_found`, `invalid_stage_transition`, `decision_not_allowed`, `transcript_missing`, `ai_provider_not_configured`, `analysis_failed`.
+
+### D10. Frontend
+- New standalone feature `src/app/pages/interviews/`:
+  - `interviews-pipeline.component.ts` — route `/interviews`, pipeline columns grouped by stage using PrimeNG Card + `@for` control flow.
+  - `interview-detail.component.ts` — route `/interviews/:id`, PrimeNG TabView with Overview / Scorecards / Transcript / AI Analysis tabs.
+  - Signal-based state, `inject()` DI, Signal Forms for create / edit, no `*ngIf` / `*ngFor`.
+- Colours via PrimeNG tokens / `tailwindcss-primeui` (`bg-primary`, `text-muted-color`, `var(--p-surface-100)`) — no hardcoded Tailwind palette classes, no `dark:` prefix.
+
+## Risks / Trade-offs
+
+- **Transcript size** → Paste transcripts can be long; DB column is `text` (no fixed limit) but prompt length is bounded by `InterviewAnalysisOptions.MaxPromptChars` (default 16000). Over-length transcripts are rejected with HTTP 413.
+- **Prompt injection via pasted transcript** → Mitigated by escaping backticks and using JSON serialisation for the facts block; system prompt explicitly instructs the model to treat transcript content as data, not instructions.
+- **Cost runaway on re-analysis** → Mitigated by requiring an explicit `POST /analyze` call; no auto-regeneration on transcript edits.
+- **Stage-enum drift vs. `PipelineStatus`** → Two separate enums deliberately; the `Interview` stage is round-level, `PipelineStatus` is candidate-level. Documented in the proposal as a non-goal.
+- **EF Core owned-collection tracker bug** → Mitigated by applying the `MarkOwnedAdded/Removed` repository helper pattern already proven in `people-lens` and `capture-ai-extraction`.
+- **Model-returned decision outside the enum** → AI response parser validates `RecommendedDecision` against the enum; invalid values are stored as null and surfaced as a warning in the response.
+
+## Migration Plan
+
+1. Ship spec + design + tasks PR (Stage 1).
+2. Implement domain, infrastructure, application, web, and frontend changes in a single apply PR (Stage 2). Includes a new EF Core migration `AddInterviews`.
+3. Archive PR (Stage 3) sync delta spec into `openspec/specs/interview-tracking/spec.md`.
+4. Rollback strategy: the migration is purely additive (two new tables, no changes to existing tables), so `dotnet ef migrations remove` locally on a pre-merge branch is safe. Post-merge rollback requires a new "down" migration dropping the tables — no data loss risk for other aggregates.
+
+## Open Questions
+
+None blocking. Rating scale (1–5 integer) chosen to match the `MoodRating` field already in `people-lens`; if product direction shifts to H/M/L later, that is a non-breaking enum migration.
+
+## Dependencies
+
+- `person-management` (shipped): validates `CandidatePersonId` exists, belongs to the user, and has `Type` including `Candidate`.
+- `ai-provider-abstraction` (shipped): provides `IAiCompletionService` and `AiProviderConfig`. If the user has no configured provider, the analyze endpoint returns HTTP 409 with code `ai_provider_not_configured`, matching `daily-weekly-briefing`.

--- a/openspec/changes/interview-tracking/proposal.md
+++ b/openspec/changes/interview-tracking/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Engineering managers interviewing candidates currently have no structured way in Mental Metal to track a candidate's hiring pipeline beyond a single `PipelineStatus` on the `Person` aggregate. Every interview round, scorecard, transcript, and hiring signal either lives elsewhere (Notion, docs) or is lost. This spec closes that gap by introducing a first-class `Interview` aggregate that records per-round state, structured scorecards, and (optionally) pasted transcripts, then uses the existing AI provider abstraction to produce a summary, a recommended decision, and risk signals — the same pattern the `daily-weekly-briefing` spec established. This is Tier 3 of the spec plan (`design/spec-plan.md`) and depends only on `person-management` and `ai-provider-abstraction`, both shipped.
+
+## What Changes
+
+- Introduce a new `Interview` aggregate (new, no existing code) scoped to `UserId` and linked to a candidate `Person` via `CandidatePersonId`.
+- Add an `InterviewStage` lifecycle (`Applied`, `ScreenScheduled`, `ScreenCompleted`, `OnsiteScheduled`, `OnsiteCompleted`, `OfferExtended`, `Hired`, `Rejected`, `Withdrawn`) with guarded transitions raising domain events on each change.
+- Add an optional `InterviewDecision` (`StrongHire`, `Hire`, `LeanHire`, `NoHire`, `StrongNoHire`) recorded when the interview loop concludes.
+- Add an owned `InterviewScorecard` entity collection (competency, rating 1–5, notes, `RecordedAtUtc`) with add / update / remove operations.
+- Add an owned `InterviewTranscript` value object (single pasted transcript per interview, plus AI-generated `Summary`, `RecommendedDecision`, `RiskSignals`). Transcript can be replaced; analysis can be regenerated.
+- Add backend minimal API endpoints:
+  - `POST /api/interviews`, `GET /api/interviews` (filter by `candidatePersonId`, `stage`), `GET /api/interviews/{id}`, `PATCH /api/interviews/{id}` (role title, scheduled date), `POST /api/interviews/{id}/advance` (stage transitions), `POST /api/interviews/{id}/decision`, `DELETE /api/interviews/{id}`
+  - `POST|PUT|DELETE /api/interviews/{id}/scorecards[/{scorecardId}]`
+  - `PUT /api/interviews/{id}/transcript`, `POST /api/interviews/{id}/analyze` (AI)
+- Add an `IInterviewAnalysisService` that wraps `IAiCompletionService` with a deterministic prompt forbidding invention (same pattern as `BriefingService`), temperature `0.3`, and bounded `MaxTokens` via `InterviewAnalysisOptions`.
+- Add frontend Angular routes: `/interviews` (pipeline kanban / list view grouped by stage), `/interviews/{id}` detail page with scorecards tab, transcript tab, AI-analysis tab; use signals, `@if`/`@for`, PrimeNG + `tailwindcss-primeui` tokens only.
+- Add EF Core migration creating `Interviews` and `InterviewScorecards` tables with owned `InterviewTranscript`.
+
+## Capabilities
+
+### New Capabilities
+- `interview-tracking`: candidate hiring-loop aggregate with staged pipeline, scorecards, transcript capture, and AI-powered summary / recommendation / risk-signal generation. Scoped to the authenticated user.
+
+### Modified Capabilities
+<!-- None. Candidate PipelineStatus on Person remains the coarse-grained signal; Interview rounds are additive and do not change person-management requirements. -->
+
+## Impact
+
+- **Affected code**: new `MentalMetal.Domain/Interviews/`, new vertical slices under `MentalMetal.Application/Interviews/`, new `InterviewsEndpoints` mapped in `MentalMetal.Web`, new EF configurations and repository in `MentalMetal.Infrastructure/Interviews/`, new Angular feature module `src/app/pages/interviews/`.
+- **Dependencies**: reuses `IAiCompletionService` and `AiProviderConfig` from `ai-provider-abstraction`; reads from `person-management` (validates candidate Person existence and user ownership).
+- **Database**: additive migration; no changes to existing tables. Interviews are soft-independent of `Person.CandidateDetails.PipelineStatus` (no automatic writes back — users can still update pipeline status manually).
+- **Non-goals**:
+  - Scheduling / calendar integration (no external calendar API).
+  - Multi-interviewer collaboration (single-user app; `RecordedAtUtc` is the only audit metadata).
+  - Audio capture or live transcription — transcript must be pasted text (audio is a separate Tier 3 spec `capture-audio`).
+  - Automatic promotion of `Interview` stage into `Person.CandidateDetails.PipelineStatus` — user-controlled.
+- **Non-breaking**: no existing endpoint, aggregate, or UI is modified.

--- a/openspec/changes/interview-tracking/specs/interview-tracking/spec.md
+++ b/openspec/changes/interview-tracking/specs/interview-tracking/spec.md
@@ -1,0 +1,358 @@
+## ADDED Requirements
+
+### Requirement: Create an interview
+
+The system SHALL allow an authenticated user to create an `Interview` record linked to a candidate `Person`. Required fields: `candidatePersonId` (must reference a Person owned by the same user whose `Type` includes `Candidate`), `roleTitle` (non-empty). Optional fields: `scheduledAtUtc`. On success the Interview SHALL be created with `Stage = Applied`, `UserId` equal to the authenticated user, `CreatedAtUtc` set from the injected clock, and the system SHALL raise an `InterviewCreated` domain event. The endpoint SHALL be `POST /api/interviews`.
+
+#### Scenario: Create interview with required fields only
+
+- **WHEN** an authenticated user sends `POST /api/interviews` with `candidatePersonId` of a valid candidate Person and `roleTitle "Staff Engineer"`
+- **THEN** the system creates an Interview with `Stage = Applied` and returns HTTP 201 with the Interview DTO
+
+#### Scenario: Create interview with scheduled date
+
+- **WHEN** an authenticated user sends `POST /api/interviews` with `candidatePersonId`, `roleTitle "Senior SRE"`, and `scheduledAtUtc "2026-04-20T15:00:00Z"`
+- **THEN** the system creates the Interview with the scheduled date and returns HTTP 201
+
+#### Scenario: Missing candidatePersonId rejected
+
+- **WHEN** an authenticated user sends `POST /api/interviews` without a `candidatePersonId`
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: Empty roleTitle rejected
+
+- **WHEN** an authenticated user sends `POST /api/interviews` with an empty `roleTitle`
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: CandidatePersonId references another user's person
+
+- **WHEN** an authenticated user sends `POST /api/interviews` with a `candidatePersonId` that belongs to another user
+- **THEN** the system returns HTTP 404 with error code `candidate_not_found`
+
+#### Scenario: Person is not a candidate
+
+- **WHEN** an authenticated user sends `POST /api/interviews` with a `candidatePersonId` whose Person Type does not include `Candidate`
+- **THEN** the system returns HTTP 400 with error code `candidate_not_found`
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** an unauthenticated client sends `POST /api/interviews`
+- **THEN** the system returns HTTP 401
+
+### Requirement: Update interview metadata
+
+The system SHALL allow an authenticated user to update an Interview's `roleTitle` and `scheduledAtUtc` via `PATCH /api/interviews/{id}`. `roleTitle`, when supplied, MUST NOT be empty. `scheduledAtUtc` MAY be set to null to clear it. The system SHALL set `UpdatedAtUtc` from the injected clock and raise an `InterviewUpdated` domain event.
+
+#### Scenario: Update role title
+
+- **WHEN** an authenticated user sends `PATCH /api/interviews/{id}` with `roleTitle "Principal Engineer"`
+- **THEN** the Interview's role title is updated and HTTP 200 is returned
+
+#### Scenario: Clear scheduled date
+
+- **WHEN** an authenticated user sends `PATCH /api/interviews/{id}` with `scheduledAtUtc` null
+- **THEN** the Interview's scheduled date is cleared and HTTP 200 is returned
+
+#### Scenario: Empty roleTitle rejected
+
+- **WHEN** an authenticated user sends `PATCH /api/interviews/{id}` with `roleTitle ""`
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Interview not found
+
+- **WHEN** an authenticated user sends `PATCH /api/interviews/{id}` for an id not owned by the user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Interview stage lifecycle
+
+The `Interview` aggregate SHALL enforce a stage lifecycle with guarded transitions. Forward transitions: `Applied → ScreenScheduled → ScreenCompleted → OnsiteScheduled → OnsiteCompleted → OfferExtended → Hired`. `Rejected` and `Withdrawn` SHALL be reachable from any non-terminal stage. Terminal stages (`Hired`, `Rejected`, `Withdrawn`) SHALL NOT have any outgoing transitions. Transitioning into `ScreenCompleted`, `OnsiteCompleted`, `Hired`, or `Rejected` SHALL set `CompletedAtUtc` from the injected clock if not already set; other transitions SHALL leave `CompletedAtUtc` unchanged. Each transition SHALL raise an `InterviewStageChanged` domain event. The endpoint SHALL be `POST /api/interviews/{id}/advance` with body `{ "targetStage": "<stage>" }`.
+
+#### Scenario: Advance from Applied to ScreenScheduled
+
+- **WHEN** an authenticated user sends `POST /api/interviews/{id}/advance` with `targetStage "ScreenScheduled"` on an Interview currently in `Applied`
+- **THEN** the stage transitions to `ScreenScheduled` and HTTP 200 is returned
+
+#### Scenario: Advance through onsite to offer
+
+- **WHEN** an authenticated user advances an Interview currently in `OnsiteCompleted` to `OfferExtended`
+- **THEN** the stage transitions and HTTP 200 is returned
+
+#### Scenario: Reject from any non-terminal stage
+
+- **WHEN** an authenticated user advances an Interview currently in `ScreenScheduled` with `targetStage "Rejected"`
+- **THEN** the stage transitions to `Rejected`, `CompletedAtUtc` is set, and HTTP 200 is returned
+
+#### Scenario: Withdraw from any non-terminal stage
+
+- **WHEN** an authenticated user advances an Interview currently in `OfferExtended` with `targetStage "Withdrawn"`
+- **THEN** the stage transitions to `Withdrawn` and HTTP 200 is returned
+
+#### Scenario: Invalid forward transition rejected
+
+- **WHEN** an authenticated user advances an Interview currently in `Applied` with `targetStage "OnsiteScheduled"` (skipping screen)
+- **THEN** the system returns HTTP 409 with error code `invalid_stage_transition`
+
+#### Scenario: Transition from terminal stage rejected
+
+- **WHEN** an authenticated user advances an Interview currently in `Hired` with any `targetStage`
+- **THEN** the system returns HTTP 409 with error code `invalid_stage_transition`
+
+### Requirement: Record interview decision
+
+The system SHALL allow an authenticated user to record a `Decision` on an Interview via `POST /api/interviews/{id}/decision` with body `{ "decision": "<value>" }` where value is one of `StrongHire`, `Hire`, `LeanHire`, `NoHire`, `StrongNoHire`. Decision MAY be recorded only when the Interview's stage is one of `ScreenCompleted`, `OnsiteCompleted`, `OfferExtended`, `Hired`, or `Rejected`. The decision MAY be updated at any time while the stage permits it. The system SHALL raise an `InterviewDecisionRecorded` domain event.
+
+#### Scenario: Record decision after onsite
+
+- **WHEN** an authenticated user records `Hire` on an Interview in `OnsiteCompleted`
+- **THEN** the decision is saved and HTTP 200 is returned
+
+#### Scenario: Update existing decision
+
+- **WHEN** an authenticated user records `StrongHire` on an Interview that already has decision `Hire`
+- **THEN** the decision is replaced and HTTP 200 is returned
+
+#### Scenario: Decision rejected before completion
+
+- **WHEN** an authenticated user records a decision on an Interview in `Applied`
+- **THEN** the system returns HTTP 409 with error code `decision_not_allowed`
+
+#### Scenario: Invalid decision value rejected
+
+- **WHEN** an authenticated user records a decision of `"maybe"`
+- **THEN** the system returns HTTP 400
+
+### Requirement: List interviews
+
+The system SHALL allow an authenticated user to retrieve a list of their Interviews via `GET /api/interviews`. The list SHALL support optional filters `candidatePersonId` and `stage`. The list SHALL be ordered by `CreatedAtUtc` descending and MUST include only Interviews belonging to the authenticated user.
+
+#### Scenario: List all interviews
+
+- **WHEN** an authenticated user sends `GET /api/interviews`
+- **THEN** the system returns all Interviews owned by that user ordered by `CreatedAtUtc` descending
+
+#### Scenario: Filter by candidate
+
+- **WHEN** an authenticated user sends `GET /api/interviews?candidatePersonId={id}`
+- **THEN** the system returns only Interviews whose `CandidatePersonId` matches
+
+#### Scenario: Filter by stage
+
+- **WHEN** an authenticated user sends `GET /api/interviews?stage=OnsiteScheduled`
+- **THEN** the system returns only Interviews whose stage matches
+
+#### Scenario: Another user's interviews excluded
+
+- **WHEN** User A and User B each have Interviews and User A sends `GET /api/interviews`
+- **THEN** the response contains only User A's Interviews
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no Interviews sends `GET /api/interviews`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get interview by ID
+
+The system SHALL allow an authenticated user to retrieve a single Interview by ID via `GET /api/interviews/{id}`, including its scorecards collection and transcript (if any).
+
+#### Scenario: Get existing interview
+
+- **WHEN** an authenticated user sends `GET /api/interviews/{id}` for an Interview they own
+- **THEN** the system returns the Interview DTO including scorecards and transcript with HTTP 200
+
+#### Scenario: Interview belongs to another user
+
+- **WHEN** an authenticated user sends `GET /api/interviews/{id}` for an Interview owned by another user
+- **THEN** the system returns HTTP 404
+
+#### Scenario: Interview not found
+
+- **WHEN** an authenticated user sends `GET /api/interviews/{id}` for a non-existent id
+- **THEN** the system returns HTTP 404
+
+### Requirement: Delete interview
+
+The system SHALL allow an authenticated user to delete an Interview via `DELETE /api/interviews/{id}`. Deletion SHALL cascade to its owned scorecards and transcript. The system SHALL raise an `InterviewDeleted` domain event.
+
+#### Scenario: Delete existing interview
+
+- **WHEN** an authenticated user sends `DELETE /api/interviews/{id}` for an Interview they own
+- **THEN** the Interview and its owned children are removed and HTTP 204 is returned
+
+#### Scenario: Delete non-existent interview
+
+- **WHEN** an authenticated user sends `DELETE /api/interviews/{id}` for an id not owned by the user
+- **THEN** the system returns HTTP 404
+
+### Requirement: Manage scorecards
+
+The system SHALL allow an authenticated user to add, update, and remove scorecards on an Interview. Each scorecard has `competency` (non-empty), `rating` (integer 1–5), optional `notes`, and `recordedAtUtc` (set from the injected clock on creation). Endpoints:
+
+- `POST /api/interviews/{id}/scorecards` — body `{ competency, rating, notes? }`. Returns HTTP 201 with the scorecard DTO.
+- `PUT /api/interviews/{id}/scorecards/{scorecardId}` — body `{ competency, rating, notes? }`. Returns HTTP 200.
+- `DELETE /api/interviews/{id}/scorecards/{scorecardId}` — returns HTTP 204.
+
+The system SHALL raise `InterviewScorecardAdded`, `InterviewScorecardUpdated`, and `InterviewScorecardRemoved` domain events respectively.
+
+#### Scenario: Add a scorecard
+
+- **WHEN** an authenticated user sends `POST /api/interviews/{id}/scorecards` with `competency "System Design"`, `rating 4`, and `notes "Strong distributed systems fundamentals"`
+- **THEN** the scorecard is added with `recordedAtUtc` set and HTTP 201 is returned
+
+#### Scenario: Update a scorecard
+
+- **WHEN** an authenticated user sends `PUT /api/interviews/{id}/scorecards/{scorecardId}` with `rating 5`
+- **THEN** the scorecard is updated and HTTP 200 is returned
+
+#### Scenario: Remove a scorecard
+
+- **WHEN** an authenticated user sends `DELETE /api/interviews/{id}/scorecards/{scorecardId}`
+- **THEN** the scorecard is removed and HTTP 204 is returned
+
+#### Scenario: Rating out of range rejected
+
+- **WHEN** an authenticated user sends `POST /api/interviews/{id}/scorecards` with `rating 6`
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Empty competency rejected
+
+- **WHEN** an authenticated user sends `POST /api/interviews/{id}/scorecards` with `competency ""`
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Scorecard on interview owned by another user
+
+- **WHEN** an authenticated user adds a scorecard to an Interview they do not own
+- **THEN** the system returns HTTP 404
+
+### Requirement: Set interview transcript
+
+The system SHALL allow an authenticated user to set or replace the transcript on an Interview via `PUT /api/interviews/{id}/transcript` with body `{ "rawText": "<text>" }`. Setting or replacing the transcript SHALL atomically clear any existing AI analysis fields (`Summary`, `RecommendedDecision`, `RiskSignals`, `AnalyzedAtUtc`, `Model`) on the transcript value object. The raw text length MUST NOT exceed `InterviewAnalysisOptions.MaxPromptChars` (default 16000); requests exceeding this SHALL return HTTP 413. The system SHALL raise an `InterviewTranscriptSet` domain event.
+
+#### Scenario: Set transcript for the first time
+
+- **WHEN** an authenticated user sends `PUT /api/interviews/{id}/transcript` with raw text
+- **THEN** the transcript is stored with analysis fields null and HTTP 200 is returned
+
+#### Scenario: Replace transcript clears stale analysis
+
+- **WHEN** an authenticated user replaces a transcript that previously had an AI analysis
+- **THEN** the new raw text is stored AND `Summary`, `RecommendedDecision`, `RiskSignals`, `AnalyzedAtUtc`, `Model` are all cleared and HTTP 200 is returned
+
+#### Scenario: Transcript too long rejected
+
+- **WHEN** an authenticated user sends a transcript exceeding `MaxPromptChars`
+- **THEN** the system returns HTTP 413
+
+#### Scenario: Empty raw text rejected
+
+- **WHEN** an authenticated user sends `PUT /api/interviews/{id}/transcript` with empty `rawText`
+- **THEN** the system returns HTTP 400
+
+### Requirement: Analyze transcript with AI
+
+The system SHALL expose `POST /api/interviews/{id}/analyze` which generates an AI-driven summary, recommended decision, and risk signals from the Interview's transcript and scorecards. The implementation SHALL call `IAiCompletionService` via an `IInterviewAnalysisService` with:
+
+- `Temperature = 0.3`
+- `MaxTokens = InterviewAnalysisOptions.MaxAnalysisTokens`
+- A system prompt forbidding the model from inventing names, dates, or scores outside the supplied facts
+- A user prompt consisting of a JSON-serialised facts block containing scorecards and the escaped transcript (backtick characters in the transcript SHALL be escaped to the Unicode form `\u0060` before being embedded into the prompt)
+
+The response SHALL include `summary` (markdown), `recommendedDecision` (one of the five `InterviewDecision` enum values or null when the model returns a value outside the enum) and `riskSignals` (list of short strings). On success the analysis fields SHALL be persisted on the transcript value object and the system SHALL raise an `InterviewAnalysisGenerated` domain event.
+
+Preconditions:
+- The Interview SHALL have a transcript with non-empty `rawText`. Otherwise the system SHALL return HTTP 409 with error code `transcript_missing`.
+- The user SHALL have an `AiProviderConfig`. Otherwise the system SHALL return HTTP 409 with error code `ai_provider_not_configured`.
+- Any provider error SHALL return HTTP 502 with error code `analysis_failed` and SHALL NOT overwrite existing analysis.
+
+The service SHALL obtain "now" from the injected clock; implementations MUST NOT read `DateTime.UtcNow` directly.
+
+#### Scenario: Analyze an interview with transcript and scorecards
+
+- **WHEN** an authenticated user with a configured AI provider sends `POST /api/interviews/{id}/analyze` and the Interview has a transcript and at least one scorecard
+- **THEN** the system calls the AI provider, persists `summary`, `recommendedDecision`, `riskSignals`, `analyzedAtUtc`, and `model` on the transcript, and returns HTTP 200 with the analysis DTO
+
+#### Scenario: Analyze regenerates over existing analysis
+
+- **WHEN** an authenticated user analyzes an Interview that already has a prior analysis
+- **THEN** the new analysis replaces the old analysis fields and HTTP 200 is returned
+
+#### Scenario: Analyze without transcript rejected
+
+- **WHEN** an authenticated user sends `POST /api/interviews/{id}/analyze` on an Interview with no transcript
+- **THEN** the system returns HTTP 409 with error code `transcript_missing`
+
+#### Scenario: Analyze without configured AI provider rejected
+
+- **WHEN** a user with no `AiProviderConfig` sends `POST /api/interviews/{id}/analyze`
+- **THEN** the system returns HTTP 409 with error code `ai_provider_not_configured` and does not call the provider
+
+#### Scenario: Model returns decision outside the enum
+
+- **WHEN** the AI provider returns `recommendedDecision` of `"maybe"` which is not a valid `InterviewDecision`
+- **THEN** the system stores `recommendedDecision` as null, still persists `summary` and `riskSignals`, and returns HTTP 200 with a warning in the response
+
+#### Scenario: Provider error surfaces as 502
+
+- **WHEN** the AI provider returns an error during analysis
+- **THEN** the system returns HTTP 502 with error code `analysis_failed` and the previously persisted analysis (if any) is unchanged
+
+#### Scenario: Transcript backticks escaped in prompt
+
+- **WHEN** the transcript `rawText` contains backtick characters
+- **THEN** the prompt sent to the AI provider contains those characters replaced with the Unicode escape `\u0060`
+
+### Requirement: Interview user isolation
+
+All Interview endpoints SHALL enforce user isolation: responses SHALL only contain Interviews whose `UserId` matches the authenticated user, and all mutations SHALL reject requests that reference Interviews, scorecards, or candidate People owned by another user. EF Core queries SHALL filter by `UserId`. LINQ predicates involving identifier collections MUST use `List<T>.Contains()` (not `HashSet<T>.Contains()`), and string comparisons MUST use `.ToLower()` (not `.ToLowerInvariant()`), to remain translatable to SQL.
+
+#### Scenario: Mutation on another user's interview rejected
+
+- **WHEN** User A attempts any mutation (`PATCH`, `POST advance`, `POST decision`, scorecard CRUD, transcript set, analyze, `DELETE`) on an Interview owned by User B
+- **THEN** the system returns HTTP 404
+
+#### Scenario: Query returns only own interviews
+
+- **WHEN** User A calls `GET /api/interviews`
+- **THEN** User B's Interviews are never returned, regardless of filters
+
+### Requirement: Interviews pipeline view
+
+The frontend SHALL provide an `/interviews` route rendering a pipeline view grouped by `InterviewStage`. Each stage column SHALL list the user's Interviews in that stage showing candidate name, role title, scheduled date (if any), and decision badge (if set). The view SHALL use PrimeNG components (Card, Tag, Button) and `tailwindcss-primeui` utility classes — no hardcoded Tailwind colour utilities, no `*ngIf` / `*ngFor`, and no `dark:` prefix. State SHALL be managed with signals; data access SHALL use `inject()` DI.
+
+#### Scenario: Render pipeline with interviews across stages
+
+- **WHEN** a user with Interviews in multiple stages navigates to `/interviews`
+- **THEN** the system renders one column per stage and populates each column with that stage's Interviews
+
+#### Scenario: Empty state per column
+
+- **WHEN** a user navigates to `/interviews` and a stage has no Interviews
+- **THEN** the corresponding column renders an empty-state placeholder
+
+#### Scenario: Create interview from pipeline
+
+- **WHEN** a user clicks "New interview" and submits the form with candidate, role title, and optional scheduled date
+- **THEN** a new Interview is created and appears in the `Applied` column
+
+### Requirement: Interview detail view
+
+The frontend SHALL provide an `/interviews/:id` route rendering the Interview detail page with a PrimeNG TabView containing four tabs: **Overview** (metadata, stage advance, decision), **Scorecards** (list / add / edit / remove), **Transcript** (paste / replace), and **AI Analysis** (trigger analyze, show summary / recommended decision / risk signals). Controls SHALL use Signal Forms where forms are involved.
+
+#### Scenario: View interview details
+
+- **WHEN** a user navigates to `/interviews/:id` for an Interview they own
+- **THEN** the page renders the four tabs populated with the Interview's data
+
+#### Scenario: Advance stage from overview tab
+
+- **WHEN** a user selects a valid next stage and clicks "Advance"
+- **THEN** the Interview's stage updates and the tab reflects the new stage
+
+#### Scenario: Add scorecard from scorecards tab
+
+- **WHEN** a user adds a scorecard with competency, rating, and notes
+- **THEN** the scorecard appears in the list
+
+#### Scenario: Run analysis from AI analysis tab
+
+- **WHEN** a user with a configured AI provider clicks "Analyze" on an Interview that has a transcript
+- **THEN** the system displays the summary, recommended decision, and risk signals returned by the API

--- a/openspec/changes/interview-tracking/tasks.md
+++ b/openspec/changes/interview-tracking/tasks.md
@@ -1,0 +1,57 @@
+## 1. Domain
+
+- [ ] 1.1 Add `InterviewStage` enum in `src/MentalMetal.Domain/Interviews/InterviewStage.cs` with values `Applied, ScreenScheduled, ScreenCompleted, OnsiteScheduled, OnsiteCompleted, OfferExtended, Hired, Rejected, Withdrawn`.
+- [ ] 1.2 Add `InterviewDecision` enum in `src/MentalMetal.Domain/Interviews/InterviewDecision.cs` with values `StrongHire, Hire, LeanHire, NoHire, StrongNoHire`.
+- [ ] 1.3 Implement `InterviewScorecard` owned entity (Id, Competency, Rating, Notes, RecordedAtUtc) with `Update(competency, rating, notes, recordedAtUtc)` method validating rating 1–5 and non-empty competency.
+- [ ] 1.4 Implement `InterviewTranscript` owned value object (RawText, Summary, RecommendedDecision, RiskSignals, AnalyzedAtUtc, Model) with `WithAnalysis(...)` and `Clear()` helpers.
+- [ ] 1.5 Implement `Interview` aggregate root (Id, UserId, CandidatePersonId, RoleTitle, Stage, ScheduledAtUtc, CompletedAtUtc, Decision, Transcript, _scorecards) with factory `Create`, `UpdateMetadata`, `AdvanceStage(targetStage, now)`, `RecordDecision(decision)`, scorecard add/update/remove, and `SetTranscript(rawText)` (clears analysis) and `ApplyAnalysis(summary, recommendedDecision, riskSignals, model, now)` methods. Use a forward-transition map + terminal-state set; throw `DomainException` on invalid transitions or decisions-before-completion.
+- [ ] 1.6 Add domain events: `InterviewCreated`, `InterviewUpdated`, `InterviewStageChanged`, `InterviewDecisionRecorded`, `InterviewScorecardAdded/Updated/Removed`, `InterviewTranscriptSet`, `InterviewAnalysisGenerated`, `InterviewDeleted`. Raise each from the aggregate at the right point.
+- [ ] 1.7 Add `IInterviewRepository` interface in Domain (get-by-id, list-for-user with filters, add, update, delete; MarkScorecardAdded/Removed helpers per the EF tracker workaround).
+- [ ] 1.8 Write unit tests covering: valid stage transitions, rejected invalid transitions, terminal-state guard, `CompletedAtUtc` set on Completed / Hired / Rejected, decision-before-completion guard, scorecard rating-range validation, transcript replacement clears analysis, backtick-bearing transcript is accepted as-is at the domain layer (escaping is a service concern).
+
+## 2. Application
+
+- [ ] 2.1 Create vertical slice folder `src/MentalMetal.Application/Interviews/` with DTOs (`InterviewResponse`, `InterviewScorecardResponse`, `InterviewTranscriptResponse`, `InterviewAnalysisResponse`) — never expose domain entities.
+- [ ] 2.2 Add handlers: `CreateInterview`, `UpdateInterview`, `AdvanceInterviewStage`, `RecordInterviewDecision`, `DeleteInterview`, `GetUserInterviews`, `GetInterviewById`.
+- [ ] 2.3 Add handlers: `AddScorecard`, `UpdateScorecard`, `RemoveScorecard`.
+- [ ] 2.4 Add handlers: `SetInterviewTranscript`, `AnalyzeInterview`.
+- [ ] 2.5 Add `IInterviewAnalysisService` + `InterviewAnalysisService` implementation in `src/MentalMetal.Application/Interviews/` that wraps `IAiCompletionService`. System prompt forbids invention; user prompt serialises facts JSON; escape backticks in transcript via `Replace("\u0060", "\\u0060")`; temperature 0.3; MaxTokens from options. Inject `TimeProvider`.
+- [ ] 2.6 Add `InterviewAnalysisOptions` with `[Range]` validated `MaxAnalysisTokens` (default 800) and `MaxPromptChars` (default 16000); register via `.AddOptions<InterviewAnalysisOptions>().BindConfiguration("InterviewAnalysis").ValidateDataAnnotations().ValidateOnStart()`.
+- [ ] 2.7 Wire services in `DependencyInjection.cs` / `ApplicationServiceCollectionExtensions.cs`.
+- [ ] 2.8 Application unit tests for: handler candidate-not-found path, user-isolation filters, analyze service prompt construction (asserts backtick escaping and facts shape), decision parsing when AI returns invalid enum value (stores null + warning).
+
+## 3. Infrastructure
+
+- [ ] 3.1 Add EF Core configuration `InterviewConfiguration` mapping `Interviews` table, indexes on `UserId` and `CandidatePersonId`, owned `InterviewTranscript` columns (`Transcript_RawText`, `Transcript_Summary`, `Transcript_RecommendedDecision`, `Transcript_RiskSignals` as jsonb, `Transcript_AnalyzedAtUtc`, `Transcript_Model`), and owned collection `InterviewScorecards` with cascade delete.
+- [ ] 3.2 Implement `InterviewRepository` using the `MarkOwnedAdded/Removed` pattern proven in `OneOnOneRepository`. Use `List<T>.Contains()` and `.ToLower()` in any LINQ filters.
+- [ ] 3.3 Register `IInterviewRepository` and DbSet in the DI container and `MentalMetalDbContext`.
+- [ ] 3.4 Generate EF Core migration: `dotnet ef migrations add AddInterviews --startup-project ../MentalMetal.Web` (after clean `dotnet build` to avoid sha512 issues; use `--no-build` if needed).
+- [ ] 3.5 Verify migration SQL creates two tables and all expected columns/indexes/FKs.
+
+## 4. Web / API
+
+- [ ] 4.1 Add `InterviewEndpoints.cs` in `src/MentalMetal.Web/Features/Interviews/` mapping all endpoints listed in the spec with `RequireAuthorization()` and resolving `UserId` from the authenticated principal.
+- [ ] 4.2 Map error codes → HTTP status codes: `candidate_not_found` → 404, `invalid_stage_transition` → 409, `decision_not_allowed` → 409, `transcript_missing` → 409, `ai_provider_not_configured` → 409, `analysis_failed` → 502, transcript too long → 413.
+- [ ] 4.3 Wire `app.MapInterviewEndpoints()` into `Program.cs`.
+- [ ] 4.4 Web integration tests (using `WebApplicationFactory`): create → advance → record decision happy path; invalid transition 409; user isolation 404; analyze without provider 409; analyze without transcript 409.
+
+## 5. Frontend
+
+- [ ] 5.1 Add `src/app/shared/models/interview.model.ts` with `Interview`, `InterviewStage`, `InterviewDecision`, `InterviewScorecard`, `InterviewTranscript`, and request/response DTOs.
+- [ ] 5.2 Add `InterviewsService` in `src/app/shared/services/interviews.service.ts` with signals-based state, `inject(HttpClient)`, and methods for list/get/create/update/advance/decision/delete and scorecards/transcript/analyze.
+- [ ] 5.3 Create standalone route `/interviews` with `InterviewsPipelineComponent` using PrimeNG Card + Tag + `@for`/`@if` control flow, grouping Interviews by stage. Layout via Tailwind grid/flex utilities only; colours via PrimeNG tokens (`bg-surface-50`, `text-muted-color`, `bg-primary`). No `*ngIf`/`*ngFor`, no hardcoded palette classes, no `dark:` prefix.
+- [ ] 5.4 Create `InterviewCreateDialogComponent` (Signal Forms) invoked from pipeline "New interview" action.
+- [ ] 5.5 Create `/interviews/:id` `InterviewDetailComponent` with PrimeNG TabView: Overview, Scorecards, Transcript, AI Analysis — each a child signal-based component using Signal Forms where needed.
+- [ ] 5.6 Add routes to `app.routes.ts` and a nav entry to the main shell.
+- [ ] 5.7 Jest/Karma unit tests for `InterviewsService` and the pipeline component (render/empty-state/filter).
+
+## 6. E2E
+
+- [ ] 6.1 Add Playwright spec in `tests/MentalMetal.E2E.Tests/` that: logs in, creates a candidate Person, navigates to `/interviews`, creates an Interview, advances to `ScreenScheduled`, adds a scorecard, sets a transcript, and asserts the expected UI updates.
+
+## 7. Tests & polish
+
+- [ ] 7.1 Run `dotnet test src/MentalMetal.slnx` — fix any failures.
+- [ ] 7.2 Run `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — fix any failures.
+- [ ] 7.3 Verify no new hardcoded Tailwind colour classes (`bg-gray-*`, `text-violet-*`, `dark:*`) nor `*ngIf`/`*ngFor` introduced via grep; lint should be clean.
+- [ ] 7.4 Manual smoke test via dev stack: `docker compose --profile dev-stack up -d --wait` and exercise the `/interviews` flow end-to-end.


### PR DESCRIPTION
## Summary

Proposal for the Tier 3 `interview-tracking` spec. Introduces a new `Interview` aggregate rooted in its own lifecycle, linked to a candidate `Person` by id, with a staged pipeline, owned scorecards, an owned transcript value object, and AI-powered analysis reusing the existing `IAiCompletionService`. This PR contains specification artifacts only — no implementation.

**Spec**: [interview-tracking (proposed)](openspec/changes/interview-tracking/proposal.md)

## Changes

- `openspec/changes/interview-tracking/proposal.md` — why + what changes + capabilities + impact
- `openspec/changes/interview-tracking/design.md` — decisions (aggregate boundary, stage lifecycle, transcript VO, analysis service determinism, backtick-escaping prompt-injection mitigation), EF plan, risks
- `openspec/changes/interview-tracking/specs/interview-tracking/spec.md` — requirements & scenarios for create / update / list / get / delete, stage lifecycle, decision, scorecards CRUD, transcript set, AI analyze, user isolation, pipeline + detail UI
- `openspec/changes/interview-tracking/tasks.md` — implementation checklist across Domain, Application, Infrastructure, Web, Frontend, E2E

Depends on shipped specs: `person-management`, `ai-provider-abstraction`. Follows the `daily-weekly-briefing` pattern for deterministic AI services (TimeProvider injection, explicit prompt construction, validated `IOptions`).

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes locally (all 606 tests green)
- [ ] Markdown-only change; no frontend tests impacted
- [ ] Copilot + CodeRabbit review of proposal/design/spec/tasks artifacts

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)