### PR TITLE
feat(capture-audio): implement Stage 2 (apply) of capture-audio spec

### DIFF
--- a/openspec/changes/capture-audio/tasks.md
+++ b/openspec/changes/capture-audio/tasks.md
@@ -1,55 +1,55 @@
 ## 1. Domain
 
-- [ ] 1.1 Extend `CaptureType` enum with `AudioRecording`
-- [ ] 1.2 Add audio fields to `Capture` aggregate: `AudioBlobRef`, `AudioMimeType`, `AudioDurationSeconds`, `AudioDiscardedAt`
-- [ ] 1.3 Add `TranscriptionStatus` enum (`NotApplicable`, `Pending`, `InProgress`, `Transcribed`, `Failed`) and property on `Capture`, independent of `ProcessingStatus`; existing (text) captures default to `NotApplicable`
-- [ ] 1.4 Add `TranscriptSegment` owned entity with `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, `LinkedPersonId`; enforce invariants in `Create`
-- [ ] 1.5 Add `TranscriptSegments` owned collection to `Capture` with `ReplaceTranscript(...)` and `IdentifySpeakers(mapping)` methods
-- [ ] 1.6 Add `Capture.CreateAudio(...)`, `Capture.AttachTranscript(...)`, `Capture.MarkTranscriptionFailed(reason)`, `Capture.MarkAudioDiscarded(now)` methods with explicit `TranscriptionStatus` transitions
-- [ ] 1.7 Add domain events: `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureTranscriptionFailed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`
-- [ ] 1.8 Unit tests covering audio-capture creation, transcript attachment, speaker mapping, `TranscriptionStatus` transitions (Pending→InProgress→Transcribed / Pending→InProgress→Failed), and segment invariants
+- [x] 1.1 Extend `CaptureType` enum with `AudioRecording`
+- [x] 1.2 Add audio fields to `Capture` aggregate: `AudioBlobRef`, `AudioMimeType`, `AudioDurationSeconds`, `AudioDiscardedAt`
+- [x] 1.3 Add `TranscriptionStatus` enum (`NotApplicable`, `Pending`, `InProgress`, `Transcribed`, `Failed`) and property on `Capture`, independent of `ProcessingStatus`; existing (text) captures default to `NotApplicable`
+- [x] 1.4 Add `TranscriptSegment` owned entity with `StartSeconds`, `EndSeconds`, `SpeakerLabel`, `Text`, `LinkedPersonId`; enforce invariants in `Create`
+- [x] 1.5 Add `TranscriptSegments` owned collection to `Capture` with `ReplaceTranscript(...)` and `IdentifySpeakers(mapping)` methods
+- [x] 1.6 Add `Capture.CreateAudio(...)`, `Capture.AttachTranscript(...)`, `Capture.MarkTranscriptionFailed(reason)`, `Capture.MarkAudioDiscarded(now)` methods with explicit `TranscriptionStatus` transitions
+- [x] 1.7 Add domain events: `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureTranscriptionFailed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`
+- [x] 1.8 Unit tests covering audio-capture creation, transcript attachment, speaker mapping, `TranscriptionStatus` transitions (Pending→InProgress→Transcribed / Pending→InProgress→Failed), and segment invariants
 
 ## 2. Application
 
-- [ ] 2.1 Define `IAudioBlobStore` interface in Application abstractions
-- [ ] 2.2 Define `IAudioTranscriptionProvider` interface returning text + segments
-- [ ] 2.3 Implement `UploadAudioCapture` handler (create capture with `TranscriptionStatus=Pending`, save blob, transition to `InProgress`, transcribe inline, split any provider segment whose `Text` exceeds 2000 chars into adjacent 2000-char segments with proportional `StartSeconds`/`EndSeconds`, on success mark `Transcribed` + discard blob, on failure mark `Failed` + raise `CaptureTranscriptionFailed` + retain blob, commit)
-- [ ] 2.4 Implement `TranscribeCapture` handler for retry flow (allow only when `TranscriptionStatus=Failed` and `AudioBlobRef` is present; reject retry on a capture whose audio was already discarded with error code `transcription.audioDiscarded`)
-- [ ] 2.5 Implement `GetCaptureTranscript` query handler
-- [ ] 2.6 Implement `UpdateCaptureSpeakers` handler (verify person existence, invoke aggregate method)
-- [ ] 2.7 Application-level unit tests for each handler (success, failure, not-found, invalid input)
+- [x] 2.1 Define `IAudioBlobStore` interface in Application abstractions
+- [x] 2.2 Define `IAudioTranscriptionProvider` interface returning text + segments
+- [x] 2.3 Implement `UploadAudioCapture` handler (create capture with `TranscriptionStatus=Pending`, save blob, transition to `InProgress`, transcribe inline, split any provider segment whose `Text` exceeds 2000 chars into adjacent 2000-char segments with proportional `StartSeconds`/`EndSeconds`, on success mark `Transcribed` + discard blob, on failure mark `Failed` + raise `CaptureTranscriptionFailed` + retain blob, commit)
+- [x] 2.4 Implement `TranscribeCapture` handler for retry flow (allow only when `TranscriptionStatus=Failed` and `AudioBlobRef` is present; reject retry on a capture whose audio was already discarded with error code `transcription.audioDiscarded`)
+- [x] 2.5 Implement `GetCaptureTranscript` query handler
+- [x] 2.6 Implement `UpdateCaptureSpeakers` handler (verify person existence, invoke aggregate method)
+- [x] 2.7 Application-level unit tests for each handler (success, failure, not-found, invalid input)
 
 ## 3. Infrastructure
 
-- [ ] 3.1 EF Core configuration for new `Capture` audio fields and owned `TranscriptSegments` collection (HasMaxLength 2000, 64)
-- [ ] 3.2 Repository helpers `MarkOwnedAdded/MarkOwnedRemoved` for transcript segments
-- [ ] 3.3 `FileSystemAudioBlobStore` implementation with `AudioBlobStoreOptions` (Range/Required, ValidateOnStart)
-- [ ] 3.4 `StubAudioTranscriptionProvider` (dev/test only — named to make clear it must never be registered in production; deterministic output, fixed speaker labels)
-- [ ] 3.5 EF migration `AddCaptureAudioFields`
-- [ ] 3.6 DI registration of new services in `Program.cs` / composition root
+- [x] 3.1 EF Core configuration for new `Capture` audio fields and owned `TranscriptSegments` collection (HasMaxLength 2000, 64)
+- [x] 3.2 Repository helpers `MarkOwnedAdded/MarkOwnedRemoved` for transcript segments
+- [x] 3.3 `FileSystemAudioBlobStore` implementation with `AudioBlobStoreOptions` (Range/Required, ValidateOnStart)
+- [x] 3.4 `StubAudioTranscriptionProvider` (dev/test only — named to make clear it must never be registered in production; deterministic output, fixed speaker labels)
+- [x] 3.5 EF migration `AddCaptureAudioFields`
+- [x] 3.6 DI registration of new services in `Program.cs` / composition root
 
 ## 4. Web API
 
-- [ ] 4.1 `POST /api/captures/audio` minimal-API endpoint with multipart handling and `RequestSizeLimit`
-- [ ] 4.2 `POST /api/captures/{id}/transcribe` endpoint
-- [ ] 4.3 `GET /api/captures/{id}/transcript` endpoint
-- [ ] 4.4 `PATCH /api/captures/{id}/speakers` endpoint
-- [ ] 4.5 DTOs for transcript segments, speaker-mapping request, and audio-upload response
-- [ ] 4.6 `AudioUploadOptions` (MaxSizeBytes, AllowedMimeTypes) with `ValidateDataAnnotations().ValidateOnStart()`
-- [ ] 4.7 Error-code constants — canonical set, identical to the proposal and spec: `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.audioDiscarded`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`
-- [ ] 4.8 Integration tests for each endpoint (happy path + key failure modes)
+- [x] 4.1 `POST /api/captures/audio` minimal-API endpoint with multipart handling and `RequestSizeLimit`
+- [x] 4.2 `POST /api/captures/{id}/transcribe` endpoint
+- [x] 4.3 `GET /api/captures/{id}/transcript` endpoint
+- [x] 4.4 `PATCH /api/captures/{id}/speakers` endpoint
+- [x] 4.5 DTOs for transcript segments, speaker-mapping request, and audio-upload response
+- [x] 4.6 `AudioUploadOptions` (MaxSizeBytes, AllowedMimeTypes) with `ValidateDataAnnotations().ValidateOnStart()`
+- [x] 4.7 Error-code constants — canonical set, identical to the proposal and spec: `audio.invalidFormat`, `audio.tooLarge`, `audio.uploadFailed`, `transcription.audioDiscarded`, `transcription.failed`, `transcription.providerUnavailable`, `capture.notFound`, `speaker.personNotFound`, `speaker.labelNotFound`
+- [x] 4.8 Integration tests for each endpoint (happy path + key failure modes)
 
 ## 5. Frontend
 
-- [ ] 5.1 `CaptureRecorderComponent` standalone component using MediaRecorder with signals
-- [ ] 5.2 `TranscriptViewerComponent` grouping segments by speaker with timecodes
-- [ ] 5.3 `SpeakerPickerComponent` with Person autocomplete
-- [ ] 5.4 API client methods for the four new endpoints
-- [ ] 5.5 Integration into capture detail view
-- [ ] 5.6 Component tests for recorder state machine and transcript grouping logic
+- [x] 5.1 `CaptureRecorderComponent` standalone component using MediaRecorder with signals
+- [x] 5.2 `TranscriptViewerComponent` grouping segments by speaker with timecodes
+- [x] 5.3 `SpeakerPickerComponent` with Person autocomplete
+- [x] 5.4 API client methods for the four new endpoints
+- [x] 5.5 Integration into capture detail view
+- [x] 5.6 Component tests for recorder state machine and transcript grouping logic
 
 ## 6. Validation
 
-- [ ] 6.1 `dotnet test src/MentalMetal.slnx` green
-- [ ] 6.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` green
-- [ ] 6.3 `openspec validate capture-audio --strict` passes
+- [x] 6.1 `dotnet test src/MentalMetal.slnx` green
+- [x] 6.2 `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` green
+- [x] 6.3 `openspec validate capture-audio --strict` passes

--- a/src/MentalMetal.Application/Captures/AudioCaptureErrorCodes.cs
+++ b/src/MentalMetal.Application/Captures/AudioCaptureErrorCodes.cs
@@ -1,0 +1,33 @@
+namespace MentalMetal.Application.Captures;
+
+/// <summary>
+/// Canonical error codes for the audio-capture feature. Mirrored exactly in
+/// proposal.md, tasks.md, and the capture-audio spec.
+/// </summary>
+public static class AudioCaptureErrorCodes
+{
+    public const string AudioInvalidFormat = "audio.invalidFormat";
+    public const string AudioTooLarge = "audio.tooLarge";
+    public const string AudioUploadFailed = "audio.uploadFailed";
+    public const string TranscriptionAudioDiscarded = "transcription.audioDiscarded";
+    public const string TranscriptionFailed = "transcription.failed";
+    public const string TranscriptionProviderUnavailable = "transcription.providerUnavailable";
+    public const string CaptureNotFound = "capture.notFound";
+    public const string SpeakerPersonNotFound = "speaker.personNotFound";
+    public const string SpeakerLabelNotFound = "speaker.labelNotFound";
+}
+
+/// <summary>
+/// Thrown by audio-capture handlers to surface a specific error code to the
+/// API layer. The endpoint catches this and maps it to an HTTP response.
+/// </summary>
+public sealed class AudioCaptureException : Exception
+{
+    public string ErrorCode { get; }
+
+    public AudioCaptureException(string errorCode, string? message = null)
+        : base(message ?? errorCode)
+    {
+        ErrorCode = errorCode;
+    }
+}

--- a/src/MentalMetal.Application/Captures/GetCaptureTranscript.cs
+++ b/src/MentalMetal.Application/Captures/GetCaptureTranscript.cs
@@ -22,7 +22,7 @@ public sealed class GetCaptureTranscriptHandler(
     public async Task<GetCaptureTranscriptResponse?> HandleAsync(
         Guid captureId, CancellationToken cancellationToken)
     {
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        var capture = await captureRepository.GetByIdWithTranscriptAsync(captureId, cancellationToken);
         if (capture is null || capture.UserId != currentUserService.UserId)
             return null;
 

--- a/src/MentalMetal.Application/Captures/GetCaptureTranscript.cs
+++ b/src/MentalMetal.Application/Captures/GetCaptureTranscript.cs
@@ -1,0 +1,37 @@
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Captures;
+
+public sealed record TranscriptSegmentResponse(
+    double StartSeconds,
+    double EndSeconds,
+    string SpeakerLabel,
+    string Text,
+    Guid? LinkedPersonId);
+
+public sealed record GetCaptureTranscriptResponse(
+    Guid CaptureId,
+    TranscriptionStatus TranscriptionStatus,
+    IReadOnlyList<TranscriptSegmentResponse> Segments);
+
+public sealed class GetCaptureTranscriptHandler(
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService)
+{
+    public async Task<GetCaptureTranscriptResponse?> HandleAsync(
+        Guid captureId, CancellationToken cancellationToken)
+    {
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        if (capture is null || capture.UserId != currentUserService.UserId)
+            return null;
+
+        var segments = capture.TranscriptSegments
+            .OrderBy(s => s.StartSeconds)
+            .Select(s => new TranscriptSegmentResponse(
+                s.StartSeconds, s.EndSeconds, s.SpeakerLabel, s.Text, s.LinkedPersonId))
+            .ToList();
+
+        return new GetCaptureTranscriptResponse(capture.Id, capture.TranscriptionStatus, segments);
+    }
+}

--- a/src/MentalMetal.Application/Captures/TranscribeCapture.cs
+++ b/src/MentalMetal.Application/Captures/TranscribeCapture.cs
@@ -18,7 +18,7 @@ public sealed class TranscribeCaptureHandler(
     public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
     {
         var userId = currentUserService.UserId;
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        var capture = await captureRepository.GetByIdWithTranscriptAsync(captureId, cancellationToken);
         if (capture is null || capture.UserId != userId)
             throw new AudioCaptureException(AudioCaptureErrorCodes.CaptureNotFound);
 
@@ -64,16 +64,19 @@ public sealed class TranscribeCaptureHandler(
             throw new AudioCaptureException(code, ex.Message);
         }
 
+        var deleted = false;
         try
         {
             await blobStore.DeleteAsync(capture.AudioBlobRef!, cancellationToken);
+            deleted = true;
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to delete audio blob after successful retry; capture {CaptureId} continues", capture.Id);
+            logger.LogWarning(ex, "Failed to delete audio blob after successful retry; capture {CaptureId} continues with blob retained", capture.Id);
         }
 
-        capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
+        if (deleted)
+            capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return CaptureResponse.From(capture);

--- a/src/MentalMetal.Application/Captures/TranscribeCapture.cs
+++ b/src/MentalMetal.Application/Captures/TranscribeCapture.cs
@@ -1,0 +1,81 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace MentalMetal.Application.Captures;
+
+public sealed class TranscribeCaptureHandler(
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
+    IAudioBlobStore blobStore,
+    IAudioTranscriptionProvider transcriptionProvider,
+    IUnitOfWork unitOfWork,
+    TimeProvider timeProvider,
+    ILogger<TranscribeCaptureHandler> logger)
+{
+    public async Task<CaptureResponse> HandleAsync(Guid captureId, CancellationToken cancellationToken)
+    {
+        var userId = currentUserService.UserId;
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        if (capture is null || capture.UserId != userId)
+            throw new AudioCaptureException(AudioCaptureErrorCodes.CaptureNotFound);
+
+        if (capture.CaptureType != CaptureType.AudioRecording)
+            throw new AudioCaptureException(AudioCaptureErrorCodes.CaptureNotFound);
+
+        if (capture.AudioDiscardedAt is not null || string.IsNullOrWhiteSpace(capture.AudioBlobRef))
+            throw new AudioCaptureException(AudioCaptureErrorCodes.TranscriptionAudioDiscarded);
+
+        if (capture.TranscriptionStatus != TranscriptionStatus.Failed)
+            throw new AudioCaptureException(
+                AudioCaptureErrorCodes.TranscriptionFailed,
+                $"Cannot retry transcription in status '{capture.TranscriptionStatus}'.");
+
+        capture.RequeueTranscription(timeProvider.GetUtcNow());
+        capture.BeginTranscription(timeProvider.GetUtcNow());
+
+        try
+        {
+            await using var stream = await blobStore.OpenReadAsync(capture.AudioBlobRef!, cancellationToken);
+            var transcription = await transcriptionProvider.TranscribeAsync(
+                new AudioTranscriptionRequest(stream, capture.AudioMimeType ?? "application/octet-stream", capture.AudioDurationSeconds ?? 0),
+                cancellationToken);
+
+            var segments = TranscriptSegmentSplitter.Split(transcription.Segments);
+            capture.AttachTranscript(transcription.FullText, segments, timeProvider.GetUtcNow());
+            foreach (var s in segments)
+                captureRepository.MarkOwnedAdded(s);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Retry transcription failed for capture {CaptureId}", capture.Id);
+            capture.MarkTranscriptionFailed(ex.Message, timeProvider.GetUtcNow());
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+
+            var code = ex is AudioTranscriptionUnavailableException
+                ? AudioCaptureErrorCodes.TranscriptionProviderUnavailable
+                : AudioCaptureErrorCodes.TranscriptionFailed;
+            throw new AudioCaptureException(code, ex.Message);
+        }
+
+        try
+        {
+            await blobStore.DeleteAsync(capture.AudioBlobRef!, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete audio blob after successful retry; capture {CaptureId} continues", capture.Id);
+        }
+
+        capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CaptureResponse.From(capture);
+    }
+}

--- a/src/MentalMetal.Application/Captures/TranscriptSegmentSplitter.cs
+++ b/src/MentalMetal.Application/Captures/TranscriptSegmentSplitter.cs
@@ -1,0 +1,67 @@
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Captures;
+
+namespace MentalMetal.Application.Captures;
+
+/// <summary>
+/// Splits provider-returned segments whose <c>Text</c> exceeds
+/// <see cref="TranscriptSegment.MaxTextLength"/> into adjacent domain segments
+/// with proportional time ranges, so no content is dropped and the domain
+/// invariants hold. See capture-audio design D3.1.
+/// </summary>
+public static class TranscriptSegmentSplitter
+{
+    public static IReadOnlyList<TranscriptSegment> Split(
+        IEnumerable<AudioTranscriptSegmentDto> providerSegments)
+    {
+        ArgumentNullException.ThrowIfNull(providerSegments);
+
+        var result = new List<TranscriptSegment>();
+        foreach (var dto in providerSegments)
+        {
+            if (dto.Text.Length <= TranscriptSegment.MaxTextLength)
+            {
+                result.Add(TranscriptSegment.Create(
+                    dto.StartSeconds, dto.EndSeconds, dto.SpeakerLabel, dto.Text));
+                continue;
+            }
+
+            var chunks = ChunkByMaxLength(dto.Text, TranscriptSegment.MaxTextLength);
+            var totalChars = dto.Text.Length;
+            var duration = dto.EndSeconds - dto.StartSeconds;
+            var consumedChars = 0;
+            var cursor = dto.StartSeconds;
+
+            for (var i = 0; i < chunks.Count; i++)
+            {
+                var chunk = chunks[i];
+                consumedChars += chunk.Length;
+                double segmentEnd;
+                if (i == chunks.Count - 1)
+                {
+                    segmentEnd = dto.EndSeconds;
+                }
+                else
+                {
+                    segmentEnd = dto.StartSeconds + (duration * consumedChars / totalChars);
+                    if (segmentEnd < cursor) segmentEnd = cursor;
+                }
+
+                result.Add(TranscriptSegment.Create(cursor, segmentEnd, dto.SpeakerLabel, chunk));
+                cursor = segmentEnd;
+            }
+        }
+        return result;
+    }
+
+    private static List<string> ChunkByMaxLength(string text, int max)
+    {
+        var chunks = new List<string>(capacity: (text.Length / max) + 1);
+        for (var i = 0; i < text.Length; i += max)
+        {
+            var len = Math.Min(max, text.Length - i);
+            chunks.Add(text.Substring(i, len));
+        }
+        return chunks;
+    }
+}

--- a/src/MentalMetal.Application/Captures/UpdateCaptureSpeakers.cs
+++ b/src/MentalMetal.Application/Captures/UpdateCaptureSpeakers.cs
@@ -21,20 +21,32 @@ public sealed class UpdateCaptureSpeakersHandler(
         ArgumentNullException.ThrowIfNull(request);
 
         var userId = currentUserService.UserId;
-        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        var capture = await captureRepository.GetByIdWithTranscriptAsync(captureId, cancellationToken);
         if (capture is null || capture.UserId != userId)
             throw new AudioCaptureException(AudioCaptureErrorCodes.CaptureNotFound);
 
-        if (request.Mappings.Count == 0)
+        // Null or empty mapping set is a no-op (per spec "Empty mapping set is a no-op").
+        var incoming = request.Mappings ?? Array.Empty<SpeakerMapping>();
+        if (incoming.Count == 0)
             return CaptureResponse.From(capture);
 
+        // Reject duplicate speaker labels — the domain mapping is label→person and duplicates
+        // in the request would silently last-write-wins.
+        var duplicateLabel = incoming
+            .GroupBy(m => m.SpeakerLabel, StringComparer.Ordinal)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (duplicateLabel is not null)
+            throw new AudioCaptureException(
+                AudioCaptureErrorCodes.SpeakerLabelNotFound,
+                $"Duplicate mapping for speaker label: {duplicateLabel.Key}");
+
         // Verify every PersonId exists for this user.
-        var personIds = request.Mappings.Select(m => m.PersonId).Distinct().ToList();
+        var personIds = incoming.Select(m => m.PersonId).Distinct().ToList();
         var people = await personRepository.GetByIdsAsync(userId, personIds, cancellationToken);
         if (people.Count != personIds.Count)
             throw new AudioCaptureException(AudioCaptureErrorCodes.SpeakerPersonNotFound);
 
-        var mapping = request.Mappings.ToDictionary(m => m.SpeakerLabel, m => m.PersonId, StringComparer.Ordinal);
+        var mapping = incoming.ToDictionary(m => m.SpeakerLabel, m => m.PersonId, StringComparer.Ordinal);
 
         try
         {

--- a/src/MentalMetal.Application/Captures/UpdateCaptureSpeakers.cs
+++ b/src/MentalMetal.Application/Captures/UpdateCaptureSpeakers.cs
@@ -1,0 +1,51 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.People;
+using MentalMetal.Domain.Users;
+
+namespace MentalMetal.Application.Captures;
+
+public sealed record SpeakerMapping(string SpeakerLabel, Guid PersonId);
+public sealed record UpdateCaptureSpeakersRequest(IReadOnlyList<SpeakerMapping> Mappings);
+
+public sealed class UpdateCaptureSpeakersHandler(
+    ICaptureRepository captureRepository,
+    IPersonRepository personRepository,
+    ICurrentUserService currentUserService,
+    IUnitOfWork unitOfWork,
+    TimeProvider timeProvider)
+{
+    public async Task<CaptureResponse> HandleAsync(
+        Guid captureId, UpdateCaptureSpeakersRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var userId = currentUserService.UserId;
+        var capture = await captureRepository.GetByIdAsync(captureId, cancellationToken);
+        if (capture is null || capture.UserId != userId)
+            throw new AudioCaptureException(AudioCaptureErrorCodes.CaptureNotFound);
+
+        if (request.Mappings.Count == 0)
+            return CaptureResponse.From(capture);
+
+        // Verify every PersonId exists for this user.
+        var personIds = request.Mappings.Select(m => m.PersonId).Distinct().ToList();
+        var people = await personRepository.GetByIdsAsync(userId, personIds, cancellationToken);
+        if (people.Count != personIds.Count)
+            throw new AudioCaptureException(AudioCaptureErrorCodes.SpeakerPersonNotFound);
+
+        var mapping = request.Mappings.ToDictionary(m => m.SpeakerLabel, m => m.PersonId, StringComparer.Ordinal);
+
+        try
+        {
+            capture.IdentifySpeakers(mapping, timeProvider.GetUtcNow());
+        }
+        catch (KeyNotFoundException ex)
+        {
+            throw new AudioCaptureException(AudioCaptureErrorCodes.SpeakerLabelNotFound, ex.Message);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CaptureResponse.From(capture);
+    }
+}

--- a/src/MentalMetal.Application/Captures/UploadAudioCapture.cs
+++ b/src/MentalMetal.Application/Captures/UploadAudioCapture.cs
@@ -1,0 +1,106 @@
+using MentalMetal.Application.Common;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Users;
+using Microsoft.Extensions.Logging;
+
+namespace MentalMetal.Application.Captures;
+
+public sealed record UploadAudioCaptureRequest(
+    Stream Audio,
+    string MimeType,
+    double DurationSeconds,
+    string? Title = null,
+    string? Source = null);
+
+public sealed class UploadAudioCaptureHandler(
+    ICaptureRepository captureRepository,
+    ICurrentUserService currentUserService,
+    IAudioBlobStore blobStore,
+    IAudioTranscriptionProvider transcriptionProvider,
+    IUnitOfWork unitOfWork,
+    TimeProvider timeProvider,
+    ILogger<UploadAudioCaptureHandler> logger)
+{
+    public async Task<CaptureResponse> HandleAsync(
+        UploadAudioCaptureRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Audio);
+
+        var userId = currentUserService.UserId;
+        var now = timeProvider.GetUtcNow();
+
+        // 1. Persist the audio blob FIRST so we have a reference for the aggregate.
+        string blobRef;
+        try
+        {
+            blobRef = await blobStore.SaveAsync(userId, request.Audio, request.MimeType, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to persist audio blob for user {UserId}", userId);
+            throw new AudioCaptureException(AudioCaptureErrorCodes.AudioUploadFailed, ex.Message);
+        }
+
+        var capture = Capture.CreateAudio(
+            userId, blobRef, request.MimeType, request.DurationSeconds, now, request.Source, request.Title);
+        await captureRepository.AddAsync(capture, cancellationToken);
+
+        // 2. Move to InProgress and transcribe synchronously.
+        capture.BeginTranscription(timeProvider.GetUtcNow());
+
+        try
+        {
+            await using var blobStream = await blobStore.OpenReadAsync(blobRef, cancellationToken);
+            var transcription = await transcriptionProvider.TranscribeAsync(
+                new AudioTranscriptionRequest(blobStream, request.MimeType, request.DurationSeconds),
+                cancellationToken);
+
+            var segments = TranscriptSegmentSplitter.Split(transcription.Segments);
+            capture.AttachTranscript(transcription.FullText, segments, timeProvider.GetUtcNow());
+
+            foreach (var segment in segments)
+                captureRepository.MarkOwnedAdded(segment);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Transcription failed for capture {CaptureId}", capture.Id);
+            capture.MarkTranscriptionFailed(ex.Message, timeProvider.GetUtcNow());
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+
+            var code = ex is AudioTranscriptionUnavailableException
+                ? AudioCaptureErrorCodes.TranscriptionProviderUnavailable
+                : AudioCaptureErrorCodes.TranscriptionFailed;
+            throw new AudioCaptureException(code, ex.Message);
+        }
+
+        // 3. Discard the blob after successful transcription (infra concern, not aggregate).
+        try
+        {
+            await blobStore.DeleteAsync(blobRef, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete audio blob {BlobRef} after transcription; capture {CaptureId} continues", blobRef, capture.Id);
+            // Swallow — orphan cleanup is future work.
+        }
+
+        capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return CaptureResponse.From(capture);
+    }
+}
+
+/// <summary>
+/// Signals that the transcription provider was unreachable (vs. returned an
+/// error for a specific file). Handlers translate this into the
+/// <c>transcription.providerUnavailable</c> error code.
+/// </summary>
+public sealed class AudioTranscriptionUnavailableException(string? message = null, Exception? inner = null)
+    : Exception(message ?? "Audio transcription provider unavailable.", inner);

--- a/src/MentalMetal.Application/Captures/UploadAudioCapture.cs
+++ b/src/MentalMetal.Application/Captures/UploadAudioCapture.cs
@@ -80,17 +80,22 @@ public sealed class UploadAudioCaptureHandler(
         }
 
         // 3. Discard the blob after successful transcription (infra concern, not aggregate).
+        // Only record the discard on the aggregate when the delete actually succeeded — if the
+        // blob is still on disk we must leave AudioBlobRef intact so orphan cleanup / retry can
+        // find it.
+        var deleted = false;
         try
         {
             await blobStore.DeleteAsync(blobRef, cancellationToken);
+            deleted = true;
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to delete audio blob {BlobRef} after transcription; capture {CaptureId} continues", blobRef, capture.Id);
-            // Swallow — orphan cleanup is future work.
+            logger.LogWarning(ex, "Failed to delete audio blob {BlobRef} after transcription; capture {CaptureId} continues with blob retained", blobRef, capture.Id);
         }
 
-        capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
+        if (deleted)
+            capture.MarkAudioDiscarded(timeProvider.GetUtcNow());
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return CaptureResponse.From(capture);

--- a/src/MentalMetal.Application/Common/Ai/IAudioTranscriptionProvider.cs
+++ b/src/MentalMetal.Application/Common/Ai/IAudioTranscriptionProvider.cs
@@ -1,0 +1,30 @@
+namespace MentalMetal.Application.Common.Ai;
+
+/// <summary>
+/// Transcribes an audio stream to text plus speaker-labeled segments.
+/// Implementations are registered behind the existing AI-provider abstraction
+/// pattern. Failure SHOULD be signaled via exceptions — handlers translate
+/// those into the <c>transcription.failed</c> / <c>transcription.providerUnavailable</c>
+/// error codes.
+/// </summary>
+public interface IAudioTranscriptionProvider
+{
+    Task<AudioTranscriptionResult> TranscribeAsync(
+        AudioTranscriptionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed record AudioTranscriptionRequest(
+    Stream AudioStream,
+    string MimeType,
+    double DurationSeconds);
+
+public sealed record AudioTranscriptionResult(
+    string FullText,
+    IReadOnlyList<AudioTranscriptSegmentDto> Segments);
+
+public sealed record AudioTranscriptSegmentDto(
+    double StartSeconds,
+    double EndSeconds,
+    string SpeakerLabel,
+    string Text);

--- a/src/MentalMetal.Application/Common/IAudioBlobStore.cs
+++ b/src/MentalMetal.Application/Common/IAudioBlobStore.cs
@@ -1,0 +1,24 @@
+namespace MentalMetal.Application.Common;
+
+/// <summary>
+/// Abstraction over audio-blob persistence. Default implementation is the
+/// filesystem store in Infrastructure; cloud implementations are future work.
+/// </summary>
+public interface IAudioBlobStore
+{
+    /// <summary>
+    /// Persists the audio bytes and returns an opaque reference that can be
+    /// fed back to <see cref="OpenReadAsync"/> / <see cref="DeleteAsync"/>.
+    /// </summary>
+    Task<string> SaveAsync(Guid userId, Stream audio, string mimeType, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Opens the blob for reading. Callers must dispose the returned stream.
+    /// </summary>
+    Task<Stream> OpenReadAsync(string blobRef, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the blob. Silently returns if the blob does not exist.
+    /// </summary>
+    Task DeleteAsync(string blobRef, CancellationToken cancellationToken);
+}

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -9,6 +9,7 @@ public sealed class Capture : AggregateRoot, IUserScoped
     private readonly List<Guid> _spawnedCommitmentIds = [];
     private readonly List<Guid> _spawnedDelegationIds = [];
     private readonly List<Guid> _spawnedObservationIds = [];
+    private readonly List<TranscriptSegment> _transcriptSegments = [];
 
     public Guid UserId { get; private set; }
     public string RawContent { get; private set; } = null!;
@@ -17,6 +18,15 @@ public sealed class Capture : AggregateRoot, IUserScoped
     public AiExtraction? AiExtraction { get; private set; }
     public ExtractionStatus ExtractionStatus { get; private set; }
     public string? FailureReason { get; private set; }
+
+    // --- Audio / transcription fields (null / NotApplicable for non-audio captures) ---
+    public string? AudioBlobRef { get; private set; }
+    public string? AudioMimeType { get; private set; }
+    public double? AudioDurationSeconds { get; private set; }
+    public DateTimeOffset? AudioDiscardedAt { get; private set; }
+    public TranscriptionStatus TranscriptionStatus { get; private set; } = TranscriptionStatus.NotApplicable;
+    public string? TranscriptionFailureReason { get; private set; }
+    public IReadOnlyList<TranscriptSegment> TranscriptSegments => _transcriptSegments;
     public IReadOnlyList<Guid> LinkedPersonIds => _linkedPersonIds;
     public IReadOnlyList<Guid> LinkedInitiativeIds => _linkedInitiativeIds;
     public IReadOnlyList<Guid> SpawnedCommitmentIds => _spawnedCommitmentIds;
@@ -291,5 +301,184 @@ public sealed class Capture : AggregateRoot, IUserScoped
 
         _spawnedObservationIds.Add(observationId);
         UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    // -----------------------------------------------------------------------
+    // Audio capture / transcription lifecycle
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates an audio capture with a placeholder <see cref="RawContent"/>
+    /// (filled in later by <see cref="AttachTranscript"/>). The capture starts
+    /// with <see cref="ProcessingStatus"/>.<c>Raw</c> and
+    /// <see cref="TranscriptionStatus"/>.<c>Pending</c>; those lifecycles are
+    /// independent — <c>ProcessingStatus</c> governs AI extraction and stays
+    /// at <c>Raw</c> until the extraction pipeline runs.
+    /// </summary>
+    public static Capture CreateAudio(
+        Guid userId,
+        string audioBlobRef,
+        string audioMimeType,
+        double audioDurationSeconds,
+        DateTimeOffset now,
+        string? source = null,
+        string? title = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(audioBlobRef, nameof(audioBlobRef));
+        ArgumentException.ThrowIfNullOrWhiteSpace(audioMimeType, nameof(audioMimeType));
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId is required.", nameof(userId));
+        if (audioDurationSeconds < 0)
+            throw new ArgumentOutOfRangeException(nameof(audioDurationSeconds), "Duration must be non-negative.");
+
+        var capture = new Capture
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            RawContent = string.Empty, // populated after transcription
+            CaptureType = CaptureType.AudioRecording,
+            ProcessingStatus = ProcessingStatus.Raw,
+            TranscriptionStatus = TranscriptionStatus.Pending,
+            AudioBlobRef = audioBlobRef,
+            AudioMimeType = audioMimeType,
+            AudioDurationSeconds = audioDurationSeconds,
+            Title = title?.Trim(),
+            Source = source?.Trim(),
+            CapturedAt = now,
+            UpdatedAt = now
+        };
+
+        capture.RaiseDomainEvent(new CaptureCreated(capture.Id, userId, CaptureType.AudioRecording));
+        capture.RaiseDomainEvent(new CaptureAudioUploaded(capture.Id, audioBlobRef, audioMimeType, audioDurationSeconds));
+
+        return capture;
+    }
+
+    /// <summary>
+    /// Marks transcription as in-flight. Only valid from <c>Pending</c>.
+    /// </summary>
+    public void BeginTranscription(DateTimeOffset now)
+    {
+        if (TranscriptionStatus != TranscriptionStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot begin transcription from '{TranscriptionStatus}'. Must be 'Pending'.");
+
+        TranscriptionStatus = TranscriptionStatus.InProgress;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Attaches transcript segments + full text to the capture after a successful
+    /// transcription. Only valid from <c>InProgress</c>. Transitions
+    /// <see cref="TranscriptionStatus"/> to <c>Transcribed</c> and raises
+    /// <see cref="CaptureTranscribed"/>. Does NOT touch <see cref="ProcessingStatus"/> —
+    /// extraction picks the capture up separately because <c>ProcessingStatus</c>
+    /// is still <c>Raw</c>.
+    /// </summary>
+    public void AttachTranscript(
+        string fullTranscriptText,
+        IEnumerable<TranscriptSegment> segments,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(fullTranscriptText, nameof(fullTranscriptText));
+        ArgumentNullException.ThrowIfNull(segments, nameof(segments));
+
+        if (TranscriptionStatus != TranscriptionStatus.InProgress)
+            throw new InvalidOperationException(
+                $"Cannot attach transcript from '{TranscriptionStatus}'. Must be 'InProgress'.");
+
+        _transcriptSegments.Clear();
+        foreach (var segment in segments)
+            _transcriptSegments.Add(segment);
+
+        RawContent = fullTranscriptText;
+        TranscriptionStatus = TranscriptionStatus.Transcribed;
+        TranscriptionFailureReason = null;
+        UpdatedAt = now;
+
+        RaiseDomainEvent(new CaptureTranscribed(Id, _transcriptSegments.Count));
+    }
+
+    /// <summary>
+    /// Marks transcription as failed. Valid from <c>InProgress</c> (initial upload
+    /// failure) or <c>Failed</c> (retry-of-retry, idempotent). Does not touch
+    /// <see cref="ProcessingStatus"/> — extraction's lifecycle is independent.
+    /// </summary>
+    public void MarkTranscriptionFailed(string? reason, DateTimeOffset now)
+    {
+        if (TranscriptionStatus is not (TranscriptionStatus.InProgress or TranscriptionStatus.Failed))
+            throw new InvalidOperationException(
+                $"Cannot mark transcription failed from '{TranscriptionStatus}'. Must be 'InProgress' or 'Failed'.");
+
+        TranscriptionStatus = TranscriptionStatus.Failed;
+        TranscriptionFailureReason = reason;
+        UpdatedAt = now;
+
+        RaiseDomainEvent(new CaptureTranscriptionFailed(Id, reason));
+    }
+
+    /// <summary>
+    /// Re-queues a failed transcription for retry. Requires
+    /// <see cref="AudioBlobRef"/> to still be present.
+    /// </summary>
+    public void RequeueTranscription(DateTimeOffset now)
+    {
+        if (TranscriptionStatus != TranscriptionStatus.Failed)
+            throw new InvalidOperationException(
+                $"Cannot requeue transcription from '{TranscriptionStatus}'. Must be 'Failed'.");
+        if (string.IsNullOrWhiteSpace(AudioBlobRef))
+            throw new InvalidOperationException(
+                "Cannot retry transcription: audio blob has been discarded.");
+
+        TranscriptionStatus = TranscriptionStatus.Pending;
+        TranscriptionFailureReason = null;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Clears <see cref="AudioBlobRef"/> and records the discard time. Call this
+    /// once the blob has been deleted from storage.
+    /// </summary>
+    public void MarkAudioDiscarded(DateTimeOffset now)
+    {
+        if (AudioDiscardedAt is not null)
+            return; // idempotent
+
+        AudioBlobRef = null;
+        AudioDiscardedAt = now;
+        UpdatedAt = now;
+
+        RaiseDomainEvent(new CaptureAudioDiscarded(Id));
+    }
+
+    /// <summary>
+    /// Bulk-maps speaker labels to PersonIds. Unmapped labels are left untouched.
+    /// Labels not present in any segment cause a <see cref="KeyNotFoundException"/>
+    /// so the caller can surface <c>speaker.labelNotFound</c>.
+    /// </summary>
+    public void IdentifySpeakers(IReadOnlyDictionary<string, Guid> mapping, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(mapping, nameof(mapping));
+
+        if (mapping.Count == 0)
+            return;
+
+        var presentLabels = _transcriptSegments.Select(s => s.SpeakerLabel).ToHashSet(StringComparer.Ordinal);
+        foreach (var label in mapping.Keys)
+        {
+            if (!presentLabels.Contains(label))
+                throw new KeyNotFoundException($"Speaker label not found on transcript: {label}");
+        }
+
+        foreach (var segment in _transcriptSegments)
+        {
+            if (mapping.TryGetValue(segment.SpeakerLabel, out var personId))
+                segment.LinkToPerson(personId);
+        }
+
+        UpdatedAt = now;
+
+        foreach (var kvp in mapping)
+            RaiseDomainEvent(new CaptureSpeakerIdentified(Id, kvp.Key, kvp.Value));
     }
 }

--- a/src/MentalMetal.Domain/Captures/CaptureEvents.cs
+++ b/src/MentalMetal.Domain/Captures/CaptureEvents.cs
@@ -66,3 +66,32 @@ public sealed record CaptureQuickDiscarded(Guid CaptureId) : IDomainEvent
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record CaptureAudioUploaded(
+    Guid CaptureId,
+    string AudioBlobRef,
+    string AudioMimeType,
+    double AudioDurationSeconds) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CaptureTranscribed(Guid CaptureId, int SegmentCount) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CaptureTranscriptionFailed(Guid CaptureId, string? Reason) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CaptureAudioDiscarded(Guid CaptureId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record CaptureSpeakerIdentified(Guid CaptureId, string SpeakerLabel, Guid PersonId) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Domain/Captures/CaptureType.cs
+++ b/src/MentalMetal.Domain/Captures/CaptureType.cs
@@ -4,5 +4,6 @@ public enum CaptureType
 {
     QuickNote,
     Transcript,
-    MeetingNotes
+    MeetingNotes,
+    AudioRecording
 }

--- a/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
+++ b/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
@@ -24,4 +24,12 @@ public interface ICaptureRepository
     Task<IReadOnlyList<Capture>> GetCloseOutQueueAsync(Guid userId, CancellationToken cancellationToken);
 
     Task AddAsync(Capture capture, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// EF Core's snapshot change detection for field-backed owned collections does not always
+    /// recognise newly-appended items as Added, so handlers must call this helper immediately
+    /// after mutating the collection on a tracked aggregate.
+    /// </summary>
+    void MarkOwnedAdded(object ownedEntity);
+    void MarkOwnedRemoved(object ownedEntity);
 }

--- a/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
+++ b/src/MentalMetal.Domain/Captures/ICaptureRepository.cs
@@ -3,6 +3,14 @@ namespace MentalMetal.Domain.Captures;
 public interface ICaptureRepository
 {
     Task<Capture?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Same as <see cref="GetByIdAsync"/> but eagerly loads the owned
+    /// <c>TranscriptSegments</c> collection. Use only from audio-capture paths
+    /// — non-audio callers should use <see cref="GetByIdAsync"/> to avoid
+    /// loading potentially large transcript data on every fetch.
+    /// </summary>
+    Task<Capture?> GetByIdWithTranscriptAsync(Guid id, CancellationToken cancellationToken);
     /// <summary>
     /// Lists captures for the user. <paramref name="includeTriaged"/> defaults to <c>false</c>,
     /// so triaged captures (confirmed, discarded, or quick-discarded) are excluded unless the

--- a/src/MentalMetal.Domain/Captures/TranscriptSegment.cs
+++ b/src/MentalMetal.Domain/Captures/TranscriptSegment.cs
@@ -1,0 +1,60 @@
+namespace MentalMetal.Domain.Captures;
+
+/// <summary>
+/// A single diarized segment of a transcribed audio capture.
+/// Owned by <see cref="Capture"/> — never referenced independently.
+/// </summary>
+public sealed class TranscriptSegment
+{
+    public const int MaxTextLength = 2000;
+    public const int MaxSpeakerLabelLength = 64;
+
+    public Guid Id { get; private set; }
+    public double StartSeconds { get; private set; }
+    public double EndSeconds { get; private set; }
+    public string SpeakerLabel { get; private set; } = null!;
+    public string Text { get; private set; } = null!;
+    public Guid? LinkedPersonId { get; private set; }
+
+    private TranscriptSegment() { } // EF Core
+
+    public static TranscriptSegment Create(
+        double startSeconds,
+        double endSeconds,
+        string speakerLabel,
+        string text,
+        Guid? linkedPersonId = null)
+    {
+        if (startSeconds < 0)
+            throw new ArgumentOutOfRangeException(nameof(startSeconds), "StartSeconds must be non-negative.");
+        if (endSeconds < startSeconds)
+            throw new ArgumentException("EndSeconds must be greater than or equal to StartSeconds.", nameof(endSeconds));
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(speakerLabel, nameof(speakerLabel));
+        if (speakerLabel.Length > MaxSpeakerLabelLength)
+            throw new ArgumentException(
+                $"SpeakerLabel must be {MaxSpeakerLabelLength} characters or fewer.", nameof(speakerLabel));
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(text, nameof(text));
+        if (text.Length > MaxTextLength)
+            throw new ArgumentException(
+                $"Text must be {MaxTextLength} characters or fewer.", nameof(text));
+
+        return new TranscriptSegment
+        {
+            Id = Guid.NewGuid(),
+            StartSeconds = startSeconds,
+            EndSeconds = endSeconds,
+            SpeakerLabel = speakerLabel.Trim(),
+            Text = text,
+            LinkedPersonId = linkedPersonId
+        };
+    }
+
+    internal void LinkToPerson(Guid personId)
+    {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+        LinkedPersonId = personId;
+    }
+}

--- a/src/MentalMetal.Domain/Captures/TranscriptionStatus.cs
+++ b/src/MentalMetal.Domain/Captures/TranscriptionStatus.cs
@@ -1,0 +1,15 @@
+namespace MentalMetal.Domain.Captures;
+
+/// <summary>
+/// Lifecycle of audio-transcription for a <see cref="Capture"/>.
+/// Independent of <see cref="ProcessingStatus"/> (which governs AI extraction).
+/// Non-audio captures stay on <see cref="NotApplicable"/> for their entire lifetime.
+/// </summary>
+public enum TranscriptionStatus
+{
+    NotApplicable,
+    Pending,
+    InProgress,
+    Transcribed,
+    Failed
+}

--- a/src/MentalMetal.Infrastructure/Ai/StubAudioTranscriptionProvider.cs
+++ b/src/MentalMetal.Infrastructure/Ai/StubAudioTranscriptionProvider.cs
@@ -1,0 +1,31 @@
+using MentalMetal.Application.Common.Ai;
+
+namespace MentalMetal.Infrastructure.Ai;
+
+/// <summary>
+/// Dev/test-only stub for <see cref="IAudioTranscriptionProvider"/>.
+/// Produces deterministic fake output (two speakers, fixed boilerplate text).
+/// MUST NEVER be registered in production — the DI wiring in
+/// <c>DependencyInjection</c> only adds this in development environments.
+/// </summary>
+public sealed class StubAudioTranscriptionProvider : IAudioTranscriptionProvider
+{
+    public Task<AudioTranscriptionResult> TranscribeAsync(
+        AudioTranscriptionRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var duration = Math.Max(request.DurationSeconds, 1.0);
+        var mid = Math.Round(duration / 2.0, 2);
+
+        var segments = new List<AudioTranscriptSegmentDto>
+        {
+            new(0.0, mid, "Speaker A", "Stub transcript segment from Speaker A."),
+            new(mid, duration, "Speaker B", "Stub transcript segment from Speaker B."),
+        };
+
+        var fullText = string.Join("\n", segments.Select(s => $"[{s.SpeakerLabel}] {s.Text}"));
+
+        return Task.FromResult(new AudioTranscriptionResult(fullText, segments));
+    }
+}

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -37,6 +37,7 @@ using MentalMetal.Infrastructure.Ai;
 using MentalMetal.Infrastructure.Auth;
 using MentalMetal.Infrastructure.Persistence;
 using MentalMetal.Infrastructure.Repositories;
+using MentalMetal.Infrastructure.Storage;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -69,6 +70,10 @@ public static class DependencyInjection
             .ValidateOnStart();
         services.AddOptions<InterviewAnalysisOptions>()
             .Bind(configuration.GetSection(InterviewAnalysisOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<AudioBlobStoreOptions>()
+            .Bind(configuration.GetSection(AudioBlobStoreOptions.SectionName))
             .ValidateDataAnnotations()
             .ValidateOnStart();
         services.AddOptions<AiProviderSettings>()
@@ -209,6 +214,14 @@ public static class DependencyInjection
         services.AddScoped<RetryProcessingHandler>();
         services.AddScoped<ConfirmExtractionHandler>();
         services.AddScoped<DiscardExtractionHandler>();
+
+        // Audio capture
+        services.AddSingleton<IAudioBlobStore, FileSystemAudioBlobStore>();
+        services.AddSingleton<IAudioTranscriptionProvider, StubAudioTranscriptionProvider>();
+        services.AddScoped<UploadAudioCaptureHandler>();
+        services.AddScoped<TranscribeCaptureHandler>();
+        services.AddScoped<GetCaptureTranscriptHandler>();
+        services.AddScoped<UpdateCaptureSpeakersHandler>();
 
         // Initiative chat services and handlers
         services.AddScoped<IInitiativeChatContextBuilder, InitiativeChatContextBuilder>();

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -215,9 +215,12 @@ public static class DependencyInjection
         services.AddScoped<ConfirmExtractionHandler>();
         services.AddScoped<DiscardExtractionHandler>();
 
-        // Audio capture
+        // Audio capture.
+        // NOTE: IAudioTranscriptionProvider is intentionally NOT registered here — callers
+        // (Program.cs) must register an environment-appropriate implementation. The repo ships
+        // StubAudioTranscriptionProvider which is wired up only in Development so production
+        // audio uploads fail loudly rather than silently serving fake transcripts.
         services.AddSingleton<IAudioBlobStore, FileSystemAudioBlobStore>();
-        services.AddSingleton<IAudioTranscriptionProvider, StubAudioTranscriptionProvider>();
         services.AddScoped<UploadAudioCaptureHandler>();
         services.AddScoped<TranscribeCaptureHandler>();
         services.AddScoped<GetCaptureTranscriptHandler>();

--- a/src/MentalMetal.Infrastructure/Migrations/20260414225819_AddCaptureAudioFields.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260414225819_AddCaptureAudioFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414225819_AddCaptureAudioFields")]
+    partial class AddCaptureAudioFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260414225819_AddCaptureAudioFields.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260414225819_AddCaptureAudioFields.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaptureAudioFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "CaptureType",
+                table: "Captures",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AudioBlobRef",
+                table: "Captures",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "AudioDiscardedAt",
+                table: "Captures",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AudioDurationSeconds",
+                table: "Captures",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AudioMimeType",
+                table: "Captures",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TranscriptionFailureReason",
+                table: "Captures",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TranscriptionStatus",
+                table: "Captures",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "NotApplicable");
+
+            migrationBuilder.CreateTable(
+                name: "CaptureTranscriptSegments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    StartSeconds = table.Column<double>(type: "double precision", nullable: false),
+                    EndSeconds = table.Column<double>(type: "double precision", nullable: false),
+                    SpeakerLabel = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Text = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    LinkedPersonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CaptureId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CaptureTranscriptSegments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CaptureTranscriptSegments_Captures_CaptureId",
+                        column: x => x.CaptureId,
+                        principalTable: "Captures",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CaptureTranscriptSegments_CaptureId",
+                table: "CaptureTranscriptSegments",
+                column: "CaptureId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CaptureTranscriptSegments");
+
+            migrationBuilder.DropColumn(
+                name: "AudioBlobRef",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "AudioDiscardedAt",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "AudioDurationSeconds",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "AudioMimeType",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "TranscriptionFailureReason",
+                table: "Captures");
+
+            migrationBuilder.DropColumn(
+                name: "TranscriptionStatus",
+                table: "Captures");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CaptureType",
+                table: "Captures",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30);
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
@@ -18,7 +18,7 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
         builder.Property(c => c.CaptureType)
             .HasConversion<string>()
             .IsRequired()
-            .HasMaxLength(20);
+            .HasMaxLength(30);
 
         builder.Property(c => c.ProcessingStatus)
             .HasConversion<string>()
@@ -88,5 +88,39 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
 
         builder.HasIndex(c => c.UserId);
         builder.HasIndex(c => new { c.UserId, c.Triaged });
+
+        // --- Audio / transcription fields ---
+        builder.Property(c => c.AudioBlobRef).HasMaxLength(500);
+        builder.Property(c => c.AudioMimeType).HasMaxLength(100);
+        builder.Property(c => c.AudioDurationSeconds);
+        builder.Property(c => c.AudioDiscardedAt);
+        builder.Property(c => c.TranscriptionStatus)
+            .HasConversion<string>()
+            .IsRequired()
+            .HasMaxLength(20)
+            .HasDefaultValue(TranscriptionStatus.NotApplicable);
+        builder.Property(c => c.TranscriptionFailureReason).HasMaxLength(2000);
+
+        builder.OwnsMany(c => c.TranscriptSegments, segment =>
+        {
+            segment.ToTable("CaptureTranscriptSegments");
+            segment.WithOwner().HasForeignKey("CaptureId");
+            segment.Property<Guid>("CaptureId");
+            segment.HasKey(s => s.Id);
+            segment.Property(s => s.Id).ValueGeneratedNever();
+            segment.Property(s => s.StartSeconds).IsRequired();
+            segment.Property(s => s.EndSeconds).IsRequired();
+            segment.Property(s => s.SpeakerLabel)
+                .IsRequired()
+                .HasMaxLength(TranscriptSegment.MaxSpeakerLabelLength);
+            segment.Property(s => s.Text)
+                .IsRequired()
+                .HasMaxLength(TranscriptSegment.MaxTextLength);
+            segment.Property(s => s.LinkedPersonId);
+            segment.HasIndex("CaptureId");
+        });
+        builder.Navigation(c => c.TranscriptSegments)
+            .UsePropertyAccessMode(PropertyAccessMode.Field)
+            .HasField("_transcriptSegments");
     }
 }

--- a/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
@@ -7,7 +7,9 @@ namespace MentalMetal.Infrastructure.Repositories;
 public sealed class CaptureRepository(MentalMetalDbContext dbContext) : ICaptureRepository
 {
     public async Task<Capture?> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
-        await dbContext.Captures.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+        await dbContext.Captures
+            .Include(c => c.TranscriptSegments)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
 
     public async Task<IReadOnlyList<Capture>> GetAllAsync(
         Guid userId,
@@ -70,4 +72,10 @@ public sealed class CaptureRepository(MentalMetalDbContext dbContext) : ICapture
 
     public async Task AddAsync(Capture capture, CancellationToken cancellationToken) =>
         await dbContext.Captures.AddAsync(capture, cancellationToken);
+
+    public void MarkOwnedAdded(object ownedEntity) =>
+        dbContext.Entry(ownedEntity).State = EntityState.Added;
+
+    public void MarkOwnedRemoved(object ownedEntity) =>
+        dbContext.Entry(ownedEntity).State = EntityState.Deleted;
 }

--- a/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
+++ b/src/MentalMetal.Infrastructure/Repositories/CaptureRepository.cs
@@ -7,6 +7,9 @@ namespace MentalMetal.Infrastructure.Repositories;
 public sealed class CaptureRepository(MentalMetalDbContext dbContext) : ICaptureRepository
 {
     public async Task<Capture?> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Captures.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+
+    public async Task<Capture?> GetByIdWithTranscriptAsync(Guid id, CancellationToken cancellationToken) =>
         await dbContext.Captures
             .Include(c => c.TranscriptSegments)
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);

--- a/src/MentalMetal.Infrastructure/Storage/AudioBlobStoreOptions.cs
+++ b/src/MentalMetal.Infrastructure/Storage/AudioBlobStoreOptions.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MentalMetal.Infrastructure.Storage;
+
+public sealed class AudioBlobStoreOptions
+{
+    public const string SectionName = "AudioBlobStore";
+
+    /// <summary>
+    /// Root directory for the filesystem-backed audio blob store. Ephemeral on
+    /// Cloud Run — acceptable because blobs are discarded within seconds on
+    /// the happy path.
+    /// </summary>
+    [Required]
+    public string RootPath { get; set; } = string.Empty;
+}

--- a/src/MentalMetal.Infrastructure/Storage/FileSystemAudioBlobStore.cs
+++ b/src/MentalMetal.Infrastructure/Storage/FileSystemAudioBlobStore.cs
@@ -1,0 +1,60 @@
+using MentalMetal.Application.Common;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Infrastructure.Storage;
+
+/// <summary>
+/// Default <see cref="IAudioBlobStore"/> implementation backed by the local
+/// filesystem. Blobs live at <c>{RootPath}/{userId}/{guid}.{ext}</c>.
+/// </summary>
+public sealed class FileSystemAudioBlobStore(IOptions<AudioBlobStoreOptions> options) : IAudioBlobStore
+{
+    private readonly string _rootPath = options.Value.RootPath;
+
+    public async Task<string> SaveAsync(
+        Guid userId, Stream audio, string mimeType, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+
+        var ext = MimeToExtension(mimeType);
+        var id = Guid.NewGuid();
+        var relative = Path.Combine(userId.ToString(), $"{id}{ext}");
+        var absolute = Path.Combine(_rootPath, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(absolute)!);
+
+        await using var file = File.Create(absolute);
+        await audio.CopyToAsync(file, cancellationToken);
+
+        // Return the relative ref so the on-disk layout can move without
+        // rewriting stored references.
+        return relative.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    public Task<Stream> OpenReadAsync(string blobRef, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(blobRef);
+        var absolute = Path.Combine(_rootPath, blobRef.Replace('/', Path.DirectorySeparatorChar));
+        Stream stream = File.OpenRead(absolute);
+        return Task.FromResult(stream);
+    }
+
+    public Task DeleteAsync(string blobRef, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(blobRef))
+            return Task.CompletedTask;
+        var absolute = Path.Combine(_rootPath, blobRef.Replace('/', Path.DirectorySeparatorChar));
+        if (File.Exists(absolute))
+            File.Delete(absolute);
+        return Task.CompletedTask;
+    }
+
+    private static string MimeToExtension(string? mimeType) => mimeType switch
+    {
+        "audio/webm" => ".webm",
+        "audio/mp4" or "audio/x-m4a" => ".m4a",
+        "audio/mpeg" => ".mp3",
+        "audio/wav" or "audio/x-wav" => ".wav",
+        "audio/ogg" => ".ogg",
+        _ => ".bin",
+    };
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CaptureRecorderComponent } from './capture-recorder.component';
+
+describe('CaptureRecorderComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CaptureRecorderComponent, HttpClientTestingModule],
+    }).compileComponents();
+  });
+
+  it('starts in idle state with zero duration', () => {
+    const fixture = TestBed.createComponent(CaptureRecorderComponent);
+    const component = fixture.componentInstance as unknown as {
+      state: () => string;
+      durationSeconds: () => number;
+      formattedDuration: () => string;
+    };
+    expect(component.state()).toBe('idle');
+    expect(component.durationSeconds()).toBe(0);
+    expect(component.formattedDuration()).toBe('00:00');
+  });
+
+  it('surfaces an error message when microphone access is denied', async () => {
+    // Stub getUserMedia on the test environment.
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: () => Promise.reject(new Error('Permission denied')),
+      },
+    });
+
+    const fixture = TestBed.createComponent(CaptureRecorderComponent);
+    const component = fixture.componentInstance as unknown as {
+      state: () => string;
+      errorMessage: () => string | null;
+      startRecording: () => Promise<void>;
+    };
+
+    await component.startRecording();
+
+    expect(component.state()).toBe('error');
+    expect(component.errorMessage()).toContain('Permission denied');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.ts
@@ -1,0 +1,152 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  computed,
+  inject,
+  output,
+  signal,
+} from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { MessageModule } from 'primeng/message';
+import { CapturesService } from '../../../shared/services/captures.service';
+import { Capture } from '../../../shared/models/capture.model';
+
+type RecorderState = 'idle' | 'recording' | 'uploading' | 'error';
+
+/**
+ * Standalone recorder that uses MediaRecorder to capture audio and POST it
+ * to /api/captures/audio. Signal-driven, zoneless-safe: every state
+ * mutation goes through .set()/.update(). See capture-audio spec
+ * "Audio capture frontend recorder".
+ */
+@Component({
+  selector: 'app-capture-recorder',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, MessageModule],
+  template: `
+    <div class="flex flex-col gap-3 rounded border border-surface-200 bg-surface-0 p-4">
+      <div class="flex items-center gap-3">
+        @if (state() === 'idle') {
+          <p-button
+            label="Record"
+            icon="pi pi-microphone"
+            severity="danger"
+            (onClick)="startRecording()"
+          />
+        }
+        @if (state() === 'recording') {
+          <p-button
+            label="Stop"
+            icon="pi pi-stop-circle"
+            severity="secondary"
+            (onClick)="stopRecording()"
+          />
+          <span class="text-sm text-muted-color">{{ formattedDuration() }}</span>
+        }
+        @if (state() === 'uploading') {
+          <p-button label="Uploading…" icon="pi pi-spin pi-spinner" [disabled]="true" />
+        }
+      </div>
+      @if (errorMessage(); as err) {
+        <p-message severity="error" [text]="err" />
+      }
+    </div>
+  `,
+})
+export class CaptureRecorderComponent implements OnDestroy {
+  private readonly capturesService = inject(CapturesService);
+
+  readonly uploaded = output<Capture>();
+
+  protected readonly state = signal<RecorderState>('idle');
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly durationSeconds = signal(0);
+
+  protected readonly formattedDuration = computed(() => {
+    const total = this.durationSeconds();
+    const mm = Math.floor(total / 60)
+      .toString()
+      .padStart(2, '0');
+    const ss = Math.floor(total % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${mm}:${ss}`;
+  });
+
+  private recorder: MediaRecorder | null = null;
+  private stream: MediaStream | null = null;
+  private chunks: Blob[] = [];
+  private startedAtMs = 0;
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+
+  async startRecording(): Promise<void> {
+    this.errorMessage.set(null);
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      this.state.set('error');
+      this.errorMessage.set(
+        err instanceof Error ? err.message : 'Microphone permission denied.',
+      );
+      return;
+    }
+
+    this.chunks = [];
+    this.recorder = new MediaRecorder(this.stream);
+    this.recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) this.chunks.push(e.data);
+    };
+    this.recorder.onstop = () => this.onRecorderStopped();
+    this.recorder.start();
+
+    this.startedAtMs = Date.now();
+    this.durationSeconds.set(0);
+    this.tickHandle = setInterval(() => {
+      this.durationSeconds.set(Math.floor((Date.now() - this.startedAtMs) / 1000));
+    }, 500);
+
+    this.state.set('recording');
+  }
+
+  stopRecording(): void {
+    if (this.recorder && this.recorder.state !== 'inactive') {
+      this.recorder.stop();
+    }
+    this.stopTick();
+    this.stream?.getTracks().forEach((t) => t.stop());
+  }
+
+  private onRecorderStopped(): void {
+    const blob = new Blob(this.chunks, { type: this.recorder?.mimeType || 'audio/webm' });
+    const duration = Math.max(0, (Date.now() - this.startedAtMs) / 1000);
+    this.state.set('uploading');
+
+    this.capturesService.uploadAudio(blob, duration).subscribe({
+      next: (capture) => {
+        this.uploaded.emit(capture);
+        this.state.set('idle');
+        this.durationSeconds.set(0);
+      },
+      error: (err) => {
+        this.state.set('error');
+        this.errorMessage.set(
+          err?.error?.message || err?.error?.errorCode || 'Upload failed.',
+        );
+      },
+    });
+  }
+
+  private stopTick(): void {
+    if (this.tickHandle !== null) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopTick();
+    this.stream?.getTracks().forEach((t) => t.stop());
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/audio-recorder/capture-recorder.component.ts
@@ -94,12 +94,25 @@ export class CaptureRecorderComponent implements OnDestroy {
     }
 
     this.chunks = [];
-    this.recorder = new MediaRecorder(this.stream);
-    this.recorder.ondataavailable = (e) => {
-      if (e.data.size > 0) this.chunks.push(e.data);
-    };
-    this.recorder.onstop = () => this.onRecorderStopped();
-    this.recorder.start();
+    try {
+      this.recorder = new MediaRecorder(this.stream);
+      this.recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) this.chunks.push(e.data);
+      };
+      this.recorder.onstop = () => this.onRecorderStopped();
+      this.recorder.start();
+    } catch (err) {
+      this.stream?.getTracks().forEach((t) => t.stop());
+      this.stream = null;
+      this.recorder = null;
+      this.state.set('error');
+      this.errorMessage.set(
+        err instanceof Error
+          ? err.message
+          : 'Recording is not supported in this browser.',
+      );
+      return;
+    }
 
     this.startedAtMs = Date.now();
     this.durationSeconds.set(0);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -14,7 +14,9 @@ import { MessageService } from 'primeng/api';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { PeopleService } from '../../../shared/services/people.service';
 import { InitiativesService } from '../../../shared/services/initiatives.service';
-import { Capture, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
+import { Capture, CaptureTranscript, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
+import { TranscriptViewerComponent } from '../transcript-viewer/transcript-viewer.component';
+import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.component';
 import { Person } from '../../../shared/models/person.model';
 import { Initiative } from '../../../shared/models/initiative.model';
 
@@ -33,6 +35,8 @@ import { Initiative } from '../../../shared/models/initiative.model';
     PanelModule,
     DividerModule,
     AutoCompleteModule,
+    TranscriptViewerComponent,
+    SpeakerPickerComponent,
   ],
   styles: [`
     .content-block {
@@ -137,6 +141,22 @@ import { Initiative } from '../../../shared/models/initiative.model';
           <h2 class="text-xl font-semibold">Content</h2>
           <div class="p-4 rounded-md border content-block whitespace-pre-wrap text-sm">{{ capture()!.rawContent }}</div>
         </section>
+
+        <!-- Transcript (audio captures only) -->
+        @if (capture()!.captureType === 'AudioRecording') {
+          <section class="flex flex-col gap-4">
+            <div class="flex items-center justify-between">
+              <h2 class="text-xl font-semibold">Transcript</h2>
+              @if (transcript()?.transcriptionStatus === 'Failed') {
+                <p-button label="Retry transcription" icon="pi pi-refresh" severity="warn" (onClick)="retryTranscription()" [loading]="retryingTranscription()" />
+              }
+            </div>
+            <app-transcript-viewer [transcript]="transcript()" (linkRequested)="openSpeakerPicker($event)" />
+            @if (pickerSpeakerLabel(); as label) {
+              <app-speaker-picker [speakerLabel]="label" (linked)="onSpeakerLinked($event)" (cancelled)="pickerSpeakerLabel.set(null)" />
+            }
+          </section>
+        }
 
         <!-- AI Extraction Review Panel -->
         @if (capture()!.processingStatus === 'Processed' && capture()!.aiExtraction) {
@@ -428,6 +448,9 @@ export class CaptureDetailComponent implements OnInit {
   readonly editSource = signal('');
   readonly selectedPerson = signal<Person | null>(null);
   readonly selectedInitiative = signal<Initiative | null>(null);
+  readonly transcript = signal<CaptureTranscript | null>(null);
+  readonly retryingTranscription = signal(false);
+  readonly pickerSpeakerLabel = signal<string | null>(null);
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -665,6 +688,7 @@ export class CaptureDetailComponent implements OnInit {
       case 'QuickNote': return 'Quick Note';
       case 'Transcript': return 'Transcript';
       case 'MeetingNotes': return 'Meeting Notes';
+      case 'AudioRecording': return 'Audio';
     }
   }
 
@@ -673,6 +697,7 @@ export class CaptureDetailComponent implements OnInit {
       case 'QuickNote': return 'info';
       case 'Transcript': return 'warn';
       case 'MeetingNotes': return 'success';
+      case 'AudioRecording': return 'warn';
     }
   }
 
@@ -703,6 +728,9 @@ export class CaptureDetailComponent implements OnInit {
         this.editSource.set(capture.source ?? '');
         this.loadLinkedPeople(capture.linkedPersonIds);
         this.loadLinkedInitiatives(capture.linkedInitiativeIds);
+        if (capture.captureType === 'AudioRecording') {
+          this.loadTranscript(capture.id);
+        }
         this.loading.set(false);
       },
       error: () => {
@@ -723,6 +751,60 @@ export class CaptureDetailComponent implements OnInit {
         this.linkedPeople.set(people.filter((p) => idSet.has(p.id)));
       },
     });
+  }
+
+  private loadTranscript(id: string): void {
+    this.capturesService.getTranscript(id).subscribe({
+      next: (t) => this.transcript.set(t),
+      error: () => this.transcript.set(null),
+    });
+  }
+
+  protected retryTranscription(): void {
+    const id = this.capture()?.id;
+    if (!id) return;
+    this.retryingTranscription.set(true);
+    this.capturesService.retryTranscription(id).subscribe({
+      next: (capture) => {
+        this.capture.set(capture);
+        this.loadTranscript(id);
+        this.retryingTranscription.set(false);
+        this.messageService.add({ severity: 'success', summary: 'Transcription retried' });
+      },
+      error: (err) => {
+        this.retryingTranscription.set(false);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Retry failed',
+          detail: err?.error?.errorCode ?? err?.error?.message ?? 'Unknown error',
+        });
+      },
+    });
+  }
+
+  protected openSpeakerPicker(speakerLabel: string): void {
+    this.pickerSpeakerLabel.set(speakerLabel);
+  }
+
+  protected onSpeakerLinked(event: { speakerLabel: string; personId: string }): void {
+    const id = this.capture()?.id;
+    if (!id) return;
+    this.capturesService
+      .updateSpeakers(id, { mappings: [{ speakerLabel: event.speakerLabel, personId: event.personId }] })
+      .subscribe({
+        next: () => {
+          this.loadTranscript(id);
+          this.pickerSpeakerLabel.set(null);
+          this.messageService.add({ severity: 'success', summary: 'Speaker linked' });
+        },
+        error: (err) => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Failed to link speaker',
+            detail: err?.error?.errorCode ?? err?.error?.message ?? 'Unknown error',
+          });
+        },
+      });
   }
 
   private loadLinkedInitiatives(initiativeIds: string[]): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
@@ -9,18 +9,21 @@ import { TagModule } from 'primeng/tag';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { Capture, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
 import { QuickCaptureDialogComponent } from '../quick-capture-dialog/quick-capture-dialog.component';
+import { CaptureRecorderComponent } from '../audio-recorder/capture-recorder.component';
 
 @Component({
   selector: 'app-captures-list',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, QuickCaptureDialogComponent],
+  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, QuickCaptureDialogComponent, CaptureRecorderComponent],
   template: `
     <div class="flex flex-col gap-6">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-bold">Captures</h1>
         <p-button label="New Capture" icon="pi pi-plus" (onClick)="showCreateDialog.set(true)" />
       </div>
+
+      <app-capture-recorder (uploaded)="onCaptureCreated($event)" />
 
       <div class="flex items-center gap-4">
         <p-select
@@ -142,6 +145,7 @@ export class CapturesListComponent implements OnInit {
       case 'QuickNote': return 'Quick Note';
       case 'Transcript': return 'Transcript';
       case 'MeetingNotes': return 'Meeting Notes';
+      case 'AudioRecording': return 'Audio';
     }
   }
 
@@ -150,6 +154,7 @@ export class CapturesListComponent implements OnInit {
       case 'QuickNote': return 'info';
       case 'Transcript': return 'warn';
       case 'MeetingNotes': return 'success';
+      case 'AudioRecording': return 'warn';
     }
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/speaker-picker/speaker-picker.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/speaker-picker/speaker-picker.component.ts
@@ -1,0 +1,68 @@
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { AutoCompleteModule, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
+import { PeopleService } from '../../../shared/services/people.service';
+import { Person } from '../../../shared/models/person.model';
+
+/**
+ * Compact speaker-identification picker. Opens inline below a speaker group,
+ * lets the user type a Person name, and emits the selected PersonId back to
+ * the parent which calls /api/captures/{id}/speakers.
+ */
+@Component({
+  selector: 'app-speaker-picker',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, ButtonModule, AutoCompleteModule],
+  template: `
+    <div class="flex items-center gap-2">
+      <span class="text-xs text-muted-color">Link {{ speakerLabel() }} →</span>
+      <p-autoComplete
+        [(ngModel)]="selected"
+        [suggestions]="suggestions()"
+        (completeMethod)="search($event)"
+        field="name"
+        placeholder="Search person"
+        [minLength]="1"
+        [forceSelection]="true"
+      />
+      <p-button
+        label="Link"
+        size="small"
+        [disabled]="!selected"
+        (onClick)="emitLink()"
+      />
+      <p-button
+        label="Cancel"
+        severity="secondary"
+        [text]="true"
+        size="small"
+        (onClick)="cancelled.emit()"
+      />
+    </div>
+  `,
+})
+export class SpeakerPickerComponent {
+  private readonly peopleService = inject(PeopleService);
+
+  readonly speakerLabel = input.required<string>();
+  readonly linked = output<{ speakerLabel: string; personId: string }>();
+  readonly cancelled = output<void>();
+
+  protected readonly suggestions = signal<Person[]>([]);
+  protected selected: Person | null = null;
+
+  protected search(event: AutoCompleteCompleteEvent): void {
+    const query = event.query.toLowerCase();
+    this.peopleService.list().subscribe((people) => {
+      const filtered = people.filter((p) => p.name.toLowerCase().includes(query));
+      this.suggestions.set(filtered);
+    });
+  }
+
+  protected emitLink(): void {
+    if (!this.selected) return;
+    this.linked.emit({ speakerLabel: this.speakerLabel(), personId: this.selected.id });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/speaker-picker/speaker-picker.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/speaker-picker/speaker-picker.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Observable, shareReplay } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { AutoCompleteModule, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
 import { PeopleService } from '../../../shared/services/people.service';
@@ -53,9 +54,14 @@ export class SpeakerPickerComponent {
   protected readonly suggestions = signal<Person[]>([]);
   protected selected: Person | null = null;
 
+  // Cache the people list for the lifetime of the component — typing in the autocomplete
+  // would otherwise hit /api/people on every keystroke.
+  private people$: Observable<Person[]> | null = null;
+
   protected search(event: AutoCompleteCompleteEvent): void {
     const query = event.query.toLowerCase();
-    this.peopleService.list().subscribe((people) => {
+    this.people$ ??= this.peopleService.list().pipe(shareReplay({ bufferSize: 1, refCount: false }));
+    this.people$.subscribe((people) => {
       const filtered = people.filter((p) => p.name.toLowerCase().includes(query));
       this.suggestions.set(filtered);
     });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/transcript-viewer/transcript-viewer.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/transcript-viewer/transcript-viewer.component.spec.ts
@@ -1,0 +1,54 @@
+import { groupBySpeaker } from './transcript-viewer.component';
+import { TranscriptSegment } from '../../../shared/models/capture.model';
+
+function seg(partial: Partial<TranscriptSegment>): TranscriptSegment {
+  return {
+    startSeconds: 0,
+    endSeconds: 1,
+    speakerLabel: 'Speaker A',
+    text: 'hi',
+    linkedPersonId: null,
+    ...partial,
+  };
+}
+
+describe('groupBySpeaker', () => {
+  it('folds consecutive segments with same speaker into one group', () => {
+    const segments: TranscriptSegment[] = [
+      seg({ startSeconds: 0, endSeconds: 2, speakerLabel: 'A', text: 'hi' }),
+      seg({ startSeconds: 2, endSeconds: 4, speakerLabel: 'A', text: 'there' }),
+      seg({ startSeconds: 4, endSeconds: 6, speakerLabel: 'B', text: 'hello' }),
+    ];
+
+    const groups = groupBySpeaker(segments);
+
+    expect(groups.length).toBe(2);
+    expect(groups[0].speakerLabel).toBe('A');
+    expect(groups[0].segments.length).toBe(2);
+    expect(groups[0].startSeconds).toBe(0);
+    expect(groups[0].endSeconds).toBe(4);
+    expect(groups[1].speakerLabel).toBe('B');
+  });
+
+  it('alternating speakers produce separate groups', () => {
+    const segments: TranscriptSegment[] = [
+      seg({ speakerLabel: 'A' }),
+      seg({ speakerLabel: 'B' }),
+      seg({ speakerLabel: 'A' }),
+    ];
+    const groups = groupBySpeaker(segments);
+    expect(groups.length).toBe(3);
+  });
+
+  it('empty input returns empty array', () => {
+    expect(groupBySpeaker([])).toEqual([]);
+  });
+
+  it('preserves linkedPersonId when any segment in the group has one', () => {
+    const groups = groupBySpeaker([
+      seg({ speakerLabel: 'A', linkedPersonId: null }),
+      seg({ speakerLabel: 'A', linkedPersonId: 'person-1' }),
+    ]);
+    expect(groups[0].linkedPersonId).toBe('person-1');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/transcript-viewer/transcript-viewer.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/transcript-viewer/transcript-viewer.component.ts
@@ -1,0 +1,107 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import {
+  CaptureTranscript,
+  TranscriptSegment,
+} from '../../../shared/models/capture.model';
+
+/**
+ * Groups consecutive segments by speaker and renders each group with its
+ * timecode. Emits an event when a user wants to link a speaker to a Person
+ * (the parent wires in the SpeakerPicker).
+ */
+export interface SpeakerGroup {
+  speakerLabel: string;
+  linkedPersonId: string | null;
+  startSeconds: number;
+  endSeconds: number;
+  segments: TranscriptSegment[];
+}
+
+@Component({
+  selector: 'app-transcript-viewer',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule],
+  template: `
+    @if (groups().length === 0) {
+      <p class="text-sm text-muted-color">No transcript available.</p>
+    } @else {
+      <div class="flex flex-col gap-4">
+        @for (group of groups(); track $index) {
+          <div class="rounded border border-surface-200 bg-surface-0 p-3">
+            <div class="mb-1 flex items-center justify-between">
+              <div class="flex items-center gap-2 text-sm font-medium">
+                <span class="text-primary">{{ group.speakerLabel }}</span>
+                @if (group.linkedPersonId) {
+                  <span class="text-xs text-muted-color">(linked)</span>
+                }
+                <span class="text-xs text-muted-color">
+                  {{ formatTime(group.startSeconds) }} – {{ formatTime(group.endSeconds) }}
+                </span>
+              </div>
+              <p-button
+                label="Link speaker"
+                size="small"
+                severity="secondary"
+                [text]="true"
+                (onClick)="linkRequested.emit(group.speakerLabel)"
+              />
+            </div>
+            <div class="flex flex-col gap-1">
+              @for (seg of group.segments; track $index) {
+                <p class="text-sm leading-relaxed">{{ seg.text }}</p>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    }
+  `,
+})
+export class TranscriptViewerComponent {
+  readonly transcript = input.required<CaptureTranscript | null>();
+  readonly linkRequested = output<string>();
+
+  protected readonly groups = computed<SpeakerGroup[]>(() => {
+    const t = this.transcript();
+    if (!t) return [];
+    return groupBySpeaker(t.segments);
+  });
+
+  protected formatTime(seconds: number): string {
+    const mm = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, '0');
+    const ss = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${mm}:${ss}`;
+  }
+}
+
+/**
+ * Exported for component tests. Folds consecutive same-speaker segments
+ * into a single group with the span [first.start, last.end].
+ */
+export function groupBySpeaker(segments: readonly TranscriptSegment[]): SpeakerGroup[] {
+  const groups: SpeakerGroup[] = [];
+  for (const segment of segments) {
+    const current = groups[groups.length - 1];
+    if (current && current.speakerLabel === segment.speakerLabel) {
+      current.segments.push(segment);
+      current.endSeconds = segment.endSeconds;
+      // Preserve "linked" across the group if any segment has a link.
+      current.linkedPersonId = current.linkedPersonId ?? segment.linkedPersonId;
+    } else {
+      groups.push({
+        speakerLabel: segment.speakerLabel,
+        linkedPersonId: segment.linkedPersonId,
+        startSeconds: segment.startSeconds,
+        endSeconds: segment.endSeconds,
+        segments: [segment],
+      });
+    }
+  }
+  return groups;
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -1,6 +1,36 @@
-export type CaptureType = 'QuickNote' | 'Transcript' | 'MeetingNotes';
+export type CaptureType = 'QuickNote' | 'Transcript' | 'MeetingNotes' | 'AudioRecording';
 
 export type ProcessingStatus = 'Raw' | 'Processing' | 'Processed' | 'Failed';
+
+export type TranscriptionStatus =
+  | 'NotApplicable'
+  | 'Pending'
+  | 'InProgress'
+  | 'Transcribed'
+  | 'Failed';
+
+export interface TranscriptSegment {
+  startSeconds: number;
+  endSeconds: number;
+  speakerLabel: string;
+  text: string;
+  linkedPersonId: string | null;
+}
+
+export interface CaptureTranscript {
+  captureId: string;
+  transcriptionStatus: TranscriptionStatus;
+  segments: TranscriptSegment[];
+}
+
+export interface SpeakerMapping {
+  speakerLabel: string;
+  personId: string;
+}
+
+export interface UpdateCaptureSpeakersRequest {
+  mappings: SpeakerMapping[];
+}
 
 export type ExtractionStatus = 'None' | 'Pending' | 'Confirmed' | 'Discarded';
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
@@ -3,11 +3,13 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   Capture,
+  CaptureTranscript,
   CaptureType,
   ConfirmExtractionResponse,
   CreateCaptureRequest,
   ProcessingStatus,
   UpdateCaptureMetadataRequest,
+  UpdateCaptureSpeakersRequest,
 } from '../models/capture.model';
 
 @Injectable({ providedIn: 'root' })
@@ -68,5 +70,34 @@ export class CapturesService {
 
   unlinkInitiative(id: string, initiativeId: string): Observable<Capture> {
     return this.http.post<Capture>(`${this.baseUrl}/${id}/unlink-initiative`, { initiativeId });
+  }
+
+  uploadAudio(blob: Blob, durationSeconds: number, title?: string, source?: string): Observable<Capture> {
+    const form = new FormData();
+    // Preserve MIME on the file part — the backend reads `file.ContentType`.
+    const ext = blob.type.includes('webm')
+      ? 'webm'
+      : blob.type.includes('mp4')
+      ? 'm4a'
+      : blob.type.includes('wav')
+      ? 'wav'
+      : 'bin';
+    form.append('file', blob, `recording.${ext}`);
+    form.append('durationSeconds', durationSeconds.toString());
+    if (title) form.append('title', title);
+    if (source) form.append('source', source);
+    return this.http.post<Capture>(`${this.baseUrl}/audio`, form);
+  }
+
+  retryTranscription(id: string): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/transcribe`, {});
+  }
+
+  getTranscript(id: string): Observable<CaptureTranscript> {
+    return this.http.get<CaptureTranscript>(`${this.baseUrl}/${id}/transcript`);
+  }
+
+  updateSpeakers(id: string, request: UpdateCaptureSpeakersRequest): Observable<Capture> {
+    return this.http.patch<Capture>(`${this.baseUrl}/${id}/speakers`, request);
   }
 }

--- a/src/MentalMetal.Web/Features/Captures/AudioCaptureEndpoints.cs
+++ b/src/MentalMetal.Web/Features/Captures/AudioCaptureEndpoints.cs
@@ -1,0 +1,119 @@
+using MentalMetal.Application.Captures;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.Options;
+
+namespace MentalMetal.Web.Features.Captures;
+
+public static class AudioCaptureEndpoints
+{
+    public static IEndpointRouteBuilder MapAudioCaptureEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/captures/audio", async (
+            HttpRequest httpRequest,
+            IOptions<AudioUploadOptions> optionsAccessor,
+            UploadAudioCaptureHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            var options = optionsAccessor.Value;
+
+            if (!httpRequest.HasFormContentType)
+                return Results.BadRequest(new { error = "Expected multipart/form-data." });
+
+            var form = await httpRequest.ReadFormAsync(cancellationToken);
+            var file = form.Files.GetFile("file");
+            if (file is null || file.Length == 0)
+                return Results.BadRequest(new { error = "Missing 'file' field." });
+
+            if (file.Length > options.MaxSizeBytes)
+                return Results.BadRequest(new { errorCode = AudioCaptureErrorCodes.AudioTooLarge });
+
+            if (!options.AllowedMimeTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
+                return Results.BadRequest(new { errorCode = AudioCaptureErrorCodes.AudioInvalidFormat });
+
+            var title = form["title"].ToString();
+            var source = form["source"].ToString();
+            var durationStr = form["durationSeconds"].ToString();
+            double duration = 0;
+            if (!string.IsNullOrWhiteSpace(durationStr) && double.TryParse(durationStr, out var parsed))
+                duration = parsed;
+
+            try
+            {
+                await using var stream = file.OpenReadStream();
+                var response = await handler.HandleAsync(
+                    new UploadAudioCaptureRequest(
+                        stream, file.ContentType, duration,
+                        string.IsNullOrWhiteSpace(title) ? null : title,
+                        string.IsNullOrWhiteSpace(source) ? null : source),
+                    cancellationToken);
+                return Results.Created($"/api/captures/{response.Id}", response);
+            }
+            catch (AudioCaptureException ex)
+            {
+                return Results.BadRequest(new { errorCode = ex.ErrorCode, message = ex.Message });
+            }
+        })
+        .RequireAuthorization()
+        .DisableAntiforgery()
+        .WithMetadata(new RequestSizeLimitAttribute(500_000_000)); // outer cap; options enforces tighter limit
+
+        app.MapPost("/api/captures/{id:guid}/transcribe", async (
+            Guid id,
+            TranscribeCaptureHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var response = await handler.HandleAsync(id, cancellationToken);
+                return Results.Ok(response);
+            }
+            catch (AudioCaptureException ex) when (ex.ErrorCode == AudioCaptureErrorCodes.CaptureNotFound)
+            {
+                return Results.NotFound(new { errorCode = ex.ErrorCode });
+            }
+            catch (AudioCaptureException ex)
+            {
+                return Results.BadRequest(new { errorCode = ex.ErrorCode, message = ex.Message });
+            }
+        }).RequireAuthorization();
+
+        app.MapGet("/api/captures/{id:guid}/transcript", async (
+            Guid id,
+            GetCaptureTranscriptHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            var response = await handler.HandleAsync(id, cancellationToken);
+            if (response is null)
+                return Results.NotFound(new { errorCode = AudioCaptureErrorCodes.CaptureNotFound });
+            return Results.Ok(response);
+        }).RequireAuthorization();
+
+        app.MapPatch("/api/captures/{id:guid}/speakers", async (
+            Guid id,
+            UpdateCaptureSpeakersRequest request,
+            UpdateCaptureSpeakersHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var response = await handler.HandleAsync(id, request, cancellationToken);
+                return Results.Ok(response);
+            }
+            catch (AudioCaptureException ex) when (ex.ErrorCode == AudioCaptureErrorCodes.CaptureNotFound)
+            {
+                return Results.NotFound(new { errorCode = ex.ErrorCode });
+            }
+            catch (AudioCaptureException ex)
+            {
+                return Results.BadRequest(new { errorCode = ex.ErrorCode, message = ex.Message });
+            }
+        }).RequireAuthorization();
+
+        return app;
+    }
+}
+
+internal class RequestSizeLimitAttribute(long bytes) : Attribute, IRequestSizeLimitMetadata
+{
+    public long? MaxRequestBodySize { get; } = bytes;
+}

--- a/src/MentalMetal.Web/Features/Captures/AudioCaptureEndpoints.cs
+++ b/src/MentalMetal.Web/Features/Captures/AudioCaptureEndpoints.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using MentalMetal.Application.Captures;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace MentalMetal.Web.Features.Captures;
@@ -8,6 +10,12 @@ public static class AudioCaptureEndpoints
 {
     public static IEndpointRouteBuilder MapAudioCaptureEndpoints(this IEndpointRouteBuilder app)
     {
+        // Read the configured upload cap at startup so the Kestrel-level RequestSizeLimit
+        // matches AudioUploadOptions.MaxSizeBytes. Otherwise clients could stream MBs past the
+        // Kestrel cap only to be rejected in-handler.
+        var uploadOptions = app.ServiceProvider
+            .GetRequiredService<IOptions<AudioUploadOptions>>().Value;
+
         app.MapPost("/api/captures/audio", async (
             HttpRequest httpRequest,
             IOptions<AudioUploadOptions> optionsAccessor,
@@ -34,8 +42,15 @@ public static class AudioCaptureEndpoints
             var source = form["source"].ToString();
             var durationStr = form["durationSeconds"].ToString();
             double duration = 0;
-            if (!string.IsNullOrWhiteSpace(durationStr) && double.TryParse(durationStr, out var parsed))
+            if (!string.IsNullOrWhiteSpace(durationStr))
+            {
+                // Culture-invariant: the browser sends "12.5" regardless of server locale.
+                if (!double.TryParse(durationStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+                    return Results.BadRequest(new { error = "Invalid durationSeconds." });
+                if (parsed < 0)
+                    return Results.BadRequest(new { error = "durationSeconds must be non-negative." });
                 duration = parsed;
+            }
 
             try
             {
@@ -55,7 +70,7 @@ public static class AudioCaptureEndpoints
         })
         .RequireAuthorization()
         .DisableAntiforgery()
-        .WithMetadata(new RequestSizeLimitAttribute(500_000_000)); // outer cap; options enforces tighter limit
+        .WithMetadata(new RequestSizeLimitAttribute(uploadOptions.MaxSizeBytes));
 
         app.MapPost("/api/captures/{id:guid}/transcribe", async (
             Guid id,

--- a/src/MentalMetal.Web/Features/Captures/AudioUploadOptions.cs
+++ b/src/MentalMetal.Web/Features/Captures/AudioUploadOptions.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MentalMetal.Web.Features.Captures;
+
+public sealed class AudioUploadOptions
+{
+    public const string SectionName = "AudioUpload";
+
+    /// <summary>
+    /// Maximum upload size in bytes. Default 50 MB. Bounded to prevent
+    /// accidental production misconfiguration.
+    /// </summary>
+    [Range(1, 500_000_000)]
+    public long MaxSizeBytes { get; set; } = 50L * 1024 * 1024;
+
+    [Required]
+    [MinLength(1)]
+    public List<string> AllowedMimeTypes { get; set; } = new()
+    {
+        "audio/webm",
+        "audio/mp4",
+        "audio/mpeg",
+        "audio/wav",
+    };
+}

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using MentalMetal.Application.Captures;
 using MentalMetal.Application.DailyCloseOut;
 using MentalMetal.Web;
+using MentalMetal.Web.Features.Captures;
 using MentalMetal.Web.Features.Interviews;
 using MentalMetal.Web.Features.Nudges;
 using MentalMetal.Application.Commitments;
@@ -51,6 +52,11 @@ builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddOptions<MentalMetal.Web.Features.Captures.AudioUploadOptions>()
+    .Bind(builder.Configuration.GetSection(MentalMetal.Web.Features.Captures.AudioUploadOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 
 // --- DataProtection ---
 // In hosted environments (e.g. Cloud Run) the local filesystem is ephemeral, so
@@ -1963,6 +1969,7 @@ app.MapGet("/api/people/{personId:guid}/evidence-summary", async (
     return Results.Ok(response);
 }).RequireAuthorization();
 
+app.MapAudioCaptureEndpoints();
 app.MapDailyCloseOutEndpoints();
 app.MapMyQueueEndpoints();
 app.MapBriefingEndpoints();

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -58,6 +58,16 @@ builder.Services.AddOptions<MentalMetal.Web.Features.Captures.AudioUploadOptions
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+// IAudioTranscriptionProvider — Development-only stub. Production environments must register
+// a real provider (future work); attempting to upload audio without one will fail at request
+// time with a clear DI error rather than silently returning fake transcripts.
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services.AddSingleton<
+        MentalMetal.Application.Common.Ai.IAudioTranscriptionProvider,
+        MentalMetal.Infrastructure.Ai.StubAudioTranscriptionProvider>();
+}
+
 // --- DataProtection ---
 // In hosted environments (e.g. Cloud Run) the local filesystem is ephemeral, so
 // keys must be persisted to durable storage. When DataProtection:BucketName is

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -23,6 +23,13 @@
       }
     }
   },
+  "AudioBlobStore": {
+    "RootPath": "./App_Data/audio-blobs"
+  },
+  "AudioUpload": {
+    "MaxSizeBytes": 52428800,
+    "AllowedMimeTypes": [ "audio/webm", "audio/mp4", "audio/mpeg", "audio/wav" ]
+  },
   "Briefing": {
     "MorningBriefingHour": 5,
     "MorningBriefingStaleHours": 12,

--- a/tests/MentalMetal.Application.Tests/Captures/TranscriptSegmentSplitterTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/TranscriptSegmentSplitterTests.cs
@@ -1,0 +1,65 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Application.Common.Ai;
+using MentalMetal.Domain.Captures;
+
+namespace MentalMetal.Application.Tests.Captures;
+
+public class TranscriptSegmentSplitterTests
+{
+    [Fact]
+    public void Split_ShortSegment_ReturnsSingle()
+    {
+        var dto = new AudioTranscriptSegmentDto(1.0, 2.0, "Speaker A", "short");
+        var result = InvokeSplit(new[] { dto });
+
+        var segment = Assert.Single(result);
+        Assert.Equal("short", segment.Text);
+        Assert.Equal(1.0, segment.StartSeconds);
+        Assert.Equal(2.0, segment.EndSeconds);
+        Assert.Equal("Speaker A", segment.SpeakerLabel);
+    }
+
+    [Fact]
+    public void Split_OverLengthSegment_SplitsIntoAdjacentSegmentsPreservingLabelAndTimeRange()
+    {
+        // 4500 chars, 60s–120s → 3 chunks (2000 + 2000 + 500)
+        var text = string.Concat(Enumerable.Repeat("a", 2000))
+                 + string.Concat(Enumerable.Repeat("b", 2000))
+                 + string.Concat(Enumerable.Repeat("c", 500));
+
+        var dto = new AudioTranscriptSegmentDto(60.0, 120.0, "Speaker A", text);
+        var result = InvokeSplit(new[] { dto });
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result, s => Assert.Equal("Speaker A", s.SpeakerLabel));
+        Assert.All(result, s => Assert.True(s.Text.Length <= TranscriptSegment.MaxTextLength));
+
+        // Concatenated text should equal original
+        Assert.Equal(text, string.Concat(result.Select(r => r.Text)));
+
+        // Adjacent — no gaps, no overlaps
+        Assert.Equal(60.0, result[0].StartSeconds);
+        Assert.Equal(result[0].EndSeconds, result[1].StartSeconds);
+        Assert.Equal(result[1].EndSeconds, result[2].StartSeconds);
+        Assert.Equal(120.0, result[2].EndSeconds);
+
+        // Proportional allocation — first two chunks equal length (2000) should take equal duration
+        var d0 = result[0].EndSeconds - result[0].StartSeconds;
+        var d1 = result[1].EndSeconds - result[1].StartSeconds;
+        Assert.Equal(d0, d1, 3);
+    }
+
+    [Fact]
+    public void Split_ExactlyMaxLength_NotSplit()
+    {
+        var text = new string('x', TranscriptSegment.MaxTextLength);
+        var dto = new AudioTranscriptSegmentDto(0, 10, "S", text);
+        var result = InvokeSplit(new[] { dto });
+
+        var segment = Assert.Single(result);
+        Assert.Equal(text, segment.Text);
+    }
+
+    private static IReadOnlyList<TranscriptSegment> InvokeSplit(
+        IEnumerable<AudioTranscriptSegmentDto> dtos) => TranscriptSegmentSplitter.Split(dtos);
+}

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureAudioTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureAudioTests.cs
@@ -1,0 +1,259 @@
+using MentalMetal.Domain.Captures;
+
+namespace MentalMetal.Domain.Tests.Captures;
+
+public class CaptureAudioTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 4, 14, 12, 0, 0, TimeSpan.Zero);
+
+    private static Capture CreateAudio() =>
+        Capture.CreateAudio(UserId, "blob/ref.webm", "audio/webm", 42.5, Now);
+
+    [Fact]
+    public void CreateAudio_ValidInputs_StartsPendingAndRaisesEvents()
+    {
+        var capture = CreateAudio();
+
+        Assert.Equal(CaptureType.AudioRecording, capture.CaptureType);
+        Assert.Equal("blob/ref.webm", capture.AudioBlobRef);
+        Assert.Equal("audio/webm", capture.AudioMimeType);
+        Assert.Equal(42.5, capture.AudioDurationSeconds);
+        Assert.Equal(TranscriptionStatus.Pending, capture.TranscriptionStatus);
+        Assert.Equal(ProcessingStatus.Raw, capture.ProcessingStatus);
+        Assert.Null(capture.AudioDiscardedAt);
+
+        Assert.Collection(capture.DomainEvents,
+            e => Assert.IsType<CaptureCreated>(e),
+            e => Assert.IsType<CaptureAudioUploaded>(e));
+    }
+
+    [Fact]
+    public void CreateAudio_EmptyBlobRef_Throws()
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            Capture.CreateAudio(UserId, "", "audio/webm", 1.0, Now));
+    }
+
+    [Fact]
+    public void CreateAudio_NegativeDuration_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Capture.CreateAudio(UserId, "ref", "audio/webm", -1, Now));
+    }
+
+    [Fact]
+    public void BeginTranscription_FromPending_TransitionsToInProgress()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        Assert.Equal(TranscriptionStatus.InProgress, c.TranscriptionStatus);
+    }
+
+    [Fact]
+    public void BeginTranscription_FromNonPending_Throws()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        Assert.Throws<InvalidOperationException>(() => c.BeginTranscription(Now));
+    }
+
+    [Fact]
+    public void AttachTranscript_FromInProgress_Transcribes_RaisesEvent_LeavesProcessingAtRaw()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.ClearDomainEvents();
+
+        var segments = new[]
+        {
+            TranscriptSegment.Create(0, 5, "Speaker A", "Hello world"),
+            TranscriptSegment.Create(5, 10, "Speaker B", "Hi there")
+        };
+
+        c.AttachTranscript("Hello world\nHi there", segments, Now);
+
+        Assert.Equal(TranscriptionStatus.Transcribed, c.TranscriptionStatus);
+        Assert.Equal(ProcessingStatus.Raw, c.ProcessingStatus); // extraction pipeline still picks up
+        Assert.Equal("Hello world\nHi there", c.RawContent);
+        Assert.Equal(2, c.TranscriptSegments.Count);
+
+        var evt = Assert.Single(c.DomainEvents);
+        var transcribed = Assert.IsType<CaptureTranscribed>(evt);
+        Assert.Equal(2, transcribed.SegmentCount);
+    }
+
+    [Fact]
+    public void AttachTranscript_FromPending_Throws()
+    {
+        var c = CreateAudio();
+        Assert.Throws<InvalidOperationException>(() =>
+            c.AttachTranscript("text", Array.Empty<TranscriptSegment>(), Now));
+    }
+
+    [Fact]
+    public void MarkTranscriptionFailed_FromInProgress_TransitionsToFailed_LeavesProcessingUntouched()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.ClearDomainEvents();
+
+        c.MarkTranscriptionFailed("provider timeout", Now);
+
+        Assert.Equal(TranscriptionStatus.Failed, c.TranscriptionStatus);
+        Assert.Equal("provider timeout", c.TranscriptionFailureReason);
+        Assert.Equal(ProcessingStatus.Raw, c.ProcessingStatus);
+
+        var evt = Assert.Single(c.DomainEvents);
+        var failed = Assert.IsType<CaptureTranscriptionFailed>(evt);
+        Assert.Equal("provider timeout", failed.Reason);
+    }
+
+    [Fact]
+    public void MarkTranscriptionFailed_FromPending_Throws()
+    {
+        var c = CreateAudio();
+        Assert.Throws<InvalidOperationException>(() => c.MarkTranscriptionFailed(null, Now));
+    }
+
+    [Fact]
+    public void RequeueTranscription_FromFailed_TransitionsToPending()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.MarkTranscriptionFailed("x", Now);
+
+        c.RequeueTranscription(Now);
+
+        Assert.Equal(TranscriptionStatus.Pending, c.TranscriptionStatus);
+        Assert.Null(c.TranscriptionFailureReason);
+    }
+
+    [Fact]
+    public void RequeueTranscription_AfterDiscard_Throws()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.MarkTranscriptionFailed("x", Now);
+        // simulate blob deletion
+        c.MarkAudioDiscarded(Now);
+
+        Assert.Throws<InvalidOperationException>(() => c.RequeueTranscription(Now));
+    }
+
+    [Fact]
+    public void MarkAudioDiscarded_ClearsBlobRefAndSetsTimestamp_IsIdempotent()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.AttachTranscript("t", new[] { TranscriptSegment.Create(0, 1, "A", "t") }, Now);
+
+        c.MarkAudioDiscarded(Now);
+
+        Assert.Null(c.AudioBlobRef);
+        Assert.Equal(Now, c.AudioDiscardedAt);
+        Assert.Equal("audio/webm", c.AudioMimeType); // retained
+        Assert.Equal(42.5, c.AudioDurationSeconds);  // retained
+        Assert.Contains(c.DomainEvents, e => e is CaptureAudioDiscarded);
+
+        c.ClearDomainEvents();
+        c.MarkAudioDiscarded(Now);
+        Assert.Empty(c.DomainEvents);
+    }
+
+    [Fact]
+    public void IdentifySpeakers_MapsLabelsToPersons_RaisesEventPerDistinctMapping()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        var segments = new[]
+        {
+            TranscriptSegment.Create(0, 5, "Speaker A", "hi"),
+            TranscriptSegment.Create(5, 10, "Speaker B", "hello"),
+            TranscriptSegment.Create(10, 15, "Speaker A", "bye"),
+        };
+        c.AttachTranscript("x", segments, Now);
+        c.ClearDomainEvents();
+
+        var sarah = Guid.NewGuid();
+        var tom = Guid.NewGuid();
+        var mapping = new Dictionary<string, Guid>
+        {
+            { "Speaker A", sarah },
+            { "Speaker B", tom }
+        };
+
+        c.IdentifySpeakers(mapping, Now);
+
+        Assert.All(c.TranscriptSegments.Where(s => s.SpeakerLabel == "Speaker A"),
+            s => Assert.Equal(sarah, s.LinkedPersonId));
+        Assert.All(c.TranscriptSegments.Where(s => s.SpeakerLabel == "Speaker B"),
+            s => Assert.Equal(tom, s.LinkedPersonId));
+
+        Assert.Equal(2, c.DomainEvents.OfType<CaptureSpeakerIdentified>().Count());
+    }
+
+    [Fact]
+    public void IdentifySpeakers_UnknownLabel_Throws()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.AttachTranscript("x", new[] { TranscriptSegment.Create(0, 1, "Speaker A", "hi") }, Now);
+
+        var mapping = new Dictionary<string, Guid> { { "Speaker Z", Guid.NewGuid() } };
+
+        Assert.Throws<KeyNotFoundException>(() => c.IdentifySpeakers(mapping, Now));
+    }
+
+    [Fact]
+    public void IdentifySpeakers_EmptyMapping_IsNoOp()
+    {
+        var c = CreateAudio();
+        c.BeginTranscription(Now);
+        c.AttachTranscript("x", new[] { TranscriptSegment.Create(0, 1, "Speaker A", "hi") }, Now);
+        c.ClearDomainEvents();
+
+        c.IdentifySpeakers(new Dictionary<string, Guid>(), Now);
+
+        Assert.Empty(c.DomainEvents);
+    }
+
+    // ----- TranscriptSegment invariants -----
+
+    [Fact]
+    public void TranscriptSegment_Create_EmptyText_Throws()
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            TranscriptSegment.Create(0, 1, "Speaker A", ""));
+    }
+
+    [Fact]
+    public void TranscriptSegment_Create_EndBeforeStart_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TranscriptSegment.Create(5, 3, "Speaker A", "text"));
+    }
+
+    [Fact]
+    public void TranscriptSegment_Create_OverLengthText_Throws()
+    {
+        var text = new string('a', TranscriptSegment.MaxTextLength + 1);
+        Assert.Throws<ArgumentException>(() =>
+            TranscriptSegment.Create(0, 1, "Speaker A", text));
+    }
+
+    [Fact]
+    public void TranscriptSegment_Create_OverLengthLabel_Throws()
+    {
+        var label = new string('x', TranscriptSegment.MaxSpeakerLabelLength + 1);
+        Assert.Throws<ArgumentException>(() =>
+            TranscriptSegment.Create(0, 1, label, "text"));
+    }
+
+    [Fact]
+    public void TranscriptSegment_Create_NegativeStart_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            TranscriptSegment.Create(-1, 1, "A", "text"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Stage 2 (apply) of the `capture-audio` spec — record + upload + transcribe + discard + speaker identification. Reuses the existing `Capture` aggregate while introducing a dedicated `TranscriptionStatus` lifecycle independent of `ProcessingStatus`, so the AI-extraction pipeline keeps running unchanged against audio captures.

**Spec**: [capture-audio](openspec/changes/capture-audio/specs/capture-audio/spec.md)

## Changes

- **Domain** — new `AudioRecording` `CaptureType`, new `TranscriptionStatus` enum, new `TranscriptSegment` owned entity (invariants: text ≤ 2000 chars, label ≤ 64, `StartSeconds` ≤ `EndSeconds`, non-negative start). `Capture.CreateAudio` / `BeginTranscription` / `AttachTranscript` / `MarkTranscriptionFailed` / `RequeueTranscription` / `MarkAudioDiscarded` / `IdentifySpeakers` and events `CaptureAudioUploaded`, `CaptureTranscribed`, `CaptureTranscriptionFailed`, `CaptureAudioDiscarded`, `CaptureSpeakerIdentified`. `ICaptureRepository.MarkOwnedAdded/Removed`.
- **Application** — `IAudioBlobStore` and `IAudioTranscriptionProvider` abstractions. Handlers: `UploadAudioCaptureHandler`, `TranscribeCaptureHandler` (retry flow), `GetCaptureTranscriptHandler`, `UpdateCaptureSpeakersHandler`. `TranscriptSegmentSplitter` splits >2000-char provider segments proportionally (no content dropped). Canonical `AudioCaptureErrorCodes`.
- **Infrastructure** — `FileSystemAudioBlobStore` + `AudioBlobStoreOptions` (Required/ValidateOnStart). `StubAudioTranscriptionProvider` (dev/test only). EF config for audio fields and owned `TranscriptSegments` collection. Migration `20260414225819_AddCaptureAudioFields`. DI wiring.
- **Web API** — `POST /api/captures/audio` (multipart), `POST /api/captures/{id}/transcribe`, `GET /api/captures/{id}/transcript`, `PATCH /api/captures/{id}/speakers`. `AudioUploadOptions` with `[Range]` and `ValidateDataAnnotations().ValidateOnStart()`; rejects size / MIME upfront with `audio.tooLarge` / `audio.invalidFormat`.
- **Frontend** — `CaptureRecorderComponent` (MediaRecorder + signals), `TranscriptViewerComponent` (groups consecutive same-speaker segments), `SpeakerPickerComponent` (Person autocomplete). `CapturesService` adds `uploadAudio` / `retryTranscription` / `getTranscript` / `updateSpeakers`. Wired into captures-list and capture-detail.
- Determinism: all handlers accept `TimeProvider` and thread `now` in.
- `openspec validate capture-audio --strict` passes.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — 736 tests pass (473 Domain + 177 Application + 86 Integration)
- [x] `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — 86 tests pass
- [x] `openspec validate capture-audio --strict` passes
- [x] New Domain tests cover `TranscriptionStatus` transitions, speaker mapping, segment invariants
- [x] New Application test covers the over-length segment splitter

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)