### PR TITLE
fix: guard OneOnOne.OccurredAt against pre-2000 dates

### DIFF
--- a/src/MentalMetal.Domain/OneOnOnes/OneOnOne.cs
+++ b/src/MentalMetal.Domain/OneOnOnes/OneOnOne.cs
@@ -4,6 +4,13 @@ namespace MentalMetal.Domain.OneOnOnes;
 
 public sealed class OneOnOne : AggregateRoot, IUserScoped
 {
+    /// <summary>
+    /// Earliest valid date a 1:1 may be recorded on. Prevents default/unset
+    /// <see cref="DateOnly"/> values (e.g. Year 1) being persisted if legacy or
+    /// malformed data bypasses endpoint-level validation.
+    /// </summary>
+    public static readonly DateOnly MinimumOccurredAt = new(2000, 1, 1);
+
     private readonly List<ActionItem> _actionItems = [];
     private readonly List<FollowUp> _followUps = [];
     private readonly List<string> _topics = [];
@@ -33,6 +40,10 @@ public sealed class OneOnOne : AggregateRoot, IUserScoped
             throw new ArgumentException("UserId is required.", nameof(userId));
         if (personId == Guid.Empty)
             throw new ArgumentException("PersonId is required.", nameof(personId));
+        if (occurredAt < MinimumOccurredAt)
+            throw new ArgumentException(
+                $"OccurredAt must be on or after {MinimumOccurredAt:yyyy-MM-dd}.",
+                nameof(occurredAt));
 
         if (moodRating is not null)
             _ = OneOnOnes.MoodRating.Create(moodRating.Value); // validate

--- a/src/MentalMetal.Domain/OneOnOnes/OneOnOne.cs
+++ b/src/MentalMetal.Domain/OneOnOnes/OneOnOne.cs
@@ -41,9 +41,10 @@ public sealed class OneOnOne : AggregateRoot, IUserScoped
         if (personId == Guid.Empty)
             throw new ArgumentException("PersonId is required.", nameof(personId));
         if (occurredAt < MinimumOccurredAt)
-            throw new ArgumentException(
-                $"OccurredAt must be on or after {MinimumOccurredAt:yyyy-MM-dd}.",
-                nameof(occurredAt));
+            throw new ArgumentOutOfRangeException(
+                nameof(occurredAt),
+                occurredAt,
+                $"OccurredAt must be on or after {MinimumOccurredAt:yyyy-MM-dd}.");
 
         if (moodRating is not null)
             _ = OneOnOnes.MoodRating.Create(moodRating.Value); // validate

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { DatePipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
@@ -22,7 +21,6 @@ import { Person } from '../../../shared/models/person.model';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
-    DatePipe,
     ButtonModule,
     DialogModule,
     InputTextModule,
@@ -62,7 +60,7 @@ import { Person } from '../../../shared/models/person.model';
           </ng-template>
           <ng-template #body let-row>
             <tr>
-              <td>{{ row.occurredAt | date: 'mediumDate' }}</td>
+              <td>{{ formatOccurredAt(row.occurredAt) }}</td>
               <td>{{ personName(row.personId) }}</td>
               <td>
                 @if (row.moodRating !== null) { {{ row.moodRating }} / 5 } @else { — }
@@ -145,6 +143,18 @@ export class OneOnOnesListComponent implements OnInit {
 
   protected personName(id: string): string {
     return this.people().find((p) => p.id === id)?.name ?? '(unknown)';
+  }
+
+  /**
+   * Defensively renders a 1:1 date. The API validates OccurredAt >= 2000-01-01,
+   * but legacy rows that bypassed validation can still exist; render them as
+   * an em dash rather than "Jan 1, 1" to avoid user confusion.
+   */
+  protected formatOccurredAt(raw: string | null | undefined): string {
+    if (!raw) return '—';
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime()) || d.getUTCFullYear() < 2000) return '—';
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
   }
 
   ngOnInit(): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/one-on-ones/one-on-ones-list/one-on-ones-list.component.ts
@@ -149,12 +149,20 @@ export class OneOnOnesListComponent implements OnInit {
    * Defensively renders a 1:1 date. The API validates OccurredAt >= 2000-01-01,
    * but legacy rows that bypassed validation can still exist; render them as
    * an em dash rather than "Jan 1, 1" to avoid user confusion.
+   *
+   * `occurredAt` is a DateOnly string (`YYYY-MM-DD`). We parse components
+   * explicitly and format in UTC so the calendar day shown matches what the
+   * user recorded, rather than shifting across midnight in local time.
    */
   protected formatOccurredAt(raw: string | null | undefined): string {
     if (!raw) return '—';
-    const d = new Date(raw);
-    if (Number.isNaN(d.getTime()) || d.getUTCFullYear() < 2000) return '—';
-    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
+    const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (!match) return '—';
+    const year = Number(match[1]);
+    if (year < 2000) return '—';
+    const utc = new Date(Date.UTC(year, Number(match[2]) - 1, Number(match[3])));
+    if (Number.isNaN(utc.getTime())) return '—';
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeZone: 'UTC' }).format(utc);
   }
 
   ngOnInit(): void {

--- a/tests/MentalMetal.Domain.Tests/OneOnOnes/OneOnOneTests.cs
+++ b/tests/MentalMetal.Domain.Tests/OneOnOnes/OneOnOneTests.cs
@@ -54,6 +54,24 @@ public class OneOnOneTests
     }
 
     [Theory]
+    [InlineData(1, 1, 1)]      // DateOnly.MinValue
+    [InlineData(1999, 12, 31)] // boundary-1
+    public void Create_OccurredAtBeforeMinimum_Throws(int year, int month, int day)
+    {
+        var bad = new DateOnly(year, month, day);
+        var ex = Assert.Throws<ArgumentException>(() =>
+            OneOnOne.Create(UserId, PersonId, bad));
+        Assert.Contains("OccurredAt", ex.Message);
+    }
+
+    [Fact]
+    public void Create_OccurredAtAtMinimum_Succeeds()
+    {
+        var o = OneOnOne.Create(UserId, PersonId, OneOnOne.MinimumOccurredAt);
+        Assert.Equal(OneOnOne.MinimumOccurredAt, o.OccurredAt);
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(6)]
     [InlineData(-1)]

--- a/tests/MentalMetal.Domain.Tests/OneOnOnes/OneOnOneTests.cs
+++ b/tests/MentalMetal.Domain.Tests/OneOnOnes/OneOnOneTests.cs
@@ -59,9 +59,9 @@ public class OneOnOneTests
     public void Create_OccurredAtBeforeMinimum_Throws(int year, int month, int day)
     {
         var bad = new DateOnly(year, month, day);
-        var ex = Assert.Throws<ArgumentException>(() =>
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
             OneOnOne.Create(UserId, PersonId, bad));
-        Assert.Contains("OccurredAt", ex.Message);
+        Assert.Equal("occurredAt", ex.ParamName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

During a UX review I found one-on-one rows rendering with date `Jan 1, 1`. The `/api/one-on-ones` endpoint validates `OccurredAt >= 2000-01-01`, but the `OneOnOne.Create` domain method has no such guard, so legacy/malformed rows (default `DateOnly` values from older code paths or migrations) leaked through to the UI.

**Spec**: [people-lens](openspec/specs/people-lens/spec.md)

## Changes

- `OneOnOne.Create` now throws `ArgumentException` when `occurredAt < 2000-01-01` (new `OneOnOne.MinimumOccurredAt` constant)
- 1:1s list defensively renders dates before year 2000 as `—` so stale rows never appear as `Jan 1, 1`
- Removed unused `DatePipe` import from the list component
- Two new domain tests: guard boundary + minimum-date success path

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (476 + 186 + 99 tests green)
- [x] `ng test --watch=false` passes (87 tests green)
- [x] Manual: 1:1s list no longer shows `Jan 1, 1` — pre-2000 rows render as `—`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved date validation for one-on-one records to ensure dates fall within a valid range.
  * Invalid or extremely old dates now display as em dashes rather than potentially incorrect formatting.
  * Added validation to prevent creating one-on-one records with dates earlier than January 1, 2000.

* **Tests**
  * Added unit tests validating one-on-one date constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->