### PR TITLE
fix: add Chat, Weekly Briefing, and Settings links to sidebar

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -54,6 +54,12 @@ import { ThemeService } from '../services/theme.service';
         <i class="pi pi-home"></i>
         <span>Dashboard</span>
       </a>
+      <a routerLink="/chat" routerLinkActive="font-semibold sidebar-link-active"
+         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
+         (click)="navClick.emit()">
+        <i class="pi pi-sparkles"></i>
+        <span>Chat</span>
+      </a>
       <a routerLink="/capture" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
          (click)="navClick.emit()">
@@ -120,6 +126,12 @@ import { ThemeService } from '../services/theme.service';
         <i class="pi pi-list-check"></i>
         <span>My Queue</span>
       </a>
+      <a routerLink="/briefings/weekly" routerLinkActive="font-semibold sidebar-link-active"
+         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
+         (click)="navClick.emit()">
+        <i class="pi pi-calendar"></i>
+        <span>Weekly Briefing</span>
+      </a>
       <a routerLink="/close-out" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
          (click)="navClick.emit()">
@@ -128,7 +140,13 @@ import { ThemeService } from '../services/theme.service';
       </a>
     </nav>
 
-    <div class="p-3 border-t sidebar-border">
+    <div class="p-3 border-t sidebar-border flex flex-col gap-1">
+      <a routerLink="/settings" routerLinkActive="font-semibold sidebar-link-active"
+         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
+         (click)="navClick.emit()">
+        <i class="pi pi-cog"></i>
+        <span>Settings</span>
+      </a>
       <button type="button"
         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm w-full theme-toggle"
         (click)="themeService.toggle()"

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -140,7 +140,7 @@ import { ThemeService } from '../services/theme.service';
       </a>
     </nav>
 
-    <div class="p-3 border-t sidebar-border flex flex-col gap-1">
+    <nav class="p-3 border-t sidebar-border flex flex-col gap-1" aria-label="Secondary">
       <a routerLink="/settings" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
          (click)="navClick.emit()">
@@ -154,7 +154,7 @@ import { ThemeService } from '../services/theme.service';
         <i [class]="themeService.isDark() ? 'pi pi-sun' : 'pi pi-moon'"></i>
         <span>{{ themeService.isDark() ? 'Light mode' : 'Dark mode' }}</span>
       </button>
-    </div>
+    </nav>
   `,
 })
 export class SidebarComponent {


### PR DESCRIPTION
## Summary

The sidebar hardcoded 13 nav links and was missing entries for three authenticated routes (`/chat`, `/briefings/weekly`, `/settings`). Settings in particular was unreachable from within the app, making AI provider configuration impossible without a bookmarked URL.

Fixes #112

## Changes

- Add `/chat` link near the top (after Dashboard) with `pi pi-sparkles` to differentiate from `/one-on-ones` which already uses `pi pi-comments`
- Add `/briefings/weekly` link grouped with flow items (between My Queue and Close-out) using `pi pi-calendar`
- Add `/settings` link to the bottom section next to the dark-mode toggle using `pi pi-cog`
- Wrap the bottom section in `flex flex-col gap-1` to preserve spacing between the new Settings link and the theme toggle

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (739 tests)
- [x] `npx ng test --watch=false` passes (86 tests)
- [x] `npx ng build --configuration=production` succeeds
- [ ] Manual: sidebar shows all 16 primary routes; active link styling applied on each new entry
- [ ] Manual: clicking Settings, Chat, and Weekly Briefing in the sidebar navigates correctly

---
Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add missing navigation entries for Chat, Weekly Briefing, and Settings to the sidebar and adjust the bottom section layout to accommodate the new Settings link.

New Features:
- Expose Chat via a dedicated sidebar navigation link near the top of the menu.
- Expose Weekly Briefing via a sidebar navigation link in the flow items section.
- Expose Settings via a sidebar navigation link in the bottom section next to the theme toggle.

Enhancements:
- Update the sidebar bottom section layout to use a vertical flex container with spacing between items for consistent spacing with the new Settings link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chat, Weekly Briefing, and Settings navigation links to the sidebar for quick access to key features and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->