### PR TITLE
fix: dark-mode toggle sync, primary palette, and 1:1 Cancel styling

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/app.config.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/app.config.ts
@@ -9,7 +9,26 @@ import Material from '@primeng/themes/material';
 
 import { routes } from './app.routes';
 
-const MentalMetalPreset = definePreset(Material, { preset: { primary: 'indigo' } });
+// Override Material's default emerald primary with indigo so primary buttons
+// render with a WCAG-AA-compliant white-on-indigo contrast in light mode.
+// `definePreset` expects a semantic token override, not a `preset` key.
+const MentalMetalPreset = definePreset(Material, {
+  semantic: {
+    primary: {
+      50: '{indigo.50}',
+      100: '{indigo.100}',
+      200: '{indigo.200}',
+      300: '{indigo.300}',
+      400: '{indigo.400}',
+      500: '{indigo.500}',
+      600: '{indigo.600}',
+      700: '{indigo.700}',
+      800: '{indigo.800}',
+      900: '{indigo.900}',
+      950: '{indigo.950}',
+    },
+  },
+});
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
@@ -116,7 +116,7 @@ import { Person } from '../../../shared/models/person.model';
           </div>
         </div>
         <ng-template #footer>
-          <p-button label="Cancel" [text]="true" (onClick)="showCreate.set(false)" />
+          <p-button label="Cancel" severity="secondary" (onClick)="showCreate.set(false)" />
           <p-button label="Create" (onClick)="submit()" [disabled]="!draftPersonId || !draftDate" />
         </ng-template>
       </p-dialog>

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts
@@ -74,7 +74,7 @@ import { PasswordSettingsComponent } from './password-settings.component';
           <label for="theme" class="text-sm font-medium">Dark Mode</label>
           <p-toggleSwitch
             id="theme"
-            [(ngModel)]="darkMode"
+            [ngModel]="darkMode()"
             (ngModelChange)="onThemeChange($event)"
           />
         </div>
@@ -119,9 +119,12 @@ export class SettingsPage implements OnInit {
   readonly savingProfile = signal(false);
   readonly savingPreferences = signal(false);
 
+  // Mirrors the live theme state so the toggle always reflects the actual
+  // theme, not whatever was saved in the user's preferences last.
+  protected readonly darkMode = this.themeService.isDark;
+
   protected name = '';
   protected timezone = '';
-  protected darkMode = false;
   protected notificationsEnabled = true;
   protected briefingTime = '08:00';
   protected livingBriefAutoApply = false;
@@ -137,7 +140,6 @@ export class SettingsPage implements OnInit {
       this.email.set(user.email);
       this.name = user.name;
       this.timezone = user.timezone;
-      this.darkMode = user.preferences.theme === 'Dark';
       this.notificationsEnabled = user.preferences.notificationsEnabled;
       this.briefingTime = user.preferences.briefingTime;
       this.livingBriefAutoApply = user.preferences.livingBriefAutoApply;
@@ -181,7 +183,7 @@ export class SettingsPage implements OnInit {
     this.savingPreferences.set(true);
     this.userService
       .updatePreferences({
-        theme: this.darkMode ? 'Dark' : 'Light',
+        theme: this.darkMode() ? 'Dark' : 'Light',
         notificationsEnabled: this.notificationsEnabled,
         briefingTime: this.briefingTime,
         livingBriefAutoApply: this.livingBriefAutoApply,


### PR DESCRIPTION
## Summary

Fixes three minor theming issues observed during exploratory testing (issue #89):

1. **Settings Dark Mode toggle out of sync** — the Settings page Dark Mode toggle was bound to a plain property initialised from saved user preferences, so it didn't reflect the actual live theme. Now bound to `ThemeService.isDark()` signal, so the toggle always reflects the real theme state.
2. **Login "Sign in" button low contrast (light mode)** — `app.config.ts` used the wrong `definePreset` shape (`{ preset: { primary: 'indigo' } }`) which was silently ignored, leaving Material's default emerald primary. White text on `emerald.500` (`#3BBFA1`) is marginal for WCAG AA. Fixed by using the correct `{ semantic: { primary: { 50..950 } } }` structure to map primary to the indigo ramp (the originally intended palette, ~8.5:1 contrast).
3. **One-on-One dialog Cancel button color inconsistency (dark mode)** — the New 1:1 dialog Cancel button used `[text]="true"` (renders in primary color), while People, Captures, Commitments, Delegations, and Initiatives create dialogs use `severity="secondary"`. Switched to `severity="secondary"` for consistency.

Fixes #89

## Changes

- `src/MentalMetal.Web/ClientApp/src/app/app.config.ts` — correct `definePreset` semantic primary override to indigo
- `src/MentalMetal.Web/ClientApp/src/app/pages/settings/settings.page.ts` — bind Dark Mode toggle to `themeService.isDark` signal
- `src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts` — Cancel button uses `severity="secondary"`

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (739 tests)
- [x] `npx ng test --watch=false` passes (86 tests)
- [x] `npx ng build --configuration=production` succeeds
- [ ] Manual: open `/settings` in dark mode → toggle shows ON
- [ ] Manual: login page Sign in button shows indigo with white text (not teal)
- [ ] Manual: New 1:1 dialog Cancel button matches Create Person dialog Cancel

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)