### PR TITLE
chore(openspec): propose nudges-rhythms

### DIFF
--- a/openspec/changes/nudges-rhythms/.openspec.yaml
+++ b/openspec/changes/nudges-rhythms/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/nudges-rhythms/design.md
+++ b/openspec/changes/nudges-rhythms/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Mental Metal tracks people and initiatives as rich aggregates, and has commitments/delegations for things with explicit completion. What's missing is a lightweight *recurring-rhythm* primitive: "remind me about X every Thursday" or "monthly career check-in with Sarah". These are not tasks -- they repeat forever (until paused or deleted) and exist to surface prompts at the right cadence. The domain model (design/domain-model.md §11) defines the `Nudge` aggregate; this spec lands a focused, deterministic implementation of it.
+
+## Dependencies
+
+- `person-management` (shipped) -- for optional `PersonId` link.
+- `initiative-management` (shipped) -- for optional `InitiativeId` link.
+- `user-auth-tenancy` (shipped) -- for UserId scoping.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ship a deterministic, testable `Nudge` aggregate with cadence-driven schedule advancement.
+- Provide CRUD + lifecycle (pause/resume, mark-nudged) endpoints under `/api/nudges`.
+- Provide an Angular `/nudges` page with list/filter/create/edit/mark-nudged/pause-resume.
+- Keep the schedule arithmetic in the domain and pure (inject `now`).
+
+**Non-Goals:**
+- Integrating nudges into `my-queue` or `daily-weekly-briefing` -- deferred to follow-up specs.
+- Push/email/SMS notifications.
+- Full cron expressions. `Custom` cadence uses `CustomIntervalDays`.
+- Cross-user sharing.
+
+## Decisions
+
+### D1: `NudgeCadence` as a value object with `CalculateNext(from, anchors)`
+
+A `NudgeCadence` record encapsulates `(Type, CustomIntervalDays?, DayOfWeek?, DayOfMonth?)` and exposes a single pure method `CalculateNext(DateOnly from)` returning the next due `DateOnly` on or after `from`. The `Nudge` aggregate calls this in `Create` and `MarkNudged` to compute `NextDueDate`.
+
+**Alternatives considered:**
+- A service `INudgeScheduler`. Rejected -- pure arithmetic belongs on the value object; a service adds indirection with no benefit.
+- Storing just a cron string. Rejected -- overkill for the four fixed cadences + a simple interval.
+
+### D2: Determinism -- inject `now` everywhere
+
+`MarkNudged(DateOnly now)`, `Resume(DateOnly now)`, and `Create(..., DateOnly today)` all take the reference date as a parameter. Handlers receive `TimeProvider` via DI and pass `TimeProvider.GetUtcNow().UtcDateTime` converted to a `DateOnly`. Matches the pattern already used by `commitment-tracking`. Tests construct nudges with fixed `DateOnly` values.
+
+### D3: `NextDueDate` is a persisted field, not computed
+
+Cadence math is cheap, but persisting `NextDueDate` makes filters (`dueBefore`, `dueToday`, `dueThisWeek`) efficient SQL. It's recomputed on create, cadence change, resume, and mark-nudged. Invariant: when `IsActive` is true, `NextDueDate` is non-null.
+
+### D4: Pause/Resume semantics
+
+`Pause()` sets `IsActive=false` and leaves `NextDueDate` untouched (so it's hidden from due-queries but we remember the schedule). `Resume(now)` reactivates and sets `NextDueDate = Cadence.CalculateNext(now)` -- the user re-anchors from today, not the stale value.
+
+### D5: Distinct error codes for distinct failure reasons
+
+- `nudge.notFound` -- nudge does not exist OR belongs to another user (we do not leak existence).
+- `nudge.invalidCadence` -- e.g., Custom without positive `CustomIntervalDays`, or Weekly without `DayOfWeek`.
+- `nudge.alreadyPaused` / `nudge.alreadyActive` -- state-transition conflicts on pause/resume.
+- `nudge.validation` -- title/notes length.
+
+### D6: Title and Notes length caps in the domain
+
+`Title`: required, 1-200 characters. `Notes`: optional, up to 2000 characters. Enforced in `Create`/`UpdateDetails` with explicit `ArgumentException` (matching EF `HasMaxLength` config). Don't rely on DB rejection.
+
+### D7: Linked aggregates by ID only; foreign keys are soft
+
+`PersonId` and `InitiativeId` are `Guid?`. The handler validates that referenced Person/Initiative belongs to the same user before accepting the link (returns `nudge.linkedEntityNotFound`). We do NOT add a hard EF FK -- avoids cross-aggregate join pulls and keeps `Nudge` independent.
+
+### D8: `DayOfMonth` clamping for Monthly
+
+If user picks `DayOfMonth=31` and the next month has 30 days, clamp to month-end. Documented in value-object tests.
+
+### D9: Frontend uses signals + PrimeNG; Signal Forms for the dialog
+
+Following CLAUDE.md: standalone components, `inject()`, signals, PrimeNG tokens. Control flow via `@if`/`@for`. The create/edit dialog uses Signal Forms (Angular 21). Person and Initiative selectors reuse existing `PeopleService` and `InitiativesService`.
+
+## Risks / Trade-offs
+
+- **Clock skew across timezones** → We operate in `DateOnly` anchored to UTC. Acceptable for v1 since briefings are also UTC-anchored. Future work: per-user timezone.
+- **`NextDueDate` drift if a user never "marks nudged"** → Intentional: the user sees a growing overdue badge. No auto-advance.
+- **Custom cadence abuse (`CustomIntervalDays=1` ≡ Daily)** → Allowed; harmless. Validation enforces a minimum of 1 and a reasonable cap of 365.
+- **Link validation is an extra round-trip** → Acceptable; same pattern as `commitment-tracking` uses for PersonId.
+
+## Migration Plan
+
+1. Add `Nudge` aggregate, value object, events, repository interface in Domain.
+2. Add EF configuration + repository in Infrastructure.
+3. `dotnet ef migrations add AddNudges` generating `Nudges` table.
+4. Ship vertical-slice handlers + Minimal API endpoints.
+5. Ship Angular `/nudges` route.
+6. No data backfill required (new table).
+
+Rollback: revert the migration (`dotnet ef migrations remove`) on the feature branch only. Once merged, any correction ships as a new migration.
+
+## Open Questions
+
+None -- the integration questions (my-queue, briefing) are deliberately deferred to follow-up specs.

--- a/openspec/changes/nudges-rhythms/design.md
+++ b/openspec/changes/nudges-rhythms/design.md
@@ -47,7 +47,7 @@ Cadence math is cheap, but persisting `NextDueDate` makes filters (`dueBefore`, 
 
 ### D4: Pause/Resume semantics
 
-`Pause()` sets `IsActive=false` and leaves `NextDueDate` untouched (so it's hidden from due-queries but we remember the schedule). `Resume(now)` reactivates and sets `NextDueDate = Cadence.CalculateNext(now)` -- the user re-anchors from today, not the stale value.
+`Pause()` sets `IsActive=false` and leaves `NextDueDate` untouched (so it's hidden from due-queries but we remember the schedule). `Resume(today)` reactivates and sets `NextDueDate = Cadence.CalculateFirst(today)` -- the user re-anchors from today (on-or-after), not the stale value.
 
 ### D5: Distinct error codes for distinct failure reasons
 

--- a/openspec/changes/nudges-rhythms/design.md
+++ b/openspec/changes/nudges-rhythms/design.md
@@ -26,7 +26,12 @@ Mental Metal tracks people and initiatives as rich aggregates, and has commitmen
 
 ### D1: `NudgeCadence` as a value object with `CalculateNext(from, anchors)`
 
-A `NudgeCadence` record encapsulates `(Type, CustomIntervalDays?, DayOfWeek?, DayOfMonth?)` and exposes a single pure method `CalculateNext(DateOnly from)` returning the next due `DateOnly` on or after `from`. The `Nudge` aggregate calls this in `Create` and `MarkNudged` to compute `NextDueDate`.
+A `NudgeCadence` record encapsulates `(Type, CustomIntervalDays?, DayOfWeek?, DayOfMonth?)` and exposes two pure methods:
+
+- `CalculateFirst(DateOnly from)` returns the first due `DateOnly` on or after `from`. Called by `Create` and `Resume` to anchor the schedule.
+- `CalculateNext(DateOnly after)` returns the next due `DateOnly` **strictly after** `after`. Called by `MarkNudged(now)` so the schedule always advances past the moment of marking.
+
+Splitting the two forms keeps the semantics explicit and matches the spec ("advances to the next occurrence strictly after today").
 
 **Alternatives considered:**
 - A service `INudgeScheduler`. Rejected -- pure arithmetic belongs on the value object; a service adds indirection with no benefit.
@@ -50,6 +55,7 @@ Cadence math is cheap, but persisting `NextDueDate` makes filters (`dueBefore`, 
 - `nudge.invalidCadence` -- e.g., Custom without positive `CustomIntervalDays`, or Weekly without `DayOfWeek`.
 - `nudge.alreadyPaused` / `nudge.alreadyActive` -- state-transition conflicts on pause/resume.
 - `nudge.validation` -- title/notes length.
+- `nudge.linkedEntityNotFound` -- referenced `Person` or `Initiative` is missing, invalid, or belongs to a different user.
 
 ### D6: Title and Notes length caps in the domain
 

--- a/openspec/changes/nudges-rhythms/proposal.md
+++ b/openspec/changes/nudges-rhythms/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Engineering managers rely on recurring rhythms -- "check in on Project X risks every Thursday", "follow up with Sarah on career goals monthly" -- but these live in memory, calendars, or ad-hoc notes and get dropped. Mental Metal needs a first-class recurring-reminder primitive (a "Nudge") that can be linked to the people and initiatives already tracked in the system, so rhythms are captured, scheduled, and surfaced consistently. This closes the last Tier 3 gap before the remaining cross-cutting query surfaces (my-queue, daily-weekly-briefing) can include nudges.
+
+## What Changes
+
+- Introduce a `Nudge` aggregate owned by a user, with a cadence (Daily, Weekly, Biweekly, Monthly, Custom), optional day-of-week / day-of-month anchors, and a computed `NextDueDate`.
+- Nudge schedule advancement (`MarkNudged(now)`) is deterministic: `now` is injected, never read from `DateTime.UtcNow` inside domain or handlers.
+- Optional links to a `Person` and/or `Initiative` by ID (no cross-aggregate references).
+- Pause / Resume lifecycle. Paused nudges do not advance.
+- CRUD + lifecycle Minimal API endpoints under `/api/nudges`.
+- Angular `/nudges` page: list with filters (active/paused, due today/this week, by person/initiative), create/edit dialog, inline "Mark as nudged", and pause/resume toggle.
+- EF Core migration adding `Nudges` table.
+- Vertical-slice handlers in `MentalMetal.Application/Features/Nudges/`.
+
+## Non-goals
+
+- `my-queue` and `daily-weekly-briefing` integration -- deferred to follow-up specs to keep scope focused. This spec only exposes the read surface needed (filters for due-today / due-this-week) so those integrations are straightforward later.
+- Push/email notifications. Nudges are surfaced via the UI and future query-side specs; no external delivery channel.
+- Arbitrary cron expressions. `Custom` cadence uses a fixed interval in days; richer scheduling can come later.
+- Sharing nudges between users.
+
+## Capabilities
+
+### New Capabilities
+- `nudges-rhythms`: Recurring reminder primitive (Nudge aggregate) with cadence-driven scheduling, optional person/initiative links, pause/resume, mark-nudged advancement, and a list/edit UI.
+
+### Modified Capabilities
+<!-- None. Integrations with my-queue and daily-weekly-briefing are deferred. -->
+
+## Impact
+
+- **Domain**: new `Nudge` aggregate in `MentalMetal.Domain/Nudges/`, value objects (`NudgeCadence`), domain events (`NudgeCreated`, `NudgeNudged`, `NudgeCadenceChanged`, `NudgePaused`, `NudgeResumed`, `NudgeUpdated`, `NudgeDeleted`). Tier: **Tier 3**. Depends on: `person-management` (shipped), `initiative-management` (shipped).
+- **Application**: new `Features/Nudges/` vertical slice (Create/Get/List/Update/Delete/MarkNudged/Pause/Resume handlers).
+- **Infrastructure**: `NudgeRepository`, EF `NudgeConfiguration`, new migration.
+- **Web**: Minimal API endpoint group `MapNudgesEndpoints()` registered in `Program.cs`.
+- **Frontend**: new `/nudges` route with list page, create/edit dialog, `NudgesService` signal store; person/initiative selectors reuse existing services.
+- **Tests**: Domain unit tests (cadence advancement, pause/resume, validation), Application handler tests, Web integration tests for endpoints, Angular component tests.
+- No changes to existing aggregates or other specs.

--- a/openspec/changes/nudges-rhythms/specs/nudges-rhythms/spec.md
+++ b/openspec/changes/nudges-rhythms/specs/nudges-rhythms/spec.md
@@ -148,21 +148,21 @@ The system SHALL allow an authenticated user to update a nudge's title, notes, a
 
 ### Requirement: Update cadence
 
-The system SHALL allow an authenticated user to change a nudge's cadence via `PATCH /api/nudges/{id}` or a dedicated cadence-update action. When the cadence changes, the system SHALL recompute `NextDueDate` from today using the new cadence. Validation rules from "Create a nudge" SHALL apply. The system SHALL raise a `NudgeCadenceChanged` domain event.
+The system SHALL expose `PATCH /api/nudges/{id}/cadence` for cadence updates (distinct from `PATCH /api/nudges/{id}`, which handles title/notes/links). When the cadence changes, the system SHALL recompute `NextDueDate` from today using the new cadence's `CalculateFirst(today)`. Validation rules from "Create a nudge" SHALL apply. The system SHALL raise a `NudgeCadenceChanged` domain event.
 
 #### Scenario: Change from Weekly to Monthly
 
-- **WHEN** an authenticated user changes a Weekly nudge to Monthly with dayOfMonth 1
+- **WHEN** an authenticated user sends PATCH `/api/nudges/{id}/cadence` changing a Weekly nudge to Monthly with dayOfMonth 1
 - **THEN** the system updates the cadence, recomputes NextDueDate to the next 1st of the month on or after today, and returns HTTP 200
 
 #### Scenario: Invalid new cadence rejected
 
-- **WHEN** an authenticated user changes a nudge to cadence Custom with customIntervalDays 0
+- **WHEN** an authenticated user sends PATCH `/api/nudges/{id}/cadence` with cadence Custom and customIntervalDays 0
 - **THEN** the system returns HTTP 400 with error code `nudge.invalidCadence`
 
 ### Requirement: Mark nudge as nudged
 
-The system SHALL allow an authenticated user to record that they acted on a nudge via `POST /api/nudges/{id}/mark-nudged`. The system SHALL set `LastNudgedAt` to the current UTC timestamp and advance `NextDueDate` to the next occurrence strictly after today based on the cadence. Only active nudges can be marked. The system SHALL raise a `NudgeNudged` domain event.
+The system SHALL allow an authenticated user to record that they acted on a nudge via `POST /api/nudges/{id}/mark-nudged`. The system SHALL set `LastNudgedAt` to the current UTC timestamp and advance `NextDueDate` to the next occurrence strictly after today via `Cadence.CalculateNext(today)`. Only active nudges can be marked. The system SHALL raise a `NudgeNudged` domain event.
 
 #### Scenario: Mark a daily nudge
 

--- a/openspec/changes/nudges-rhythms/specs/nudges-rhythms/spec.md
+++ b/openspec/changes/nudges-rhythms/specs/nudges-rhythms/spec.md
@@ -1,0 +1,284 @@
+## ADDED Requirements
+
+### Requirement: Create a nudge
+
+The system SHALL allow an authenticated user to create a new Nudge with a title and cadence. Title MUST NOT be empty and MUST NOT exceed 200 characters. Cadence MUST be one of `Daily`, `Weekly`, `Biweekly`, `Monthly`, or `Custom`. When cadence is `Weekly` or `Biweekly`, `DayOfWeek` MUST be provided. When cadence is `Monthly`, `DayOfMonth` MUST be provided and MUST be between 1 and 31. When cadence is `Custom`, `CustomIntervalDays` MUST be provided and MUST be between 1 and 365. Optional fields: `PersonId`, `InitiativeId`, `Notes` (up to 2000 characters), `StartDate` (defaults to today). The system SHALL compute `NextDueDate` from the cadence and start date, set `IsActive=true`, set `CreatedAtUtc`, and raise a `NudgeCreated` domain event. The Nudge SHALL be scoped to the authenticated user's UserId.
+
+#### Scenario: Create a daily nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with title "Review risk log" and cadence "Daily"
+- **THEN** the system creates a Nudge with cadence Daily, NextDueDate equal to today, IsActive=true, and returns HTTP 201
+
+#### Scenario: Create a weekly nudge anchored to Thursday
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with title "Project X risks", cadence "Weekly", and dayOfWeek "Thursday"
+- **THEN** the system creates a Nudge with NextDueDate equal to the next Thursday on or after today and returns HTTP 201
+
+#### Scenario: Create a monthly nudge anchored to day 15
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with title "Career check-in with Sarah", cadence "Monthly", dayOfMonth 15, and personId for Sarah
+- **THEN** the system creates a Nudge with NextDueDate equal to the 15th of the current or next month and returns HTTP 201
+
+#### Scenario: Create a custom-interval nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with title "Retro temperature", cadence "Custom", and customIntervalDays 10
+- **THEN** the system creates a Nudge advancing every 10 days and returns HTTP 201
+
+#### Scenario: Empty title rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with an empty title
+- **THEN** the system returns HTTP 400 with error code `nudge.validation`
+
+#### Scenario: Title over 200 characters rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with a title longer than 200 characters
+- **THEN** the system returns HTTP 400 with error code `nudge.validation`
+
+#### Scenario: Weekly without day of week rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with cadence "Weekly" and no dayOfWeek
+- **THEN** the system returns HTTP 400 with error code `nudge.invalidCadence`
+
+#### Scenario: Custom without positive interval rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with cadence "Custom" and customIntervalDays 0 or negative
+- **THEN** the system returns HTTP 400 with error code `nudge.invalidCadence`
+
+#### Scenario: PersonId for another user rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges` with a personId that belongs to a different user
+- **THEN** the system returns HTTP 400 with error code `nudge.linkedEntityNotFound`
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a nudge and User B creates a nudge
+- **THEN** each nudge is scoped to its respective user's UserId
+
+### Requirement: List nudges with filters
+
+The system SHALL allow an authenticated user to retrieve their nudges. The list SHALL support optional filters: `isActive` (true/false), `personId`, `initiativeId`, `dueBefore` (DateOnly -- returns active nudges with `NextDueDate <= dueBefore`), and `dueWithinDays` (integer -- returns active nudges due within N days from today). The list SHALL be ordered by `NextDueDate` ascending, with paused nudges sorted last when `isActive` is not filtered.
+
+#### Scenario: List all nudges
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges`
+- **THEN** the system returns all of that user's nudges ordered by NextDueDate ascending with HTTP 200
+
+#### Scenario: Filter active
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges?isActive=true`
+- **THEN** the system returns only nudges with IsActive=true
+
+#### Scenario: Filter due today
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges?dueBefore=<today>&isActive=true`
+- **THEN** the system returns only active nudges whose NextDueDate is on or before today
+
+#### Scenario: Filter due this week
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges?dueWithinDays=7`
+- **THEN** the system returns only active nudges whose NextDueDate is within 7 days from today
+
+#### Scenario: Filter by person
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges?personId={id}`
+- **THEN** the system returns only nudges linked to that person
+
+#### Scenario: Filter by initiative
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges?initiativeId={id}`
+- **THEN** the system returns only nudges linked to that initiative
+
+#### Scenario: Empty list
+
+- **WHEN** an authenticated user with no nudges sends a GET to `/api/nudges`
+- **THEN** the system returns an empty array with HTTP 200
+
+### Requirement: Get nudge by ID
+
+The system SHALL allow an authenticated user to retrieve a single nudge by ID. A nudge belonging to another user SHALL be treated as not found (no existence leak).
+
+#### Scenario: Get existing nudge
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges/{id}` with a valid nudge ID they own
+- **THEN** the system returns the nudge with all fields including cadence, anchors, NextDueDate, LastNudgedAt, IsActive, and linked IDs
+
+#### Scenario: Nudge not found
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges/{id}` with an ID that does not exist
+- **THEN** the system returns HTTP 404 with error code `nudge.notFound`
+
+#### Scenario: Nudge belongs to another user
+
+- **WHEN** an authenticated user sends a GET to `/api/nudges/{id}` for a nudge owned by a different user
+- **THEN** the system returns HTTP 404 with error code `nudge.notFound`
+
+### Requirement: Update nudge details
+
+The system SHALL allow an authenticated user to update a nudge's title, notes, and optional links (PersonId, InitiativeId) via `PATCH /api/nudges/{id}`. Title MUST NOT be empty and MUST NOT exceed 200 characters. Notes MUST NOT exceed 2000 characters. Updating details SHALL set `UpdatedAtUtc` and raise a `NudgeUpdated` domain event when any field changes.
+
+#### Scenario: Update title
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with a new title
+- **THEN** the system updates the title, sets UpdatedAtUtc, and returns HTTP 200
+
+#### Scenario: Update notes
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with new notes
+- **THEN** the system updates the notes and returns HTTP 200
+
+#### Scenario: Set person link
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with a personId
+- **THEN** the system sets the PersonId and returns HTTP 200
+
+#### Scenario: Clear person link
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with personId=null
+- **THEN** the system clears the PersonId and returns HTTP 200
+
+#### Scenario: Empty title rejected
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with an empty title
+- **THEN** the system returns HTTP 400 with error code `nudge.validation`
+
+#### Scenario: PersonId for another user rejected
+
+- **WHEN** an authenticated user sends a PATCH to `/api/nudges/{id}` with a personId belonging to a different user
+- **THEN** the system returns HTTP 400 with error code `nudge.linkedEntityNotFound`
+
+### Requirement: Update cadence
+
+The system SHALL allow an authenticated user to change a nudge's cadence via `PATCH /api/nudges/{id}` or a dedicated cadence-update action. When the cadence changes, the system SHALL recompute `NextDueDate` from today using the new cadence. Validation rules from "Create a nudge" SHALL apply. The system SHALL raise a `NudgeCadenceChanged` domain event.
+
+#### Scenario: Change from Weekly to Monthly
+
+- **WHEN** an authenticated user changes a Weekly nudge to Monthly with dayOfMonth 1
+- **THEN** the system updates the cadence, recomputes NextDueDate to the next 1st of the month on or after today, and returns HTTP 200
+
+#### Scenario: Invalid new cadence rejected
+
+- **WHEN** an authenticated user changes a nudge to cadence Custom with customIntervalDays 0
+- **THEN** the system returns HTTP 400 with error code `nudge.invalidCadence`
+
+### Requirement: Mark nudge as nudged
+
+The system SHALL allow an authenticated user to record that they acted on a nudge via `POST /api/nudges/{id}/mark-nudged`. The system SHALL set `LastNudgedAt` to the current UTC timestamp and advance `NextDueDate` to the next occurrence strictly after today based on the cadence. Only active nudges can be marked. The system SHALL raise a `NudgeNudged` domain event.
+
+#### Scenario: Mark a daily nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/mark-nudged` for an active daily nudge
+- **THEN** the system advances NextDueDate to tomorrow, sets LastNudgedAt, and returns HTTP 200
+
+#### Scenario: Mark a weekly Thursday nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/mark-nudged` for an active weekly Thursday nudge on a Thursday
+- **THEN** the system advances NextDueDate to the following Thursday, sets LastNudgedAt, and returns HTTP 200
+
+#### Scenario: Mark a monthly nudge with day clamp
+
+- **WHEN** a monthly nudge is anchored to dayOfMonth 31 and is marked on January 31st
+- **THEN** the system advances NextDueDate to February 28th or 29th (clamped to month-end)
+
+#### Scenario: Mark a paused nudge rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/mark-nudged` for a paused nudge
+- **THEN** the system returns HTTP 409 with error code `nudge.notActive`
+
+#### Scenario: Nudge not found
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/mark-nudged` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404 with error code `nudge.notFound`
+
+### Requirement: Pause a nudge
+
+The system SHALL allow an authenticated user to pause an active nudge via `POST /api/nudges/{id}/pause`. The system SHALL set `IsActive=false` while preserving `NextDueDate` and `LastNudgedAt`. The system SHALL raise a `NudgePaused` domain event. Only active nudges can be paused.
+
+#### Scenario: Pause an active nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/pause` for an active nudge
+- **THEN** the system sets IsActive=false and returns HTTP 200
+
+#### Scenario: Pause an already paused nudge rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/pause` for a paused nudge
+- **THEN** the system returns HTTP 409 with error code `nudge.alreadyPaused`
+
+### Requirement: Resume a nudge
+
+The system SHALL allow an authenticated user to resume a paused nudge via `POST /api/nudges/{id}/resume`. The system SHALL set `IsActive=true` and recompute `NextDueDate` from today using the current cadence. The system SHALL raise a `NudgeResumed` domain event. Only paused nudges can be resumed.
+
+#### Scenario: Resume a paused nudge
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/resume` for a paused nudge
+- **THEN** the system sets IsActive=true, recomputes NextDueDate from today, and returns HTTP 200
+
+#### Scenario: Resume an active nudge rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/nudges/{id}/resume` for an active nudge
+- **THEN** the system returns HTTP 409 with error code `nudge.alreadyActive`
+
+### Requirement: Delete a nudge
+
+The system SHALL allow an authenticated user to delete a nudge via `DELETE /api/nudges/{id}`. The system SHALL raise a `NudgeDeleted` domain event.
+
+#### Scenario: Delete an existing nudge
+
+- **WHEN** an authenticated user sends a DELETE to `/api/nudges/{id}` for a nudge they own
+- **THEN** the system removes the nudge and returns HTTP 204
+
+#### Scenario: Delete nudge not found
+
+- **WHEN** an authenticated user sends a DELETE to `/api/nudges/{id}` with an ID that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404 with error code `nudge.notFound`
+
+### Requirement: Determinism -- inject current time
+
+The system SHALL compute `NextDueDate` using a `TimeProvider` injected into application handlers. Domain methods (`Create`, `MarkNudged`, `Resume`, `UpdateCadence`) SHALL accept the current date as a parameter. Handlers SHALL NOT read `DateTime.UtcNow` directly.
+
+#### Scenario: Tests use fixed time
+
+- **WHEN** a unit test constructs a Nudge with a fixed `today` value and marks it as nudged with a fixed `now`
+- **THEN** the resulting NextDueDate is deterministic and asserts pass
+
+### Requirement: Nudges list UI
+
+The frontend SHALL provide a `/nudges` page that displays nudges with title, cadence label, next due date, person link, initiative link, active/paused badge, and actions (Mark as nudged, Pause/Resume, Edit, Delete). The page SHALL support filters for active/paused, due today/this week, by person, and by initiative.
+
+#### Scenario: View nudge list
+
+- **WHEN** a user navigates to `/nudges`
+- **THEN** the page displays the user's nudges with cadence, next due date, person/initiative links, and active status
+
+#### Scenario: Filter due today
+
+- **WHEN** a user selects the "Due today" filter
+- **THEN** only nudges with NextDueDate on or before today and IsActive=true are shown
+
+#### Scenario: Mark as nudged from list
+
+- **WHEN** a user clicks "Mark as nudged" on an active nudge in the list
+- **THEN** the nudge's NextDueDate advances and the row updates without a full page reload
+
+#### Scenario: Pause and resume from list
+
+- **WHEN** a user clicks "Pause" on an active nudge, then "Resume" on the same nudge
+- **THEN** the badge toggles and NextDueDate recomputes from today on resume
+
+### Requirement: Nudge create/edit form
+
+The frontend SHALL provide a dialog for creating and editing nudges. The form SHALL include title, cadence selector, conditional anchor inputs (DayOfWeek for Weekly/Biweekly, DayOfMonth for Monthly, CustomIntervalDays for Custom), start date picker, optional person selector, optional initiative selector, and notes.
+
+#### Scenario: Create a nudge via dialog
+
+- **WHEN** a user opens the create dialog, fills in title, selects Weekly, picks Thursday, and submits
+- **THEN** a new nudge is created and appears in the list
+
+#### Scenario: Edit a nudge
+
+- **WHEN** a user edits a nudge's title and cadence and submits
+- **THEN** the nudge is updated and the list reflects the new values
+
+#### Scenario: Cadence-specific anchors shown conditionally
+
+- **WHEN** a user selects cadence "Monthly" in the dialog
+- **THEN** a DayOfMonth input is shown and the DayOfWeek input is hidden

--- a/openspec/changes/nudges-rhythms/tasks.md
+++ b/openspec/changes/nudges-rhythms/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Domain
 
-- [ ] 1.1 Create `MentalMetal.Domain/Nudges/` folder with `Nudge.cs` aggregate (Id, UserId, Title, Cadence VO, StartDate, NextDueDate, LastNudgedAt, PersonId?, InitiativeId?, Notes, IsActive, CreatedAtUtc, UpdatedAtUtc).
-- [ ] 1.2 Add `NudgeCadence` value object with `CadenceType` enum (Daily, Weekly, Biweekly, Monthly, Custom) and a pure `CalculateNext(DateOnly from)` method, including DayOfMonth clamping for short months.
+- [ ] 1.1 Create `src/MentalMetal.Domain/Nudges/` folder with `Nudge.cs` aggregate (Id, UserId, Title, Cadence VO, StartDate, NextDueDate, LastNudgedAt, PersonId?, InitiativeId?, Notes, IsActive, CreatedAtUtc, UpdatedAtUtc).
+- [ ] 1.2 Add `NudgeCadence` value object with `CadenceType` enum (Daily, Weekly, Biweekly, Monthly, Custom) and pure `CalculateFirst(DateOnly from)` (returns next due on or after `from` -- for Create/Resume) and `CalculateNext(DateOnly after)` (returns next due strictly after `after` -- for MarkNudged) methods, including DayOfMonth clamping for short months.
 - [ ] 1.3 Implement domain behaviour: `Create(userId, title, cadence, today, ...)`, `UpdateDetails`, `UpdateCadence`, `MarkNudged(now)`, `Pause()`, `Resume(today)`, with length/cadence validation and invariant checks.
 - [ ] 1.4 Add domain events: `NudgeCreated`, `NudgeUpdated`, `NudgeCadenceChanged`, `NudgeNudged`, `NudgePaused`, `NudgeResumed`, `NudgeDeleted`.
 - [ ] 1.5 Add `INudgeRepository` interface in Domain.
-- [ ] 1.6 Add domain unit tests in `MentalMetal.Domain.Tests/Nudges/` covering cadence math for all five cadences, pause/resume state transitions, validation (title length, cadence-specific required fields), and DayOfMonth=31 clamping edge case.
+- [ ] 1.6 Add domain unit tests in `tests/MentalMetal.Domain.Tests/Nudges/` covering cadence math for all five cadences, pause/resume state transitions, validation (title length, cadence-specific required fields), and DayOfMonth=31 clamping edge case.
 
 ## 2. Application
 
-- [ ] 2.1 Create `MentalMetal.Application/Features/Nudges/` vertical-slice folder.
+- [ ] 2.1 Create `src/MentalMetal.Application/Features/Nudges/` vertical-slice folder.
 - [ ] 2.2 Implement `CreateNudge` handler with link validation (PersonId/InitiativeId belong to user) and `TimeProvider` injection.
 - [ ] 2.3 Implement `GetNudge` handler (not-found on wrong owner -- no existence leak).
 - [ ] 2.4 Implement `ListNudges` handler with filters (isActive, personId, initiativeId, dueBefore, dueWithinDays) -- use `.ToLower()` and `List<T>.Contains()` patterns, no `ToLowerInvariant()` or `HashSet`.
@@ -30,14 +30,14 @@
 
 ## 4. Web API
 
-- [ ] 4.1 Add `NudgesEndpoints.cs` with `MapNudgesEndpoints()` for POST, GET (list+filters), GET {id}, PATCH, PATCH cadence, POST mark-nudged, POST pause, POST resume, DELETE.
+- [ ] 4.1 Add `src/MentalMetal.Web/Features/Nudges/NudgesEndpoints.cs` with `MapNudgesEndpoints()` for `POST /api/nudges`, `GET /api/nudges` (list+filters), `GET /api/nudges/{id}`, `PATCH /api/nudges/{id}` (title/notes/links), `PATCH /api/nudges/{id}/cadence`, `POST /api/nudges/{id}/mark-nudged`, `POST /api/nudges/{id}/pause`, `POST /api/nudges/{id}/resume`, `DELETE /api/nudges/{id}`.
 - [ ] 4.2 Register endpoints in `Program.cs`.
 - [ ] 4.3 Map handler errors to ProblemDetails with distinct codes.
-- [ ] 4.4 Add integration tests in `MentalMetal.Web.IntegrationTests/Nudges/` covering happy paths + each distinct error code.
+- [ ] 4.4 Add integration tests in `tests/MentalMetal.Web.IntegrationTests/Nudges/` covering happy paths + each distinct error code.
 
 ## 5. Frontend
 
-- [ ] 5.1 Add `nudges` feature folder under `ClientApp/src/app/features/nudges/` (standalone components, signals).
+- [ ] 5.1 Add `nudges` feature folder under `src/MentalMetal.Web/ClientApp/src/app/features/nudges/` (standalone components, signals).
 - [ ] 5.2 Add `NudgesService` with signal-based state (list signal, filter signals, loading, error).
 - [ ] 5.3 Implement `NudgesListComponent` with PrimeNG table, filter toolbar (active/paused, due today/this week, person, initiative), and action buttons (Mark as nudged, Pause/Resume, Edit, Delete). Use `@if`/`@for`, Tailwind for layout only, PrimeNG tokens for colour.
 - [ ] 5.4 Implement `NudgeEditDialogComponent` using Signal Forms with conditional anchor inputs (DayOfWeek / DayOfMonth / CustomIntervalDays).

--- a/openspec/changes/nudges-rhythms/tasks.md
+++ b/openspec/changes/nudges-rhythms/tasks.md
@@ -1,0 +1,52 @@
+## 1. Domain
+
+- [ ] 1.1 Create `MentalMetal.Domain/Nudges/` folder with `Nudge.cs` aggregate (Id, UserId, Title, Cadence VO, StartDate, NextDueDate, LastNudgedAt, PersonId?, InitiativeId?, Notes, IsActive, CreatedAtUtc, UpdatedAtUtc).
+- [ ] 1.2 Add `NudgeCadence` value object with `CadenceType` enum (Daily, Weekly, Biweekly, Monthly, Custom) and a pure `CalculateNext(DateOnly from)` method, including DayOfMonth clamping for short months.
+- [ ] 1.3 Implement domain behaviour: `Create(userId, title, cadence, today, ...)`, `UpdateDetails`, `UpdateCadence`, `MarkNudged(now)`, `Pause()`, `Resume(today)`, with length/cadence validation and invariant checks.
+- [ ] 1.4 Add domain events: `NudgeCreated`, `NudgeUpdated`, `NudgeCadenceChanged`, `NudgeNudged`, `NudgePaused`, `NudgeResumed`, `NudgeDeleted`.
+- [ ] 1.5 Add `INudgeRepository` interface in Domain.
+- [ ] 1.6 Add domain unit tests in `MentalMetal.Domain.Tests/Nudges/` covering cadence math for all five cadences, pause/resume state transitions, validation (title length, cadence-specific required fields), and DayOfMonth=31 clamping edge case.
+
+## 2. Application
+
+- [ ] 2.1 Create `MentalMetal.Application/Features/Nudges/` vertical-slice folder.
+- [ ] 2.2 Implement `CreateNudge` handler with link validation (PersonId/InitiativeId belong to user) and `TimeProvider` injection.
+- [ ] 2.3 Implement `GetNudge` handler (not-found on wrong owner -- no existence leak).
+- [ ] 2.4 Implement `ListNudges` handler with filters (isActive, personId, initiativeId, dueBefore, dueWithinDays) -- use `.ToLower()` and `List<T>.Contains()` patterns, no `ToLowerInvariant()` or `HashSet`.
+- [ ] 2.5 Implement `UpdateNudge` handler (title/notes/links).
+- [ ] 2.6 Implement `UpdateNudgeCadence` handler.
+- [ ] 2.7 Implement `MarkNudgeAsNudged`, `PauseNudge`, `ResumeNudge` handlers.
+- [ ] 2.8 Implement `DeleteNudge` handler.
+- [ ] 2.9 Define application-layer DTOs (`NudgeResponse`, `CreateNudgeRequest`, `UpdateNudgeRequest`, `UpdateCadenceRequest`).
+- [ ] 2.10 Add error codes: `nudge.notFound`, `nudge.validation`, `nudge.invalidCadence`, `nudge.linkedEntityNotFound`, `nudge.notActive`, `nudge.alreadyPaused`, `nudge.alreadyActive`.
+- [ ] 2.11 Add application handler tests for success + distinct error paths.
+
+## 3. Infrastructure
+
+- [ ] 3.1 Add `NudgeConfiguration` EF config (table `Nudges`, Title max 200, Notes max 2000, cadence stored as owned value object, indexes on UserId + NextDueDate, IsActive).
+- [ ] 3.2 Implement `NudgeRepository : INudgeRepository` with EF queries (soft user scoping, filter translation).
+- [ ] 3.3 Register `INudgeRepository` in DI.
+- [ ] 3.4 Generate migration: `dotnet ef migrations add AddNudges --startup-project ../MentalMetal.Web`.
+
+## 4. Web API
+
+- [ ] 4.1 Add `NudgesEndpoints.cs` with `MapNudgesEndpoints()` for POST, GET (list+filters), GET {id}, PATCH, PATCH cadence, POST mark-nudged, POST pause, POST resume, DELETE.
+- [ ] 4.2 Register endpoints in `Program.cs`.
+- [ ] 4.3 Map handler errors to ProblemDetails with distinct codes.
+- [ ] 4.4 Add integration tests in `MentalMetal.Web.IntegrationTests/Nudges/` covering happy paths + each distinct error code.
+
+## 5. Frontend
+
+- [ ] 5.1 Add `nudges` feature folder under `ClientApp/src/app/features/nudges/` (standalone components, signals).
+- [ ] 5.2 Add `NudgesService` with signal-based state (list signal, filter signals, loading, error).
+- [ ] 5.3 Implement `NudgesListComponent` with PrimeNG table, filter toolbar (active/paused, due today/this week, person, initiative), and action buttons (Mark as nudged, Pause/Resume, Edit, Delete). Use `@if`/`@for`, Tailwind for layout only, PrimeNG tokens for colour.
+- [ ] 5.4 Implement `NudgeEditDialogComponent` using Signal Forms with conditional anchor inputs (DayOfWeek / DayOfMonth / CustomIntervalDays).
+- [ ] 5.5 Register `/nudges` route and add nav link.
+- [ ] 5.6 Add component tests (list filters, dialog conditional inputs, mark-nudged flow).
+
+## 6. Verification
+
+- [ ] 6.1 Run `dotnet test src/MentalMetal.slnx` -- all green.
+- [ ] 6.2 Run `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` -- all green.
+- [ ] 6.3 Run `openspec validate nudges-rhythms --strict`.
+- [ ] 6.4 Manually smoke-test the `/nudges` page against dev-stack: create each cadence, mark-nudged, pause/resume, delete.


### PR DESCRIPTION
## Summary

OpenSpec proposal for a new `Nudge` aggregate: recurring reminders with cadence-driven scheduling (Daily/Weekly/Biweekly/Monthly/Custom), optional Person/Initiative links, pause/resume, mark-nudged advancement, and a `/nudges` UI. Schedule math is deterministic (`TimeProvider` injected, `now` passed into domain methods). Integrations with `my-queue` and `daily-weekly-briefing` are deferred to follow-up specs to keep scope focused.

## Changes

- `openspec/changes/nudges-rhythms/proposal.md` — why, what changes, capabilities, impact
- `openspec/changes/nudges-rhythms/design.md` — cadence VO, determinism, error codes, pause/resume semantics, DayOfMonth clamping
- `openspec/changes/nudges-rhythms/specs/nudges-rhythms/spec.md` — 12 requirements with WHEN/THEN scenarios
- `openspec/changes/nudges-rhythms/tasks.md` — Domain / Application / Infrastructure / Web / Frontend / Verification task breakdown
- `openspec/changes/nudges-rhythms/.openspec.yaml`

## Test Plan

- [x] `openspec validate nudges-rhythms --strict` passes
- [x] All 4 artifacts complete per `openspec status`
- [ ] Reviewer checks: scenarios testable, error codes distinct, determinism captured, CLAUDE.md patterns respected in tasks

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification documentation for a new recurring reminder feature with configurable schedules, optional personal and item linking, lifecycle management (pause/resume), and planned API and interface designs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->