### PR TITLE
fix: make includeArchived optional on GET /api/people

### DIFF
--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -448,11 +448,11 @@ app.MapPost("/api/people", async (
 
 app.MapGet("/api/people", async (
     PersonType? type,
-    bool includeArchived,
+    bool? includeArchived,
     GetPeopleHandler handler,
     CancellationToken cancellationToken) =>
 {
-    var list = await handler.HandleAsync(type, includeArchived, cancellationToken);
+    var list = await handler.HandleAsync(type, includeArchived ?? false, cancellationToken);
     return Results.Ok(list);
 }).RequireAuthorization();
 

--- a/tests/MentalMetal.Web.IntegrationTests/People/PeopleEndpointsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/People/PeopleEndpointsTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Json;
+using MentalMetal.Web.IntegrationTests.Infrastructure;
+
+namespace MentalMetal.Web.IntegrationTests.People;
+
+public sealed class PeopleEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private sealed record PersonBody(
+        Guid Id,
+        Guid UserId,
+        string Name,
+        string Type,
+        bool IsArchived);
+
+    private async Task<HttpClient> AuthedClientAsync()
+    {
+        var (_, token) = await SeedUserWithPasswordAndSignInAsync(
+            $"user-{Guid.NewGuid():N}@test.invalid", "password-123");
+        return WithBearer(CreateClient(), token);
+    }
+
+    // Regression: the people list endpoint previously required `includeArchived` in the
+    // query string (non-nullable `bool`). Front-end calls without the param — like
+    // `PeopleListComponent.loadPeople()` — returned 400 and left the list empty. The
+    // endpoint now treats the param as optional and defaults it to `false`. See issue #88.
+    [Fact]
+    public async Task GetPeople_WithNoQueryParameters_Returns200()
+    {
+        var client = await AuthedClientAsync();
+
+        // Seed a person so the happy path also asserts payload shape.
+        var create = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Issue 88 Person",
+            type = "Stakeholder",
+        });
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+
+        var resp = await client.GetAsync("/api/people");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await ReadJsonAsync<List<PersonBody>>(resp);
+        Assert.NotNull(body);
+        Assert.Single(body!);
+        Assert.Equal("Issue 88 Person", body![0].Name);
+        Assert.False(body![0].IsArchived);
+    }
+
+    [Fact]
+    public async Task GetPeople_WithIncludeArchivedFalse_OmitsArchivedPeople()
+    {
+        var client = await AuthedClientAsync();
+
+        var create = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Alice",
+            type = "DirectReport",
+        });
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+        var created = await ReadJsonAsync<PersonBody>(create);
+        Assert.NotNull(created);
+
+        var archive = await client.PostAsync($"/api/people/{created!.Id}/archive", content: null);
+        Assert.True(archive.IsSuccessStatusCode, $"Archive failed: {archive.StatusCode}");
+
+        // Default request — the fix makes includeArchived optional (false by default).
+        var resp = await client.GetAsync("/api/people");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await ReadJsonAsync<List<PersonBody>>(resp);
+        Assert.NotNull(body);
+        Assert.Empty(body!);
+
+        // Explicit includeArchived=true returns the archived row.
+        var respIncludeArchived = await client.GetAsync("/api/people?includeArchived=true");
+        Assert.Equal(HttpStatusCode.OK, respIncludeArchived.StatusCode);
+        var bodyIncludeArchived = await ReadJsonAsync<List<PersonBody>>(respIncludeArchived);
+        Assert.NotNull(bodyIncludeArchived);
+        Assert.Single(bodyIncludeArchived!);
+        Assert.True(bodyIncludeArchived![0].IsArchived);
+    }
+}


### PR DESCRIPTION
## Summary

`GET /api/people` declared `includeArchived` as a non-nullable `bool` query parameter with no default. When the Angular `PeopleListComponent` loads on `/people`, it calls `PeopleService.list(type)` without that parameter, so Kestrel returned **400 BadHttpRequest** (`Required parameter "bool includeArchived" was not provided`). The subscribe errored out and the list rendered the empty state — even when data existed.

Making the parameter nullable (and defaulting to `false`) restores the expected behaviour. Reproduced directly with `curl` against a dev instance; confirmed `/api/commitments`, `/api/delegations`, and `/api/goals` all return their data unchanged — the empty-state symptom reported in the issue for People was the real regression, and the other pages will continue to work.

Fixes #88

## Changes

- `src/MentalMetal.Web/Program.cs` — `GET /api/people` takes `bool? includeArchived` and passes `includeArchived ?? false` to the handler
- `tests/MentalMetal.Web.IntegrationTests/People/PeopleEndpointsTests.cs` — new regression coverage:
  - `GetPeople_WithNoQueryParameters_Returns200` locks in that a bare GET returns 200 with the seeded person
  - `GetPeople_WithIncludeArchivedFalse_OmitsArchivedPeople` confirms the default still hides archived rows and `?includeArchived=true` surfaces them

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (739/739, incl. 2 new integration tests)
- [x] `ng test --watch=false` passes (86/86)
- [x] Manual `curl`: `GET /api/people` (no query) → 200 with seeded data; previously 400

---
Generated with [Claude Code](https://claude.com/claude-code)