### PR TITLE
fix: scope New Interview candidate dropdown to Candidate-type people

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/pages/interviews/interviews-pipeline/interviews-pipeline.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/interviews/interviews-pipeline/interviews-pipeline.component.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { InterviewsPipelineComponent } from './interviews-pipeline.component';
+import { Person } from '../../../shared/models/person.model';
+
+describe('InterviewsPipelineComponent', () => {
+  let fixture: ComponentFixture<InterviewsPipelineComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InterviewsPipelineComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: '**', children: [] }]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterviewsPipelineComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  function person(overrides: Partial<Person> = {}): Person {
+    return {
+      id: 'p1',
+      userId: 'u1',
+      name: 'Alex Candidate',
+      type: 'Candidate',
+      email: null,
+      role: null,
+      team: null,
+      notes: null,
+      careerDetails: null,
+      candidateDetails: null,
+      isArchived: false,
+      archivedAt: null,
+      createdAt: '2026-04-14T00:00:00Z',
+      updatedAt: '2026-04-14T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  // Regression for issue #120: the component previously fetched the full people
+  // list with no type filter, so the New Interview dropdown either mixed in
+  // non-candidates or — in user reports — appeared empty depending on seed data.
+  // It must now request people scoped to `type=Candidate`.
+  it('requests people filtered to Candidate on init', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const peopleReq = httpMock.expectOne(
+      (r) => r.url === '/api/people' && r.method === 'GET',
+    );
+    expect(peopleReq.request.params.get('type')).toBe('Candidate');
+    peopleReq.flush([person()]);
+
+    const interviewsReq = httpMock.expectOne(
+      (r) => r.url === '/api/interviews' && r.method === 'GET',
+    );
+    interviewsReq.flush([]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const options = (fixture.componentInstance as unknown as {
+      peopleOptions(): Array<{ label: string; value: string }>;
+    }).peopleOptions();
+    expect(options).toEqual([{ label: 'Alex Candidate', value: 'p1' }]);
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/interviews/interviews-pipeline/interviews-pipeline.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/interviews/interviews-pipeline/interviews-pipeline.component.ts
@@ -149,7 +149,11 @@ export class InterviewsPipelineComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.peopleService.list().subscribe({ next: (p) => this.people.set(p) });
+    // Only Candidate-type people are valid for the New Interview dropdown.
+    // Without this filter the list silently mixes in DirectReports/Stakeholders,
+    // and — more importantly — previously passed no `type` param, which this
+    // component never intended. See issue #120.
+    this.peopleService.list('Candidate').subscribe({ next: (p) => this.people.set(p) });
     this.load();
   }
 

--- a/tests/MentalMetal.Web.IntegrationTests/People/PeopleEndpointsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/People/PeopleEndpointsTests.cs
@@ -79,4 +79,43 @@ public sealed class PeopleEndpointsTests(PostgresFixture postgres) : Integration
         Assert.Single(bodyIncludeArchived!);
         Assert.True(bodyIncludeArchived![0].IsArchived);
     }
+
+    // Regression for issue #120: the New Interview dialog now calls
+    // `GET /api/people?type=Candidate`. The filter must return only Candidate-typed
+    // people and must not regress the implicit-includeArchived=false behaviour (#88).
+    [Fact]
+    public async Task GetPeople_FilterByCandidateType_ReturnsOnlyCandidates()
+    {
+        var client = await AuthedClientAsync();
+
+        var directReport = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Dana DirectReport",
+            type = "DirectReport",
+        });
+        Assert.Equal(HttpStatusCode.Created, directReport.StatusCode);
+
+        var stakeholder = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Sam Stakeholder",
+            type = "Stakeholder",
+        });
+        Assert.Equal(HttpStatusCode.Created, stakeholder.StatusCode);
+
+        var candidate = await client.PostAsJsonAsync("/api/people", new
+        {
+            name = "Alex Candidate",
+            type = "Candidate",
+        });
+        Assert.Equal(HttpStatusCode.Created, candidate.StatusCode);
+
+        var resp = await client.GetAsync("/api/people?type=Candidate");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await ReadJsonAsync<List<PersonBody>>(resp);
+        Assert.NotNull(body);
+        Assert.Single(body!);
+        Assert.Equal("Alex Candidate", body![0].Name);
+        Assert.Equal("Candidate", body![0].Type);
+    }
 }


### PR DESCRIPTION
## Summary

The New Interview dialog at `/interviews` loaded the full people list with no type filter, so its Candidate dropdown either mixed in DirectReports/Stakeholders or — depending on seed data — appeared empty and irrelevant, blocking interview creation via the UI.

Fix: `InterviewsPipelineComponent.ngOnInit` now calls `PeopleService.list('Candidate')` so the dropdown is sourced directly from candidate-typed people. Backend already supported `?type=<PersonType>` on `GET /api/people`; no backend change required.

## Changes

- `interviews-pipeline.component.ts` — pass `'Candidate'` to `PeopleService.list()`
- New `interviews-pipeline.component.spec.ts` — asserts the dialog fetches `/api/people?type=Candidate` on init and populates options from the filtered response
- `PeopleEndpointsTests.cs` — new regression covering `GET /api/people?type=Candidate` (seeds DirectReport / Stakeholder / Candidate; asserts only the candidate is returned); does not regress the #88 implicit-`includeArchived=false` behaviour

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (758 tests)
- [x] `ng test --watch=false` passes (87 tests)
- [ ] Manual: create a Candidate-typed person, open `/interviews` -> New Interview, confirm the candidate appears in the dropdown

Fixes #120

---
Generated with [Claude Code](https://claude.com/claude-code)