### PR TITLE
fix: validate required fields on create endpoints (#113)

### DIFF
--- a/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
+++ b/src/MentalMetal.Application/Commitments/CommitmentDtos.cs
@@ -4,7 +4,7 @@ namespace MentalMetal.Application.Commitments;
 
 public sealed record CreateCommitmentRequest(
     string Description,
-    CommitmentDirection Direction,
+    CommitmentDirection? Direction,
     Guid PersonId,
     DateOnly? DueDate = null,
     Guid? InitiativeId = null,

--- a/src/MentalMetal.Application/Commitments/CreateCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/CreateCommitment.cs
@@ -13,7 +13,7 @@ public sealed class CreateCommitmentHandler(
         CreateCommitmentRequest request, CancellationToken cancellationToken)
     {
         if (request.Direction is null)
-            throw new ArgumentException("Direction is required.", nameof(request));
+            throw new ArgumentException("Direction is required.", nameof(request.Direction));
 
         var commitment = Commitment.Create(
             currentUserService.UserId,

--- a/src/MentalMetal.Application/Commitments/CreateCommitment.cs
+++ b/src/MentalMetal.Application/Commitments/CreateCommitment.cs
@@ -12,10 +12,13 @@ public sealed class CreateCommitmentHandler(
     public async Task<CommitmentResponse> HandleAsync(
         CreateCommitmentRequest request, CancellationToken cancellationToken)
     {
+        if (request.Direction is null)
+            throw new ArgumentException("Direction is required.", nameof(request));
+
         var commitment = Commitment.Create(
             currentUserService.UserId,
             request.Description,
-            request.Direction,
+            request.Direction.Value,
             request.PersonId,
             request.DueDate,
             request.InitiativeId,

--- a/src/MentalMetal.Application/Observations/ObservationDtos.cs
+++ b/src/MentalMetal.Application/Observations/ObservationDtos.cs
@@ -5,7 +5,7 @@ namespace MentalMetal.Application.Observations;
 public sealed record CreateObservationRequest(
     Guid PersonId,
     string Description,
-    ObservationTag Tag,
+    ObservationTag? Tag,
     DateOnly? OccurredAt = null,
     Guid? SourceCaptureId = null);
 

--- a/src/MentalMetal.Application/Observations/ObservationHandlers.cs
+++ b/src/MentalMetal.Application/Observations/ObservationHandlers.cs
@@ -12,11 +12,14 @@ public sealed class CreateObservationHandler(
     public async Task<ObservationResponse> HandleAsync(
         CreateObservationRequest request, CancellationToken cancellationToken)
     {
+        if (request.Tag is null)
+            throw new ArgumentException("Tag is required.", nameof(request.Tag));
+
         var observation = Observation.Create(
             currentUserService.UserId,
             request.PersonId,
             request.Description,
-            request.Tag,
+            request.Tag.Value,
             request.OccurredAt,
             request.SourceCaptureId);
 

--- a/src/MentalMetal.Application/OneOnOnes/CreateOneOnOne.cs
+++ b/src/MentalMetal.Application/OneOnOnes/CreateOneOnOne.cs
@@ -12,10 +12,13 @@ public sealed class CreateOneOnOneHandler(
     public async Task<OneOnOneResponse> HandleAsync(
         CreateOneOnOneRequest request, CancellationToken cancellationToken)
     {
+        if (request.OccurredAt is null)
+            throw new ArgumentException("OccurredAt is required.", nameof(request));
+
         var oneOnOne = OneOnOne.Create(
             currentUserService.UserId,
             request.PersonId,
-            request.OccurredAt,
+            request.OccurredAt.Value,
             request.Notes,
             request.Topics,
             request.MoodRating);

--- a/src/MentalMetal.Application/OneOnOnes/CreateOneOnOne.cs
+++ b/src/MentalMetal.Application/OneOnOnes/CreateOneOnOne.cs
@@ -13,7 +13,7 @@ public sealed class CreateOneOnOneHandler(
         CreateOneOnOneRequest request, CancellationToken cancellationToken)
     {
         if (request.OccurredAt is null)
-            throw new ArgumentException("OccurredAt is required.", nameof(request));
+            throw new ArgumentException("OccurredAt is required.", nameof(request.OccurredAt));
 
         var oneOnOne = OneOnOne.Create(
             currentUserService.UserId,

--- a/src/MentalMetal.Application/OneOnOnes/OneOnOneDtos.cs
+++ b/src/MentalMetal.Application/OneOnOnes/OneOnOneDtos.cs
@@ -4,7 +4,7 @@ namespace MentalMetal.Application.OneOnOnes;
 
 public sealed record CreateOneOnOneRequest(
     Guid PersonId,
-    DateOnly OccurredAt,
+    DateOnly? OccurredAt,
     string? Notes = null,
     IReadOnlyList<string>? Topics = null,
     int? MoodRating = null);

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -1864,11 +1864,23 @@ app.MapPost("/api/observations", async (
     CreateObservationHandler handler,
     CancellationToken ct) =>
 {
-    if (!Enum.IsDefined(typeof(ObservationTag), request.Tag))
+    if (request.Tag is null)
     {
         return Results.Problem(
             statusCode: StatusCodes.Status400BadRequest,
-            title: $"Unknown observation tag '{(int)request.Tag}'.",
+            title: "Observation tag is required.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "observation.validation",
+                ["field"] = "tag",
+            });
+    }
+
+    if (!Enum.IsDefined(typeof(ObservationTag), request.Tag.Value))
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: $"Unknown observation tag '{(int)request.Tag.Value}'.",
             extensions: new Dictionary<string, object?>
             {
                 ["code"] = "observation.invalidTag",

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -435,6 +435,18 @@ app.MapPost("/api/people", async (
     CreatePersonHandler handler,
     CancellationToken cancellationToken) =>
 {
+    if (string.IsNullOrWhiteSpace(request.Name))
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: "Name is required.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "person.validation",
+                ["field"] = "name",
+            });
+    }
+
     try
     {
         var response = await handler.HandleAsync(request, cancellationToken);
@@ -443,6 +455,33 @@ app.MapPost("/api/people", async (
     catch (InvalidOperationException ex)
     {
         return Results.Conflict(new { error = ex.Message });
+    }
+    catch (ArgumentException)
+    {
+        // Defensive: domain guard clauses (e.g. name/type invariants) fall here.
+        // Return a sanitized 400 rather than leaking internal argument names or
+        // stack traces from the exception message.
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: "Invalid person data.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "person.validation",
+                ["field"] = "name",
+            });
+    }
+    catch (Microsoft.EntityFrameworkCore.DbUpdateException)
+    {
+        // Defensive: EF constraint / translation failures can leak Npgsql/LINQ
+        // details through the default error handler. Fold them into a clean 400.
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: "Invalid person data.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "person.validation",
+                ["field"] = "name",
+            });
     }
 }).RequireAuthorization();
 
@@ -1021,6 +1060,18 @@ app.MapPost("/api/commitments", async (
     CreateCommitmentHandler handler,
     CancellationToken cancellationToken) =>
 {
+    if (request.Direction is null)
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: "Direction is required.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "commitment.validation",
+                ["field"] = "direction",
+            });
+    }
+
     try
     {
         var response = await handler.HandleAsync(request, cancellationToken);
@@ -1028,7 +1079,13 @@ app.MapPost("/api/commitments", async (
     }
     catch (ArgumentException ex)
     {
-        return Results.BadRequest(new { error = ex.Message });
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: ex.Message,
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "commitment.validation",
+            });
     }
 }).RequireAuthorization();
 
@@ -1655,14 +1712,41 @@ app.MapPost("/api/chat/threads/{threadId:guid}/unarchive", async (
 app.MapPost("/api/one-on-ones", async (
     CreateOneOnOneRequest request,
     CreateOneOnOneHandler handler,
+    TimeProvider timeProvider,
     CancellationToken ct) =>
 {
+    IResult OccurredAtValidation(string title) => Results.Problem(
+        statusCode: StatusCodes.Status400BadRequest,
+        title: title,
+        extensions: new Dictionary<string, object?>
+        {
+            ["code"] = "oneOnOne.validation",
+            ["field"] = "occurredAt",
+        });
+
+    if (request.OccurredAt is null)
+        return OccurredAtValidation("OccurredAt is required.");
+
+    var occurredAt = request.OccurredAt.Value;
+    var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+    if (occurredAt < new DateOnly(2000, 1, 1) || occurredAt > today.AddDays(1))
+        return OccurredAtValidation("OccurredAt must be on or after 2000-01-01 and not more than one day in the future.");
+
     try
     {
         var response = await handler.HandleAsync(request, ct);
         return Results.Created($"/api/one-on-ones/{response.Id}", response);
     }
-    catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+    catch (ArgumentException ex)
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: ex.Message,
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "oneOnOne.validation",
+            });
+    }
 }).RequireAuthorization();
 
 app.MapGet("/api/one-on-ones", async (
@@ -1780,12 +1864,33 @@ app.MapPost("/api/observations", async (
     CreateObservationHandler handler,
     CancellationToken ct) =>
 {
+    if (!Enum.IsDefined(typeof(ObservationTag), request.Tag))
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: $"Unknown observation tag '{(int)request.Tag}'.",
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "observation.invalidTag",
+                ["field"] = "tag",
+            });
+    }
+
     try
     {
         var response = await handler.HandleAsync(request, ct);
         return Results.Created($"/api/observations/{response.Id}", response);
     }
-    catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+    catch (ArgumentException ex)
+    {
+        return Results.Problem(
+            statusCode: StatusCodes.Status400BadRequest,
+            title: ex.Message,
+            extensions: new Dictionary<string, object?>
+            {
+                ["code"] = "observation.validation",
+            });
+    }
 }).RequireAuthorization();
 
 app.MapGet("/api/observations", async (

--- a/tests/MentalMetal.Web.IntegrationTests/People/CreateEndpointValidationTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/People/CreateEndpointValidationTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text.Json;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.People;
+using MentalMetal.Web.IntegrationTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MentalMetal.Web.IntegrationTests.People;
+
+/// <summary>
+/// Regression coverage for issue #113: create endpoints that previously silently
+/// accepted missing/invalid required fields now return a clean 400 ProblemDetails
+/// response with a machine-readable <c>code</c> (and, where relevant, <c>field</c>).
+/// </summary>
+public sealed class CreateEndpointValidationTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private async Task<(Guid UserId, HttpClient Client)> AuthedClientAsync()
+    {
+        var (userId, token) = await SeedUserWithPasswordAndSignInAsync(
+            $"user-{Guid.NewGuid():N}@test.invalid", "password-123");
+        return (userId, WithBearer(CreateClient(), token));
+    }
+
+    private async Task<Guid> SeedPersonAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IPersonRepository>();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var person = Person.Create(userId, $"Person-{Guid.NewGuid():N}", PersonType.DirectReport);
+        await repo.AddAsync(person, CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+        return person.Id;
+    }
+
+    private static async Task<(string? code, string? field, string rawBody)> ReadProblemAsync(HttpResponseMessage response)
+    {
+        var raw = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        var root = doc.RootElement;
+        string? code = root.TryGetProperty("code", out var c) ? c.GetString() : null;
+        string? field = root.TryGetProperty("field", out var f) ? f.GetString() : null;
+        return (code, field, raw);
+    }
+
+    [Fact]
+    public async Task CreateOneOnOne_WithoutOccurredAt_Returns400WithFieldCode()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var personId = await SeedPersonAsync(userId);
+
+        var response = await client.PostAsync("/api/one-on-ones", JsonBody(new
+        {
+            personId = personId,
+            notes = "missing occurredAt",
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var (code, field, _) = await ReadProblemAsync(response);
+        Assert.Equal("oneOnOne.validation", code);
+        Assert.Equal("occurredAt", field);
+    }
+
+    [Fact]
+    public async Task CreateCommitment_WithoutDirection_Returns400WithFieldCode()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var personId = await SeedPersonAsync(userId);
+
+        var response = await client.PostAsync("/api/commitments", JsonBody(new
+        {
+            description = "Ship the thing",
+            personId = personId,
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var (code, field, _) = await ReadProblemAsync(response);
+        Assert.Equal("commitment.validation", code);
+        Assert.Equal("direction", field);
+    }
+
+    [Fact]
+    public async Task CreateObservation_WithOutOfRangeTag_Returns400WithInvalidTagCode()
+    {
+        var (userId, client) = await AuthedClientAsync();
+        var personId = await SeedPersonAsync(userId);
+
+        var response = await client.PostAsync("/api/observations", JsonBody(new
+        {
+            personId = personId,
+            description = "x",
+            tag = 999,
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var (code, _, _) = await ReadProblemAsync(response);
+        Assert.Equal("observation.invalidTag", code);
+    }
+
+    [Fact]
+    public async Task CreatePerson_WithEmptyName_Returns400AndDoesNotLeakEfException()
+    {
+        var (_, client) = await AuthedClientAsync();
+
+        var response = await client.PostAsync("/api/people", JsonBody(new
+        {
+            name = "",
+            type = "DirectReport",
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var (code, field, raw) = await ReadProblemAsync(response);
+        Assert.Equal("person.validation", code);
+        Assert.Equal("name", field);
+        // Sanity: the EF Core / Npgsql internals must not leak through.
+        Assert.DoesNotContain("LINQ", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Npgsql", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ArgumentException", raw, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreatePerson_WithMissingName_Returns400AndDoesNotLeakEfException()
+    {
+        var (_, client) = await AuthedClientAsync();
+
+        var response = await client.PostAsync("/api/people", JsonBody(new
+        {
+            type = "DirectReport",
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var (code, field, raw) = await ReadProblemAsync(response);
+        Assert.Equal("person.validation", code);
+        Assert.Equal("name", field);
+        Assert.DoesNotContain("LINQ", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Npgsql", raw, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #113. Four `POST /api/...` create endpoints previously accepted missing or out-of-range required fields and silently persisted garbage data (e.g. `occurredAt: 0001-01-01` rendering as `Jan 1, 1` in the UI) or surfaced leaky `ArgumentException` / `DbUpdateException` messages as 500/409 responses. This PR adds endpoint-level validation with clean ProblemDetails 400 responses and machine-readable error codes.

## Changes

- **1:1 (`POST /api/one-on-ones`)** — `OccurredAt` is now nullable in the DTO; endpoint rejects missing or out-of-range dates (before year 2000 or more than one day in the future) with `400 + code: oneOnOne.validation`, `field: occurredAt`.
- **Commitment (`POST /api/commitments`)** — `Direction` is now nullable in the DTO; endpoint rejects missing direction with `400 + code: commitment.validation`, `field: direction`.
- **Observation (`POST /api/observations`)** — endpoint validates `tag` via `Enum.IsDefined` and rejects unknown values with `400 + code: observation.invalidTag`.
- **Person (`POST /api/people`)** — endpoint validates trimmed name non-empty before the aggregate; `ArgumentException` and `DbUpdateException` escape paths are translated to `400 + code: person.validation` with sanitized titles (no EF / Npgsql / LINQ text leakage).
- Integration tests: one per failure mode, including an explicit assertion that no EF exception text leaks on the person path.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — 744 passed
- [x] `(cd src/MentalMetal.Web/ClientApp && npx ng test --watch=false)` — 86 passed
- [x] Missing `occurredAt` returns 400 with field `occurredAt`
- [x] Missing `direction` returns 400 with field `direction`
- [x] Unknown observation tag returns 400 with code `observation.invalidTag`
- [x] Empty/missing person name returns 400 with field `name` and no EF text in body

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)