### PR TITLE
openspec: propose capture-audio

### DIFF
--- a/openspec/changes/capture-audio/.openspec.yaml
+++ b/openspec/changes/capture-audio/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/capture-audio/design.md
+++ b/openspec/changes/capture-audio/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Mental Metal's `capture-text` feature (shipped) gives managers a single `Capture` aggregate for any textual input. Many recorded conversations (1:1s, leadership syncs, interviews) are happening today, but typing notes live degrades attention. We already have an AI provider abstraction (`ai-provider-abstraction`) and a downstream `capture-ai-extraction` pipeline that turns any `Capture.RawContent` into commitments, delegations, and links. The missing step is a path from microphone → transcript → populated `RawContent` with speaker context preserved.
+
+Dependencies: `capture-text` (base aggregate), `person-management` (speaker linking), `ai-provider-abstraction` (transcription provider pattern).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Record/upload audio from the browser and persist it to a capture.
+- Transcribe audio asynchronously (for MVP: inline on upload) producing text + speaker-labeled segments.
+- Link transcript speakers to existing `Person` entries with a bulk mapping API.
+- Automatically discard the audio blob once transcription succeeds; retain duration + MIME for UX.
+- Reuse the existing `Capture` aggregate — do not fork a new audio aggregate.
+
+**Non-Goals:**
+- Real-time streaming transcription.
+- Cloud object storage (S3/GCS/Azure) — filesystem implementation only, behind an interface.
+- Cross-capture voiceprint matching (same speaker recognized across recordings).
+- Editing/splitting transcript segments.
+- User-configurable retention (audio discard is the only policy for MVP).
+- Translation / multi-language selection in the UI.
+
+## Decisions
+
+### D1: Extend `Capture` aggregate rather than creating `AudioCapture`
+
+Adding optional audio fields + an owned `TranscriptSegments` collection keeps downstream extraction, triage, and link APIs identical. A new aggregate would fork every list/filter query and double the surface area. Alternative considered and rejected: separate `AudioCapture` aggregate referencing `Capture` by ID.
+
+### D2: `TranscriptSegments` as an EF-owned collection
+
+Segments are only meaningful in the context of their parent `Capture` and never queried independently. An owned collection keeps aggregate invariants (user-scoping, lifecycle) intact. Infrastructure uses the repo's existing `MarkOwnedAdded`/`MarkOwnedRemoved` helpers. Domain enforces segment text length (≤ 2000 chars) and `StartSeconds ≤ EndSeconds` in a `TranscriptSegment.Create(...)` factory so EF column limits match domain invariants.
+
+### D3: Synchronous transcription for MVP
+
+On `POST /api/captures/audio`, the handler persists the capture (status `Raw`), stores the blob, then calls `IAudioTranscriptionProvider.TranscribeAsync` inline, sets segments + `RawContent`, discards the blob, and marks status `Processed` (transcription-level, not extraction-level — the capture-ai-extraction pipeline still runs separately). We chose synchronous over a background job queue because we do not yet have a background worker in the system. `POST /api/captures/{id}/transcribe` exists so a user can retry after a provider failure without re-uploading.
+
+### D4: Audio discard after successful transcription
+
+A `Capture.MarkAudioDiscarded(now)` method nulls `AudioBlobRef` and sets `AudioDiscardedAt`. The `IAudioBlobStore.DeleteAsync(ref)` is called from the handler after the aggregate state transitions, not inside the aggregate — blob storage is infrastructure. If delete fails we log and continue (the capture is still valid; an orphan cleanup job can reap later — future work).
+
+### D5: Storage abstraction
+
+`IAudioBlobStore` with `SaveAsync(userId, stream, mime) → string ref`, `OpenReadAsync(ref) → Stream`, `DeleteAsync(ref)`. Default `FileSystemAudioBlobStore` writes to `{options.RootPath}/{userId}/{guid}.{ext}`. Options (`AudioBlobStoreOptions`) validated via `ValidateDataAnnotations().ValidateOnStart()`. Root path is ephemeral in Docker — acceptable because blobs are discarded within seconds of upload on the happy path.
+
+### D6: Upload size + format validation
+
+Options (`AudioUploadOptions`): `MaxSizeBytes` (default 50 MB, `[Range(1, 500_000_000)]`), `AllowedMimeTypes` (default `audio/webm,audio/mp4,audio/mpeg,audio/wav`). The endpoint uses minimal API `[FromForm] IFormFile` with `RequestSizeLimit` attribute honoring the option. Rejection returns `audio.tooLarge` or `audio.invalidFormat` before any bytes land on disk (Kestrel enforces the size cap).
+
+### D7: Speaker identification API shape
+
+`PATCH /api/captures/{id}/speakers` takes `{ mappings: [{ speakerLabel, personId }] }`. The aggregate method `IdentifySpeakers(IReadOnlyDictionary<string, PersonId> mapping)` walks `TranscriptSegments` and sets `LinkedPersonId` on every segment with a matching label. Unmapped labels are untouched. Passing a label not present in any segment returns `speaker.labelNotFound`. Person existence is verified in the handler (not in the aggregate) to avoid a cross-aggregate dependency in Domain; failure returns `speaker.personNotFound`.
+
+### D8: Frontend recorder
+
+Standalone `CaptureRecorderComponent` using `navigator.mediaDevices.getUserMedia` + `MediaRecorder`. Signals: `isRecording`, `durationSeconds`, `error`. Stop → `Blob` → `FormData` → `POST /api/captures/audio`. No waveform visualization for MVP.
+
+### D9: Determinism and prompt-safe text
+
+Handlers accept `TimeProvider` / injected `now` (the repo uses `TimeProvider` abstraction for `BriefingService`). Transcript text that flows into downstream AI prompts is escaped for backticks to `\u0060` — this escaping lives in the extraction pipeline (already shipped in `capture-ai-extraction`), not here, but we add a regression test that an audio-origin capture triggers the same safe path.
+
+## Risks / Trade-offs
+
+- **Long synchronous upload** → Mitigation: 50 MB cap; provider call is the bottleneck. If this becomes painful we'll move to background jobs (tracked as future work).
+- **Ephemeral filesystem on Cloud Run** → Mitigation: blobs are discarded on success; any in-flight blob lost on container restart results in a `transcription.failed` and an orphaned capture with no audio. User can re-upload. Acceptable for MVP.
+- **Speaker diarization accuracy varies by provider** → Mitigation: we store whatever labels the provider returns and let users re-map; no guarantees are made about label stability.
+- **Orphaned blobs on transcription failure** → Mitigation: future cleanup job; note in ops docs. Not a hard failure.
+- **MediaRecorder MIME output differs per browser** → Mitigation: allow the common set; reject unknown formats with `audio.invalidFormat`.
+
+## Dependencies
+
+- `capture-text` — `Capture` aggregate, `CaptureType` enum (adds `AudioRecording`).
+- `person-management` — `PersonId`, `PersonRepository` for existence checks.
+- `ai-provider-abstraction` — `IAudioTranscriptionProvider` added alongside existing AI provider interfaces.
+
+## Open Questions
+
+- Which production transcription provider to ship first (Claude/OpenAI/Gemini)? Deferred — stub dev provider is wired; real provider plug-in is a small follow-up.
+- Retention opt-out UX (keep audio for N days) — explicitly deferred.

--- a/openspec/changes/capture-audio/design.md
+++ b/openspec/changes/capture-audio/design.md
@@ -31,9 +31,24 @@ Adding optional audio fields + an owned `TranscriptSegments` collection keeps do
 
 Segments are only meaningful in the context of their parent `Capture` and never queried independently. An owned collection keeps aggregate invariants (user-scoping, lifecycle) intact. Infrastructure uses the repo's existing `MarkOwnedAdded`/`MarkOwnedRemoved` helpers. Domain enforces segment text length (≤ 2000 chars) and `StartSeconds ≤ EndSeconds` in a `TranscriptSegment.Create(...)` factory so EF column limits match domain invariants.
 
-### D3: Synchronous transcription for MVP
+### D3: Synchronous transcription for MVP with a dedicated `TranscriptionStatus`
 
-On `POST /api/captures/audio`, the handler persists the capture (status `Raw`), stores the blob, then calls `IAudioTranscriptionProvider.TranscribeAsync` inline, sets segments + `RawContent`, discards the blob, and marks status `Processed` (transcription-level, not extraction-level — the capture-ai-extraction pipeline still runs separately). We chose synchronous over a background job queue because we do not yet have a background worker in the system. `POST /api/captures/{id}/transcribe` exists so a user can retry after a provider failure without re-uploading.
+Transcription is run synchronously during the upload request (no background queue — background queueing is explicitly out of scope for MVP). Because the existing `Capture.ProcessingStatus` (`Raw`/`Processing`/`Processed`/`Failed`) is already owned by the AI-extraction pipeline (where `Processed` means extraction finished and `AiExtraction` is populated, and `CaptureProcessingFailed` means extraction failed), we introduce a separate lifecycle on the aggregate:
+
+```
+TranscriptionStatus: NotApplicable | Pending | InProgress | Transcribed | Failed
+```
+
+- Text captures keep `TranscriptionStatus = NotApplicable`.
+- `POST /api/captures/audio` creates the capture with `ProcessingStatus = Raw` and `TranscriptionStatus = Pending`, stores the blob, flips to `InProgress`, calls `IAudioTranscriptionProvider.TranscribeAsync` inline, on success sets segments + `RawContent`, transitions `TranscriptionStatus = Transcribed`, discards the blob, and raises `CaptureTranscribed` + `CaptureAudioDiscarded`. `ProcessingStatus` stays `Raw` so the extraction pipeline picks the capture up exactly as it does for a text capture.
+- On provider failure (exception or error response) the aggregate transitions `TranscriptionStatus = Failed`, raises `CaptureTranscriptionFailed`, and leaves `ProcessingStatus = Raw` (the extraction pipeline's lifecycle is untouched). The HTTP response returns `transcription.failed` (or `transcription.providerUnavailable` when the provider was unreachable).
+- `POST /api/captures/{id}/transcribe` re-runs transcription for captures in `TranscriptionStatus = Failed` whose audio blob is still present.
+
+This separation keeps the two concerns — transcription and AI extraction — cleanly addressable and prevents the audio flow from ever synthesising a `Processed` state that downstream consumers would read as "extraction complete".
+
+### D3.1: Over-length transcript segments
+
+`TranscriptSegment.Text` is bounded at 2000 characters to match the EF column and the domain invariant. When `IAudioTranscriptionProvider` returns a segment whose `Text` exceeds 2000 characters, the `UploadAudioCapture`/`TranscribeCapture` handler SHALL split the segment into adjacent segments of ≤ 2000 characters, preserving `SpeakerLabel` and allocating `StartSeconds`/`EndSeconds` proportionally to each chunk's character count. Splitting rather than truncating was chosen so no content is lost — transcripts feed downstream extraction where truncation would silently drop context.
 
 ### D4: Audio discard after successful transcription
 

--- a/openspec/changes/capture-audio/proposal.md
+++ b/openspec/changes/capture-audio/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Engineering managers spend many hours in 1:1s, leadership syncs, and interviews. Typing notes live disrupts attention; recording audio and transcribing after the fact captures context faithfully and lets users focus on the conversation. Speaker diarization and identification turn a raw transcript into structured dialogue linked to people already in Mental Metal, enabling downstream extraction (commitments, delegations, decisions) to attribute statements to the right person. Audio is discarded after transcription to minimize storage, privacy exposure, and retention risk.
+
+## What Changes
+
+- Extend the existing `Capture` aggregate with audio-specific fields: `AudioBlobRef` (storage pointer), `AudioMimeType`, `AudioDurationSeconds`, `AudioDiscardedAt`.
+- Add an owned collection `TranscriptSegments` on `Capture` (per-segment `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, optional `LinkedPersonId`).
+- Add a new capture type `AudioRecording` (extension of existing enum).
+- New AI abstraction: `IAudioTranscriptionProvider` returning transcript text plus speaker-labeled segments; transcript text is assigned to the existing `Capture.RawContent` so `capture-ai-extraction` works unchanged.
+- New storage abstraction `IAudioBlobStore` with a filesystem-backed default implementation (configurable root path). Cloud providers deferred as future work.
+- Retention policy: on successful transcription, the audio blob is deleted from storage and `AudioDiscardedAt` is set. Duration and MIME type remain for UX context.
+- New endpoints:
+  - `POST /api/captures/audio` (multipart upload; creates capture + queues/kicks transcription synchronously for MVP).
+  - `POST /api/captures/{id}/transcribe` (re-trigger transcription on a failed capture).
+  - `GET /api/captures/{id}/transcript` (returns transcript segments).
+  - `PATCH /api/captures/{id}/speakers` (bulk mapping from speaker label → PersonId).
+- Frontend: standalone recorder component using the browser `MediaRecorder` API (signals-driven), a transcript viewer grouping segments by speaker, and a speaker-identification picker with Person autocomplete.
+- Error codes: `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`.
+
+## Capabilities
+
+### New Capabilities
+
+- `capture-audio`: Record, upload, and transcribe audio into a Capture with speaker-diarized transcript segments linkable to Persons; discards the audio blob after successful transcription.
+
+### Modified Capabilities
+
+(None — no existing spec requirements change. `capture-text` stays intact; audio captures populate `RawContent` just as text captures do, and `capture-ai-extraction` consumes it unchanged.)
+
+## Impact
+
+- **Domain**: `Capture` aggregate gains audio fields and an owned `TranscriptSegment` collection; new domain events `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`.
+- **Application**: New vertical slices — `UploadAudioCapture`, `TranscribeCapture`, `GetCaptureTranscript`, `UpdateCaptureSpeakers`.
+- **Infrastructure**: `IAudioBlobStore` (filesystem default), `IAudioTranscriptionProvider` (stub dev provider; real provider wiring out of scope); EF configuration for owned `TranscriptSegments` collection; new migration.
+- **Web/API**: New endpoints and DTOs listed above; request-size limits enforced via options.
+- **Frontend**: New recorder, transcript view, and speaker-mapping components wired into capture detail.
+- **Tier**: Tier 3. Depends on `capture-text` (base aggregate) and `person-management` (speaker linking). Consumed by `capture-ai-extraction` without changes.
+- **Non-goals**: Real-time live transcription; cloud blob storage (S3/GCS/Azure); multi-language transcription UX selection; speaker voiceprint matching across captures; editing transcript segments; retention opt-out (flagged as future).

--- a/openspec/changes/capture-audio/proposal.md
+++ b/openspec/changes/capture-audio/proposal.md
@@ -11,12 +11,13 @@ Engineering managers spend many hours in 1:1s, leadership syncs, and interviews.
 - New storage abstraction `IAudioBlobStore` with a filesystem-backed default implementation (configurable root path). Cloud providers deferred as future work.
 - Retention policy: on successful transcription, the audio blob is deleted from storage and `AudioDiscardedAt` is set. Duration and MIME type remain for UX context.
 - New endpoints:
-  - `POST /api/captures/audio` (multipart upload; creates capture + queues/kicks transcription synchronously for MVP).
+  - `POST /api/captures/audio` (multipart upload; creates capture and runs transcription synchronously during upload for MVP — background queueing is out of scope).
   - `POST /api/captures/{id}/transcribe` (re-trigger transcription on a failed capture).
   - `GET /api/captures/{id}/transcript` (returns transcript segments).
   - `PATCH /api/captures/{id}/speakers` (bulk mapping from speaker label → PersonId).
+- Introduce a dedicated `Capture.TranscriptionStatus` lifecycle (`NotApplicable`, `Pending`, `InProgress`, `Transcribed`, `Failed`) that is independent of the existing `ProcessingStatus` (which governs AI extraction). After successful transcription the flow sets `TranscriptionStatus=Transcribed` and leaves `ProcessingStatus=Raw` so `capture-ai-extraction` runs unchanged.
 - Frontend: standalone recorder component using the browser `MediaRecorder` API (signals-driven), a transcript viewer grouping segments by speaker, and a speaker-identification picker with Person autocomplete.
-- Error codes: `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`.
+- Error codes (canonical list, reconciled across proposal/tasks/spec): `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.audioDiscarded`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`.
 
 ## Capabilities
 
@@ -30,7 +31,7 @@ Engineering managers spend many hours in 1:1s, leadership syncs, and interviews.
 
 ## Impact
 
-- **Domain**: `Capture` aggregate gains audio fields and an owned `TranscriptSegment` collection; new domain events `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`.
+- **Domain**: `Capture` aggregate gains audio fields, a dedicated `TranscriptionStatus` lifecycle (independent of `ProcessingStatus`), and an owned `TranscriptSegment` collection; new domain events `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureTranscriptionFailed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`.
 - **Application**: New vertical slices — `UploadAudioCapture`, `TranscribeCapture`, `GetCaptureTranscript`, `UpdateCaptureSpeakers`.
 - **Infrastructure**: `IAudioBlobStore` (filesystem default), `IAudioTranscriptionProvider` (stub dev provider; real provider wiring out of scope); EF configuration for owned `TranscriptSegments` collection; new migration.
 - **Web/API**: New endpoints and DTOs listed above; request-size limits enforced via options.

--- a/openspec/changes/capture-audio/specs/capture-audio/spec.md
+++ b/openspec/changes/capture-audio/specs/capture-audio/spec.md
@@ -26,27 +26,31 @@ The system SHALL allow an authenticated user to upload an audio recording via mu
 
 ### Requirement: Transcribe an audio capture
 
-The system SHALL transcribe an `AudioRecording` capture using `IAudioTranscriptionProvider`, populate `Capture.RawContent` with the full transcript text, populate the owned `TranscriptSegments` collection with per-segment start/end seconds, speaker label, and text, and raise a `CaptureTranscribed` domain event. Transcription SHALL run synchronously on upload. If transcription fails, the capture's processing status SHALL transition to `Failed` with an error reason, and the response SHALL include error code `transcription.failed`. The endpoint `POST /api/captures/{id}/transcribe` SHALL allow retrying a failed transcription.
+The system SHALL transcribe an `AudioRecording` capture using `IAudioTranscriptionProvider`, populate `Capture.RawContent` with the full transcript text, populate the owned `TranscriptSegments` collection with per-segment start/end seconds, speaker label, and text, transition `Capture.TranscriptionStatus` from `Pending` → `InProgress` → `Transcribed`, and raise a `CaptureTranscribed` domain event. Transcription SHALL run synchronously during upload (background queueing is out of scope for MVP).
+
+`TranscriptionStatus` is a lifecycle independent of `ProcessingStatus` (which governs AI extraction). On successful transcription `ProcessingStatus` SHALL remain `Raw` so the existing `capture-ai-extraction` pipeline picks up the capture unchanged; transcription completion is represented exclusively by `TranscriptionStatus = Transcribed`.
+
+If transcription fails the system SHALL transition `TranscriptionStatus` to `Failed`, raise a `CaptureTranscriptionFailed` domain event (distinct from `CaptureProcessingFailed`, which is reserved for AI-extraction failure), leave `ProcessingStatus` untouched, and return error code `transcription.failed` (or `transcription.providerUnavailable` when the provider was unreachable). The endpoint `POST /api/captures/{id}/transcribe` SHALL allow retrying a transcription when `TranscriptionStatus = Failed` and the audio blob is still present.
 
 #### Scenario: Successful transcription populates transcript
 
 - **WHEN** an audio capture is uploaded and the transcription provider returns text and segments
-- **THEN** `Capture.RawContent` contains the full transcript text, `TranscriptSegments` contains one segment per provider segment, and a `CaptureTranscribed` event is raised
+- **THEN** `Capture.RawContent` contains the full transcript text, `TranscriptSegments` contains one segment per provider segment, `Capture.TranscriptionStatus` is `Transcribed`, `Capture.ProcessingStatus` remains `Raw`, and a `CaptureTranscribed` event is raised
 
 #### Scenario: Transcription failure
 
-- **WHEN** the transcription provider throws or returns an error
-- **THEN** the capture's processing status becomes `Failed`, a `CaptureProcessingFailed` event is raised, and the upload response returns error code `transcription.failed`
+- **WHEN** the transcription provider throws or returns an error during upload
+- **THEN** `Capture.TranscriptionStatus` becomes `Failed`, `Capture.ProcessingStatus` is unchanged, a `CaptureTranscriptionFailed` event is raised, and the upload response returns error code `transcription.failed`
 
 #### Scenario: Retry transcription on failed capture
 
-- **WHEN** an authenticated user POSTs to `/api/captures/{id}/transcribe` for a capture in status `Failed` with the audio still present
-- **THEN** the system re-runs transcription and returns HTTP 200 with the updated capture
+- **WHEN** an authenticated user POSTs to `/api/captures/{id}/transcribe` for a capture with `TranscriptionStatus = Failed` and the audio still present
+- **THEN** the system re-runs transcription and returns HTTP 200 with the updated capture (`TranscriptionStatus = Transcribed` on success)
 
 #### Scenario: Retry on capture with discarded audio
 
 - **WHEN** an authenticated user POSTs to `/api/captures/{id}/transcribe` for a capture where `AudioDiscardedAt` is set
-- **THEN** the system returns HTTP 400 with error code `audio.uploadFailed` (no audio available)
+- **THEN** the system returns HTTP 400 with error code `transcription.audioDiscarded` (the upload previously succeeded; the audio was intentionally discarded after a successful transcription and cannot be retried)
 
 ### Requirement: Discard audio after successful transcription
 
@@ -123,6 +127,15 @@ The `TranscriptSegment` value SHALL enforce the following invariants at creation
 
 - **WHEN** a `TranscriptSegment` is created with `Text` longer than 2000 characters
 - **THEN** the domain throws an invariant-violation exception
+
+### Requirement: Split over-length provider segments
+
+When `IAudioTranscriptionProvider` returns a segment whose `Text` exceeds 2000 characters, the transcription handler SHALL split that segment into adjacent `TranscriptSegment` instances each ≤ 2000 characters, preserving the original `SpeakerLabel` and allocating `StartSeconds`/`EndSeconds` proportionally to each chunk's character length so the concatenated chunks span the original segment's time range without gaps or overlaps. No content from the provider SHALL be dropped.
+
+#### Scenario: Provider segment longer than 2000 characters is split
+
+- **WHEN** the provider returns a single segment with 4500 characters spanning 60.0s–120.0s labeled "Speaker A"
+- **THEN** the resulting `TranscriptSegments` contain three adjacent segments each ≤ 2000 characters, all labeled "Speaker A", whose `StartSeconds`/`EndSeconds` divide the 60.0s–120.0s range proportionally to character counts and whose concatenated `Text` matches the provider's original text
 
 ### Requirement: Audio capture frontend recorder
 

--- a/openspec/changes/capture-audio/specs/capture-audio/spec.md
+++ b/openspec/changes/capture-audio/specs/capture-audio/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Upload an audio capture
+
+The system SHALL allow an authenticated user to upload an audio recording via multipart `POST /api/captures/audio`. The request MUST include a file field, an optional `title`, and an optional `source`. The system SHALL create a new `Capture` with `Type = AudioRecording`, set `CapturedAt` to the current time, scope the Capture to the authenticated user's `UserId`, persist the audio bytes via `IAudioBlobStore`, and record `AudioBlobRef`, `AudioMimeType`, and `AudioDurationSeconds` on the aggregate. The system SHALL raise a `CaptureAudioUploaded` domain event. On success the response is HTTP 201 with the created capture.
+
+#### Scenario: Upload a valid audio file
+
+- **WHEN** an authenticated user POSTs a multipart request to `/api/captures/audio` with a 2 MB `audio/webm` file and title "1:1 with Sarah"
+- **THEN** the system creates a Capture with type `AudioRecording`, stores the blob, sets `AudioMimeType = "audio/webm"` and `AudioDurationSeconds`, and returns HTTP 201 with the created capture
+
+#### Scenario: Reject file over size limit
+
+- **WHEN** an authenticated user POSTs an audio file larger than the configured `MaxSizeBytes`
+- **THEN** the system returns HTTP 400 with error code `audio.tooLarge` and no Capture is created
+
+#### Scenario: Reject unsupported MIME type
+
+- **WHEN** an authenticated user POSTs a file whose MIME type is not in the configured allow-list
+- **THEN** the system returns HTTP 400 with error code `audio.invalidFormat` and no Capture is created
+
+#### Scenario: Missing file field
+
+- **WHEN** an authenticated user POSTs to `/api/captures/audio` without a file
+- **THEN** the system returns HTTP 400 with a validation error
+
+### Requirement: Transcribe an audio capture
+
+The system SHALL transcribe an `AudioRecording` capture using `IAudioTranscriptionProvider`, populate `Capture.RawContent` with the full transcript text, populate the owned `TranscriptSegments` collection with per-segment start/end seconds, speaker label, and text, and raise a `CaptureTranscribed` domain event. Transcription SHALL run synchronously on upload. If transcription fails, the capture's processing status SHALL transition to `Failed` with an error reason, and the response SHALL include error code `transcription.failed`. The endpoint `POST /api/captures/{id}/transcribe` SHALL allow retrying a failed transcription.
+
+#### Scenario: Successful transcription populates transcript
+
+- **WHEN** an audio capture is uploaded and the transcription provider returns text and segments
+- **THEN** `Capture.RawContent` contains the full transcript text, `TranscriptSegments` contains one segment per provider segment, and a `CaptureTranscribed` event is raised
+
+#### Scenario: Transcription failure
+
+- **WHEN** the transcription provider throws or returns an error
+- **THEN** the capture's processing status becomes `Failed`, a `CaptureProcessingFailed` event is raised, and the upload response returns error code `transcription.failed`
+
+#### Scenario: Retry transcription on failed capture
+
+- **WHEN** an authenticated user POSTs to `/api/captures/{id}/transcribe` for a capture in status `Failed` with the audio still present
+- **THEN** the system re-runs transcription and returns HTTP 200 with the updated capture
+
+#### Scenario: Retry on capture with discarded audio
+
+- **WHEN** an authenticated user POSTs to `/api/captures/{id}/transcribe` for a capture where `AudioDiscardedAt` is set
+- **THEN** the system returns HTTP 400 with error code `audio.uploadFailed` (no audio available)
+
+### Requirement: Discard audio after successful transcription
+
+When transcription completes successfully the system SHALL delete the audio blob from storage and record the deletion by setting `AudioDiscardedAt` on the Capture and clearing `AudioBlobRef`. `AudioMimeType` and `AudioDurationSeconds` SHALL be retained. The system SHALL raise a `CaptureAudioDiscarded` domain event.
+
+#### Scenario: Audio discarded on success
+
+- **WHEN** an audio capture is transcribed successfully
+- **THEN** `IAudioBlobStore.DeleteAsync` is called, `AudioBlobRef` is null, `AudioDiscardedAt` is set to the current time, and `AudioDurationSeconds` and `AudioMimeType` are retained
+
+#### Scenario: Audio retained on transcription failure
+
+- **WHEN** transcription fails
+- **THEN** the audio blob is retained, `AudioBlobRef` is unchanged, and `AudioDiscardedAt` is null
+
+### Requirement: Retrieve transcript segments
+
+The system SHALL allow an authenticated user to retrieve the transcript segments of one of their captures via `GET /api/captures/{id}/transcript`. The response SHALL contain an array of segments ordered by `StartSeconds` ascending, each with `startSeconds`, `endSeconds`, `speakerLabel`, `text`, and optional `linkedPersonId`.
+
+#### Scenario: Get transcript for transcribed capture
+
+- **WHEN** an authenticated user GETs `/api/captures/{id}/transcript` for a transcribed capture
+- **THEN** the system returns HTTP 200 with the ordered segment list
+
+#### Scenario: Transcript empty for non-transcribed capture
+
+- **WHEN** an authenticated user GETs the transcript of a capture with no segments
+- **THEN** the system returns HTTP 200 with an empty array
+
+#### Scenario: Capture not found
+
+- **WHEN** an authenticated user GETs the transcript of a capture that does not exist or belongs to another user
+- **THEN** the system returns HTTP 404 with error code `capture.notFound`
+
+### Requirement: Identify speakers on a transcript
+
+The system SHALL allow an authenticated user to bulk-map transcript speaker labels to existing `Person` IDs via `PATCH /api/captures/{id}/speakers`. The request SHALL contain `mappings`, an array of `{ speakerLabel, personId }` pairs. For each pair the system SHALL set `LinkedPersonId` on every `TranscriptSegment` with that label. Each `personId` MUST exist and belong to the authenticated user. The system SHALL raise a `CaptureSpeakerIdentified` domain event per distinct label mapped.
+
+#### Scenario: Map a speaker to a person
+
+- **WHEN** an authenticated user PATCHes `/api/captures/{id}/speakers` with `{ mappings: [{ speakerLabel: "Speaker A", personId: "<sarah>" }] }`
+- **THEN** every transcript segment labeled "Speaker A" has `LinkedPersonId = <sarah>` and the system returns HTTP 200
+
+#### Scenario: Person does not exist
+
+- **WHEN** an authenticated user passes a `personId` that does not exist or belongs to another user
+- **THEN** the system returns HTTP 400 with error code `speaker.personNotFound`
+
+#### Scenario: Speaker label not in transcript
+
+- **WHEN** an authenticated user passes a `speakerLabel` not present in any segment
+- **THEN** the system returns HTTP 400 with error code `speaker.labelNotFound`
+
+#### Scenario: Empty mapping set is a no-op
+
+- **WHEN** an authenticated user PATCHes with an empty `mappings` array
+- **THEN** the system returns HTTP 200 and the transcript is unchanged
+
+### Requirement: Transcript segment invariants
+
+The `TranscriptSegment` value SHALL enforce the following invariants at creation and update: `Text` MUST NOT be empty and MUST be 2000 characters or fewer; `StartSeconds` MUST be non-negative; `EndSeconds` MUST be greater than or equal to `StartSeconds`; `SpeakerLabel` MUST NOT be empty and MUST be 64 characters or fewer. Violations SHALL throw a domain exception.
+
+#### Scenario: Reject empty segment text
+
+- **WHEN** a `TranscriptSegment` is created with empty `Text`
+- **THEN** the domain throws an invariant-violation exception
+
+#### Scenario: Reject segment with end before start
+
+- **WHEN** a `TranscriptSegment` is created with `EndSeconds < StartSeconds`
+- **THEN** the domain throws an invariant-violation exception
+
+#### Scenario: Reject over-length segment text
+
+- **WHEN** a `TranscriptSegment` is created with `Text` longer than 2000 characters
+- **THEN** the domain throws an invariant-violation exception
+
+### Requirement: Audio capture frontend recorder
+
+The frontend SHALL provide a standalone, signal-driven recorder component that uses the browser `MediaRecorder` API to record audio in the user's default supported format, shows the elapsed duration while recording, and on stop uploads the resulting blob to `POST /api/captures/audio`. On successful upload the new capture SHALL appear in the capture list.
+
+#### Scenario: Record and upload
+
+- **WHEN** a user clicks Record, speaks, and clicks Stop in the recorder
+- **THEN** the component uploads the audio and the new capture appears in the capture list with type `AudioRecording`
+
+#### Scenario: Microphone permission denied
+
+- **WHEN** the user denies microphone permission
+- **THEN** the recorder displays an error message and does not attempt to upload
+
+### Requirement: Transcript viewer UI
+
+The frontend SHALL provide a transcript viewer on the capture detail page that groups consecutive segments by speaker, visually distinguishes speakers, and shows each segment's timecode. Each speaker group SHALL offer an action to link the speaker to an existing `Person` via an autocomplete picker.
+
+#### Scenario: View transcript with speaker groups
+
+- **WHEN** a user opens the detail view of a transcribed audio capture
+- **THEN** the transcript is displayed as blocks grouped by speaker with timecodes visible
+
+#### Scenario: Link speaker to person
+
+- **WHEN** a user selects a Person in the speaker picker for a given speaker label
+- **THEN** the frontend PATCHes `/api/captures/{id}/speakers` and the display updates to show the person's name next to every matching segment

--- a/openspec/changes/capture-audio/tasks.md
+++ b/openspec/changes/capture-audio/tasks.md
@@ -1,0 +1,54 @@
+## 1. Domain
+
+- [ ] 1.1 Extend `CaptureType` enum with `AudioRecording`
+- [ ] 1.2 Add audio fields to `Capture` aggregate: `AudioBlobRef`, `AudioMimeType`, `AudioDurationSeconds`, `AudioDiscardedAt`
+- [ ] 1.3 Add `TranscriptSegment` owned entity with `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, `LinkedPersonId`; enforce invariants in `Create`
+- [ ] 1.4 Add `TranscriptSegments` owned collection to `Capture` with `ReplaceTranscript(...)` and `IdentifySpeakers(mapping)` methods
+- [ ] 1.5 Add `Capture.CreateAudio(...)`, `Capture.AttachTranscript(...)`, `Capture.MarkAudioDiscarded(now)` methods
+- [ ] 1.6 Add domain events: `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`
+- [ ] 1.7 Unit tests covering audio-capture creation, transcript attachment, speaker mapping, and segment invariants
+
+## 2. Application
+
+- [ ] 2.1 Define `IAudioBlobStore` interface in Application abstractions
+- [ ] 2.2 Define `IAudioTranscriptionProvider` interface returning text + segments
+- [ ] 2.3 Implement `UploadAudioCapture` handler (create capture, save blob, transcribe inline, discard blob, commit)
+- [ ] 2.4 Implement `TranscribeCapture` handler for retry flow
+- [ ] 2.5 Implement `GetCaptureTranscript` query handler
+- [ ] 2.6 Implement `UpdateCaptureSpeakers` handler (verify person existence, invoke aggregate method)
+- [ ] 2.7 Application-level unit tests for each handler (success, failure, not-found, invalid input)
+
+## 3. Infrastructure
+
+- [ ] 3.1 EF Core configuration for new `Capture` audio fields and owned `TranscriptSegments` collection (HasMaxLength 2000, 64)
+- [ ] 3.2 Repository helpers `MarkOwnedAdded/MarkOwnedRemoved` for transcript segments
+- [ ] 3.3 `FileSystemAudioBlobStore` implementation with `AudioBlobStoreOptions` (Range/Required, ValidateOnStart)
+- [ ] 3.4 `StubAudioTranscriptionProvider` for dev/test environments (deterministic output)
+- [ ] 3.5 EF migration `AddCaptureAudioFields`
+- [ ] 3.6 DI registration of new services in `Program.cs` / composition root
+
+## 4. Web API
+
+- [ ] 4.1 `POST /api/captures/audio` minimal-API endpoint with multipart handling and `RequestSizeLimit`
+- [ ] 4.2 `POST /api/captures/{id}/transcribe` endpoint
+- [ ] 4.3 `GET /api/captures/{id}/transcript` endpoint
+- [ ] 4.4 `PATCH /api/captures/{id}/speakers` endpoint
+- [ ] 4.5 DTOs for transcript segments, speaker-mapping request, and audio-upload response
+- [ ] 4.6 `AudioUploadOptions` (MaxSizeBytes, AllowedMimeTypes) with `ValidateDataAnnotations().ValidateOnStart()`
+- [ ] 4.7 Error-code constants (`audio.invalidFormat`, `audio.tooLarge`, `transcription.failed`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`)
+- [ ] 4.8 Integration tests for each endpoint (happy path + key failure modes)
+
+## 5. Frontend
+
+- [ ] 5.1 `CaptureRecorderComponent` standalone component using MediaRecorder with signals
+- [ ] 5.2 `TranscriptViewerComponent` grouping segments by speaker with timecodes
+- [ ] 5.3 `SpeakerPickerComponent` with Person autocomplete
+- [ ] 5.4 API client methods for the four new endpoints
+- [ ] 5.5 Integration into capture detail view
+- [ ] 5.6 Component tests for recorder state machine and transcript grouping logic
+
+## 6. Validation
+
+- [ ] 6.1 `dotnet test src/MentalMetal.slnx` green
+- [ ] 6.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` green
+- [ ] 6.3 `openspec validate capture-audio --strict` passes

--- a/openspec/changes/capture-audio/tasks.md
+++ b/openspec/changes/capture-audio/tasks.md
@@ -2,18 +2,19 @@
 
 - [ ] 1.1 Extend `CaptureType` enum with `AudioRecording`
 - [ ] 1.2 Add audio fields to `Capture` aggregate: `AudioBlobRef`, `AudioMimeType`, `AudioDurationSeconds`, `AudioDiscardedAt`
-- [ ] 1.3 Add `TranscriptSegment` owned entity with `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, `LinkedPersonId`; enforce invariants in `Create`
-- [ ] 1.4 Add `TranscriptSegments` owned collection to `Capture` with `ReplaceTranscript(...)` and `IdentifySpeakers(mapping)` methods
-- [ ] 1.5 Add `Capture.CreateAudio(...)`, `Capture.AttachTranscript(...)`, `Capture.MarkAudioDiscarded(now)` methods
-- [ ] 1.6 Add domain events: `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`
-- [ ] 1.7 Unit tests covering audio-capture creation, transcript attachment, speaker mapping, and segment invariants
+- [ ] 1.3 Add `TranscriptionStatus` enum (`NotApplicable`, `Pending`, `InProgress`, `Transcribed`, `Failed`) and property on `Capture`, independent of `ProcessingStatus`; existing (text) captures default to `NotApplicable`
+- [ ] 1.4 Add `TranscriptSegment` owned entity with `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, `LinkedPersonId`; enforce invariants in `Create`
+- [ ] 1.5 Add `TranscriptSegments` owned collection to `Capture` with `ReplaceTranscript(...)` and `IdentifySpeakers(mapping)` methods
+- [ ] 1.6 Add `Capture.CreateAudio(...)`, `Capture.AttachTranscript(...)`, `Capture.MarkTranscriptionFailed(reason)`, `Capture.MarkAudioDiscarded(now)` methods with explicit `TranscriptionStatus` transitions
+- [ ] 1.7 Add domain events: `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureTranscriptionFailed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`
+- [ ] 1.8 Unit tests covering audio-capture creation, transcript attachment, speaker mapping, `TranscriptionStatus` transitions (Pending→InProgress→Transcribed / Pending→InProgress→Failed), and segment invariants
 
 ## 2. Application
 
 - [ ] 2.1 Define `IAudioBlobStore` interface in Application abstractions
 - [ ] 2.2 Define `IAudioTranscriptionProvider` interface returning text + segments
-- [ ] 2.3 Implement `UploadAudioCapture` handler (create capture, save blob, transcribe inline, discard blob, commit)
-- [ ] 2.4 Implement `TranscribeCapture` handler for retry flow
+- [ ] 2.3 Implement `UploadAudioCapture` handler (create capture with `TranscriptionStatus=Pending`, save blob, transition to `InProgress`, transcribe inline, split any provider segment whose `Text` exceeds 2000 chars into adjacent 2000-char segments with proportional `StartSeconds`/`EndSeconds`, on success mark `Transcribed` + discard blob, on failure mark `Failed` + raise `CaptureTranscriptionFailed` + retain blob, commit)
+- [ ] 2.4 Implement `TranscribeCapture` handler for retry flow (allow only when `TranscriptionStatus=Failed` and `AudioBlobRef` is present; reject retry on a capture whose audio was already discarded with error code `transcription.audioDiscarded`)
 - [ ] 2.5 Implement `GetCaptureTranscript` query handler
 - [ ] 2.6 Implement `UpdateCaptureSpeakers` handler (verify person existence, invoke aggregate method)
 - [ ] 2.7 Application-level unit tests for each handler (success, failure, not-found, invalid input)
@@ -23,7 +24,7 @@
 - [ ] 3.1 EF Core configuration for new `Capture` audio fields and owned `TranscriptSegments` collection (HasMaxLength 2000, 64)
 - [ ] 3.2 Repository helpers `MarkOwnedAdded/MarkOwnedRemoved` for transcript segments
 - [ ] 3.3 `FileSystemAudioBlobStore` implementation with `AudioBlobStoreOptions` (Range/Required, ValidateOnStart)
-- [ ] 3.4 `StubAudioTranscriptionProvider` for dev/test environments (deterministic output)
+- [ ] 3.4 `StubAudioTranscriptionProvider` (dev/test only — named to make clear it must never be registered in production; deterministic output, fixed speaker labels)
 - [ ] 3.5 EF migration `AddCaptureAudioFields`
 - [ ] 3.6 DI registration of new services in `Program.cs` / composition root
 
@@ -35,7 +36,7 @@
 - [ ] 4.4 `PATCH /api/captures/{id}/speakers` endpoint
 - [ ] 4.5 DTOs for transcript segments, speaker-mapping request, and audio-upload response
 - [ ] 4.6 `AudioUploadOptions` (MaxSizeBytes, AllowedMimeTypes) with `ValidateDataAnnotations().ValidateOnStart()`
-- [ ] 4.7 Error-code constants (`audio.invalidFormat`, `audio.tooLarge`, `transcription.failed`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`)
+- [ ] 4.7 Error-code constants — canonical set, identical to the proposal and spec: `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.audioDiscarded`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`
 - [ ] 4.8 Integration tests for each endpoint (happy path + key failure modes)
 
 ## 5. Frontend


### PR DESCRIPTION
## Summary

Proposes the **capture-audio** capability (Tier 3). Extends the existing `Capture` aggregate with audio record/upload, provider-backed transcription with speaker diarization, speaker-to-Person identification, and a post-transcription audio-discard policy. Filesystem-backed blob store is the default; cloud storage is deferred.

**Spec**: [capture-audio](openspec/changes/capture-audio/specs/capture-audio/spec.md)

## Changes

- `proposal.md` — why, what, capabilities (new: `capture-audio`; no modified capabilities), impact, non-goals
- `design.md` — decisions (extend aggregate vs. new; owned `TranscriptSegments`; sync transcription for MVP; discard policy; storage abstraction; upload size/format caps; speaker PATCH shape; frontend recorder), risks, dependencies
- `specs/capture-audio/spec.md` — requirements: upload, transcribe (with retry), discard, get transcript, identify speakers, segment invariants, recorder UI, transcript viewer UI
- `tasks.md` — Domain / Application / Infrastructure / Web / Frontend / Validation task groups

## Test Plan

- [x] `openspec validate capture-audio --strict` passes
- [ ] `dotnet test src/MentalMetal.slnx` — not applicable for proposal-only change (no code)
- [ ] `ng test --watch=false` — not applicable for proposal-only change (no code)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specifications and implementation roadmap for a new audio capture feature, including support for audio upload, automatic transcription, and speaker identification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->