### PR TITLE
fix: strip markdown code fences before parsing AI JSON responses

### DIFF
--- a/src/MentalMetal.Application/Captures/ProcessCapture.cs
+++ b/src/MentalMetal.Application/Captures/ProcessCapture.cs
@@ -95,7 +95,8 @@ public sealed class ProcessCaptureHandler(
 
     internal static AiExtraction ParseExtraction(string jsonContent)
     {
-        using var json = System.Text.Json.JsonDocument.Parse(jsonContent);
+        var stripped = JsonResponseParser.StripCodeFences(jsonContent);
+        using var json = System.Text.Json.JsonDocument.Parse(stripped);
         var root = json.RootElement;
 
         return new AiExtraction

--- a/src/MentalMetal.Application/Common/Ai/JsonResponseParser.cs
+++ b/src/MentalMetal.Application/Common/Ai/JsonResponseParser.cs
@@ -1,0 +1,47 @@
+namespace MentalMetal.Application.Common.Ai;
+
+/// <summary>
+/// Helpers for parsing AI provider responses that are expected to contain JSON.
+/// Some providers (notably Anthropic's Claude models) frequently wrap structured
+/// JSON output in a markdown code fence (<c>```json ... ```</c>) even when the
+/// system prompt explicitly forbids it. Callers should run provider output through
+/// <see cref="StripCodeFences"/> before handing it to <c>System.Text.Json</c>.
+/// </summary>
+public static class JsonResponseParser
+{
+    /// <summary>
+    /// If <paramref name="raw"/> is wrapped in a markdown code fence, remove it.
+    /// The language tag (e.g. <c>json</c>) is optional and matched case-insensitively.
+    /// Un-fenced input is returned trimmed but otherwise unchanged.
+    /// </summary>
+    /// <param name="raw">Raw AI response content.</param>
+    /// <returns>Content with any surrounding code fence removed and trimmed.</returns>
+    public static string StripCodeFences(string raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            return raw ?? string.Empty;
+
+        var trimmed = raw.Trim();
+        if (!trimmed.StartsWith("```", StringComparison.Ordinal))
+            return trimmed;
+
+        // Opening fence: drop everything up to and including the first newline.
+        // This handles "```json\n...", "```JSON\n...", "```\n...", and "```   \n...".
+        var firstNewline = trimmed.IndexOf('\n');
+        if (firstNewline < 0)
+        {
+            // Single line starting with ``` — degenerate; give up and return as-is trimmed
+            // so the downstream JSON parser surfaces the real error.
+            return trimmed;
+        }
+
+        var inner = trimmed[(firstNewline + 1)..];
+
+        // Closing fence: strip trailing ``` if present (tolerating trailing whitespace/newlines).
+        var innerTrimmed = inner.TrimEnd();
+        if (innerTrimmed.EndsWith("```", StringComparison.Ordinal))
+            inner = innerTrimmed[..^3];
+
+        return inner.Trim();
+    }
+}

--- a/src/MentalMetal.Application/Initiatives/Brief/BriefMaintenanceService.cs
+++ b/src/MentalMetal.Application/Initiatives/Brief/BriefMaintenanceService.cs
@@ -199,7 +199,8 @@ public sealed class BriefMaintenanceService(
 
     internal static BriefUpdateProposal ParseProposal(string jsonContent, IReadOnlyList<Guid> sourceCaptureIds)
     {
-        using var doc = JsonDocument.Parse(jsonContent);
+        var stripped = JsonResponseParser.StripCodeFences(jsonContent);
+        using var doc = JsonDocument.Parse(stripped);
         var root = doc.RootElement;
 
         return new BriefUpdateProposal

--- a/src/MentalMetal.Application/Interviews/InterviewAnalysisService.cs
+++ b/src/MentalMetal.Application/Interviews/InterviewAnalysisService.cs
@@ -122,17 +122,8 @@ public sealed class InterviewAnalysisService(
 
     private static (string Summary, InterviewDecision? Decision, IReadOnlyList<string> Signals, string? Warning) ParseResponse(string content)
     {
-        var trimmed = content.Trim();
         // Tolerate markdown-fenced output even though the system prompt forbids it.
-        if (trimmed.StartsWith("```", StringComparison.Ordinal))
-        {
-            var firstNewline = trimmed.IndexOf('\n');
-            if (firstNewline > 0)
-                trimmed = trimmed[(firstNewline + 1)..];
-            if (trimmed.EndsWith("```", StringComparison.Ordinal))
-                trimmed = trimmed[..^3];
-            trimmed = trimmed.Trim();
-        }
+        var trimmed = JsonResponseParser.StripCodeFences(content);
 
         AnalysisPayload? payload;
         try

--- a/tests/MentalMetal.Application.Tests/Common/Ai/JsonResponseParserTests.cs
+++ b/tests/MentalMetal.Application.Tests/Common/Ai/JsonResponseParserTests.cs
@@ -1,0 +1,94 @@
+using MentalMetal.Application.Common.Ai;
+
+namespace MentalMetal.Application.Tests.Common.Ai;
+
+public class JsonResponseParserTests
+{
+    [Fact]
+    public void StripCodeFences_JsonLanguageFence_StripsFence()
+    {
+        const string input = "```json\n{\"summary\":\"hi\"}\n```";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"summary\":\"hi\"}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_PlainFence_StripsFence()
+    {
+        const string input = "```\n{\"summary\":\"hi\"}\n```";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"summary\":\"hi\"}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_UppercaseLanguageTag_StripsFence()
+    {
+        const string input = "```JSON\n{\"a\":1}\n```";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"a\":1}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_SurroundingWhitespace_Trims()
+    {
+        const string input = "   \n```json\n{\"a\":1}\n```\n   ";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"a\":1}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_UnfencedJson_LeavesContentUnchangedExceptTrim()
+    {
+        const string input = "{\"summary\":\"hi\"}";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void StripCodeFences_UnfencedJsonWithSurroundingWhitespace_Trims()
+    {
+        const string input = "  \n{\"summary\":\"hi\"}\n  ";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"summary\":\"hi\"}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_FenceWithTrailingNewlineAfterClose_StripsCleanly()
+    {
+        const string input = "```json\n{\"a\":1}\n```\n";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\"a\":1}", result);
+    }
+
+    [Fact]
+    public void StripCodeFences_EmptyString_ReturnsEmpty()
+    {
+        var result = JsonResponseParser.StripCodeFences(string.Empty);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void StripCodeFences_MultilineJsonInsideFence_PreservesInternalNewlines()
+    {
+        const string input = "```json\n{\n  \"a\": 1,\n  \"b\": 2\n}\n```";
+
+        var result = JsonResponseParser.StripCodeFences(input);
+
+        Assert.Equal("{\n  \"a\": 1,\n  \"b\": 2\n}", result);
+    }
+}


### PR DESCRIPTION
## Summary

Anthropic's Claude models frequently wrap structured JSON output in a `` ```json ... ``` `` markdown code fence even when the system prompt explicitly forbids it. Two AI features — capture extraction (`ProcessCapture`) and living-brief refresh (`BriefMaintenanceService`) — called `JsonDocument.Parse` / `JsonSerializer.Deserialize` directly on raw model output, so any fenced response produced a parse error at byte 0 and the feature was marked `Failed`. `InterviewAnalysisService` already tolerated this; this PR lifts that logic into a shared `JsonResponseParser.StripCodeFences` helper and uses it from all three callsites.

Fixes #116.

## Changes

- New `src/MentalMetal.Application/Common/Ai/JsonResponseParser.cs` — `StripCodeFences(string)` handles `` ```json ``, `` ``` ``, case-insensitive language tags, surrounding whitespace, and passes un-fenced JSON through unchanged.
- `ProcessCaptureHandler.ParseExtraction` now strips fences before `JsonDocument.Parse`.
- `BriefMaintenanceService.ParseProposal` now strips fences before `JsonDocument.Parse`.
- `InterviewAnalysisService.ParseResponse` now delegates to the shared helper (behaviour unchanged).
- New xUnit tests covering the helper's edge cases.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (753 tests)
- [x] `ng test --watch=false` passes (86 tests)
- [ ] Smoke: `POST /api/captures/{id}/process` and `POST /api/initiatives/{id}/brief/refresh` against `claude-haiku-4-5-20251001` no longer end in `Failed` with a backtick parse error

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved parsing reliability for AI-generated responses by automatically removing Markdown code fence formatting, reducing JSON parsing errors when processing AI outputs.

* **Tests**
  * Added comprehensive unit tests to validate code fence removal across various response formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->