### PR TITLE
fix: include personName in goal API responses

### DIFF
--- a/src/MentalMetal.Application/Goals/GoalDtos.cs
+++ b/src/MentalMetal.Application/Goals/GoalDtos.cs
@@ -28,6 +28,7 @@ public sealed record GoalResponse(
     Guid Id,
     Guid UserId,
     Guid PersonId,
+    string? PersonName,
     string Title,
     string? Description,
     GoalType GoalType,
@@ -39,10 +40,11 @@ public sealed record GoalResponse(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt)
 {
-    public static GoalResponse From(Goal g) => new(
+    public static GoalResponse From(Goal g, string? personName = null) => new(
         g.Id,
         g.UserId,
         g.PersonId,
+        personName,
         g.Title,
         g.Description,
         g.Type,

--- a/src/MentalMetal.Application/Goals/GoalHandlers.cs
+++ b/src/MentalMetal.Application/Goals/GoalHandlers.cs
@@ -1,11 +1,26 @@
 using MentalMetal.Application.Common;
 using MentalMetal.Domain.Goals;
+using MentalMetal.Domain.People;
 using MentalMetal.Domain.Users;
 
 namespace MentalMetal.Application.Goals;
 
+internal static class GoalPersonNameResolver
+{
+    public static async Task<string?> ResolveAsync(
+        IPersonRepository personRepository,
+        Guid userId,
+        Guid personId,
+        CancellationToken cancellationToken)
+    {
+        var people = await personRepository.GetByIdsAsync(userId, [personId], cancellationToken);
+        return people.FirstOrDefault()?.Name;
+    }
+}
+
 public sealed class CreateGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -22,12 +37,15 @@ public sealed class CreateGoalHandler(
 
         await repository.AddAsync(goal, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class UpdateGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -42,12 +60,15 @@ public sealed class UpdateGoalHandler(
 
         goal.Update(request.Title, request.Description, request.TargetDate);
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class GetGoalByIdHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService)
 {
     public async Task<GoalResponse?> HandleAsync(Guid id, CancellationToken cancellationToken)
@@ -56,12 +77,15 @@ public sealed class GetGoalByIdHandler(
         if (goal is null || goal.UserId != currentUserService.UserId)
             return null;
 
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class GetUserGoalsHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService)
 {
     public async Task<List<GoalResponse>> HandleAsync(
@@ -70,14 +94,25 @@ public sealed class GetUserGoalsHandler(
         GoalStatus? statusFilter,
         CancellationToken cancellationToken)
     {
+        var userId = currentUserService.UserId;
         var items = await repository.GetAllAsync(
-            currentUserService.UserId, personIdFilter, typeFilter, statusFilter, null, null, cancellationToken);
-        return items.Select(GoalResponse.From).ToList();
+            userId, personIdFilter, typeFilter, statusFilter, null, null, cancellationToken);
+
+        // Batch-resolve person names to avoid N+1.
+        var personIds = items.Select(g => g.PersonId).Distinct().ToList();
+        var people = await personRepository.GetByIdsAsync(userId, personIds, cancellationToken);
+        var personNames = people.ToDictionary(p => p.Id, p => p.Name);
+
+        return items
+            .Select(g => GoalResponse.From(
+                g, personNames.TryGetValue(g.PersonId, out var pn) ? pn : null))
+            .ToList();
     }
 }
 
 public sealed class AchieveGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -91,12 +126,15 @@ public sealed class AchieveGoalHandler(
 
         goal.Achieve();
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class MissGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -110,12 +148,15 @@ public sealed class MissGoalHandler(
 
         goal.Miss();
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class DeferGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -130,12 +171,15 @@ public sealed class DeferGoalHandler(
 
         goal.Defer(request.Reason);
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class ReactivateGoalHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -149,12 +193,15 @@ public sealed class ReactivateGoalHandler(
 
         goal.Reactivate();
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }
 
 public sealed class RecordGoalCheckInHandler(
     IGoalRepository repository,
+    IPersonRepository personRepository,
     ICurrentUserService currentUserService,
     IUnitOfWork unitOfWork)
 {
@@ -170,6 +217,8 @@ public sealed class RecordGoalCheckInHandler(
         var checkIn = goal.RecordCheckIn(request.Note, request.Progress);
         repository.MarkOwnedAdded(checkIn);
         await unitOfWork.SaveChangesAsync(cancellationToken);
-        return GoalResponse.From(goal);
+        var personName = await GoalPersonNameResolver.ResolveAsync(
+            personRepository, currentUserService.UserId, goal.PersonId, cancellationToken);
+        return GoalResponse.From(goal, personName);
     }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/goals/goals-list/goals-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/goals/goals-list/goals-list.component.ts
@@ -77,7 +77,7 @@ import { Person } from '../../../shared/models/person.model';
           <ng-template #body let-row>
             <tr>
               <td>{{ row.title }}</td>
-              <td>{{ personName(row.personId) }}</td>
+              <td>{{ row.personName ?? personName(row.personId) }}</td>
               <td>{{ row.goalType }}</td>
               <td><p-tag [value]="row.status" [severity]="statusSeverity(row.status)" /></td>
               <td>{{ row.targetDate ? (row.targetDate | date: 'mediumDate') : '—' }}</td>

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/goal.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/goal.model.ts
@@ -12,6 +12,7 @@ export interface Goal {
   id: string;
   userId: string;
   personId: string;
+  personName: string | null;
   title: string;
   description: string | null;
   goalType: GoalType;

--- a/tests/MentalMetal.Web.IntegrationTests/PeopleLens/PeopleLensEndpointsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/PeopleLens/PeopleLensEndpointsTests.cs
@@ -33,6 +33,7 @@ public sealed class PeopleLensEndpointsTests(PostgresFixture postgres) : Integra
         Guid Id,
         Guid UserId,
         Guid PersonId,
+        string? PersonName,
         string Title,
         string? Description,
         string GoalType,
@@ -312,6 +313,38 @@ public sealed class PeopleLensEndpointsTests(PostgresFixture postgres) : Integra
         var after = (await ReadJsonAsync<GoalBody>(resp))!;
         Assert.Equal("Deferred", after.Status);
         Assert.Equal("Reprioritized to Q3", after.DeferralReason);
+    }
+
+    private sealed record PersonBody(Guid Id);
+
+    [Fact]
+    public async Task ListGoals_ForLinkedPerson_PopulatesPersonName()
+    {
+        var client = await AuthedClientAsync();
+
+        var personResp = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Goal Test Person",
+            type = "DirectReport",
+        });
+        Assert.Equal(HttpStatusCode.Created, personResp.StatusCode);
+        var person = (await ReadJsonAsync<PersonBody>(personResp))!;
+
+        var createResp = await client.PostAsJsonAsync("/api/goals", new
+        {
+            personId = person.Id,
+            title = "Ship roadmap",
+            goalType = "Performance",
+        });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = (await ReadJsonAsync<GoalBody>(createResp))!;
+        Assert.Equal("Goal Test Person", created.PersonName);
+
+        var listResp = await client.GetAsync("/api/goals");
+        Assert.Equal(HttpStatusCode.OK, listResp.StatusCode);
+        var list = (await ReadJsonAsync<List<GoalBody>>(listResp))!;
+        var match = Assert.Single(list, g => g.Id == created.Id);
+        Assert.Equal("Goal Test Person", match.PersonName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The Goals list page showed "(unknown)" in the Person column whenever a goal was created via API (or any flow that didn't pre-load the people map before goals rendered). The frontend was resolving names from a separately-loaded `PeopleService.list()` response, racing with the goals query.

Fixed server-side: the goals API now returns `personName` alongside `personId`, eliminating the frontend race.

Fixes #87

## Changes

- `GoalResponse` carries a nullable `PersonName`, populated by all goal handlers via `IPersonRepository.GetByIdsAsync` (batched in the list handler to avoid N+1)
- `Goal` frontend model adds `personName: string | null`
- Goals list template renders `row.personName ?? personName(row.personId)` (server value preferred; local lookup retained as legacy fallback)
- New integration test `ListGoals_ForLinkedPerson_PopulatesPersonName` verifies both Create and List responses

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (all suites green; new PeopleLens test included)
- [x] `npx ng test --watch=false` passes (86/86)
- [ ] Manual: create person + goal via API, navigate to /goals, confirm Person column shows the name

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)