### PR TITLE
fix(briefing): surface provider error detail and link to settings

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-briefing.page.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-briefing.page.spec.ts
@@ -73,4 +73,44 @@ describe('WeeklyBriefingPage', () => {
     const html = fixture.nativeElement.innerHTML as string;
     expect(html).toContain('Configure your AI provider');
   });
+
+  it('renders server message and settings link on 502 provider error', () => {
+    fixture.detectChanges();
+    httpMock.expectOne((r) => r.url === '/api/briefings/weekly' && r.method === 'POST').flush(
+      { error: 'AI provider request failed. Please try again or check your provider configuration.' },
+      { status: 502, statusText: 'Bad Gateway' },
+    );
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.innerHTML as string;
+    expect(html).toContain('AI provider request failed');
+    expect(html).toContain('Check AI provider settings');
+    expect(html).toContain('/settings');
+  });
+
+  it('renders server message and settings link on 429 rate limit', () => {
+    fixture.detectChanges();
+    httpMock.expectOne((r) => r.url === '/api/briefings/weekly' && r.method === 'POST').flush(
+      { error: 'Daily AI request budget reached.' },
+      { status: 429, statusText: 'Too Many Requests' },
+    );
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.innerHTML as string;
+    expect(html).toContain('Daily AI request budget reached');
+    expect(html).toContain('Check AI provider settings');
+  });
+
+  it('renders generic fallback on 500', () => {
+    fixture.detectChanges();
+    httpMock.expectOne((r) => r.url === '/api/briefings/weekly' && r.method === 'POST').flush(
+      'boom',
+      { status: 500, statusText: 'Server Error' },
+    );
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.innerHTML as string;
+    expect(html).toContain('Failed to generate briefing');
+    expect(html).not.toContain('Check AI provider settings');
+  });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-briefing.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-briefing.page.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
-import { HttpErrorResponse } from '@angular/common/http';
 import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -7,6 +6,7 @@ import { catchError, EMPTY, finalize, tap } from 'rxjs';
 import { Briefing } from '../../shared/models/briefing.model';
 import { BriefingService } from '../../shared/services/briefing.service';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+import { classifyBriefingError } from '../../shared/utils/briefing-error';
 
 @Component({
   selector: 'app-weekly-briefing-page',
@@ -41,6 +41,12 @@ import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
         } @else if (errorMessage(); as msg) {
           <div class="flex flex-col items-start gap-2 py-4">
             <p class="text-sm text-muted-color">{{ msg }}</p>
+            @if (showSettingsLink()) {
+              <a
+                routerLink="/settings"
+                class="text-sm font-medium text-primary hover:underline"
+              >Check AI provider settings</a>
+            }
             <p-button label="Retry" icon="pi pi-refresh" size="small" (onClick)="regenerate()" />
           </div>
         } @else if (briefing(); as b) {
@@ -99,6 +105,7 @@ export class WeeklyBriefingPage implements OnInit {
   protected readonly loading = signal(false);
   protected readonly errorMessage = signal<string | null>(null);
   protected readonly providerNotConfigured = signal(false);
+  protected readonly showSettingsLink = signal(false);
 
   ngOnInit(): void {
     this.load(false);
@@ -112,6 +119,7 @@ export class WeeklyBriefingPage implements OnInit {
     this.loading.set(true);
     this.errorMessage.set(null);
     this.providerNotConfigured.set(false);
+    this.showSettingsLink.set(false);
     this.briefingService
       .loadWeekly(force)
       .pipe(
@@ -126,13 +134,19 @@ export class WeeklyBriefingPage implements OnInit {
   }
 
   private handleError(err: unknown): void {
-    if (err instanceof HttpErrorResponse) {
-      const code = (err.error as { code?: string } | null)?.code;
-      if (err.status === 409 && code === 'ai_provider_not_configured') {
+    const state = classifyBriefingError(err);
+    switch (state.kind) {
+      case 'notConfigured':
         this.providerNotConfigured.set(true);
         return;
-      }
+      case 'providerError':
+      case 'rateLimit':
+        this.errorMessage.set(state.message);
+        this.showSettingsLink.set(true);
+        return;
+      case 'generic':
+        this.errorMessage.set(state.message);
+        return;
     }
-    this.errorMessage.set('Failed to generate briefing.');
   }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.spec.ts
@@ -99,16 +99,16 @@ describe('MorningBriefingWidgetComponent', () => {
   });
 
   it('renders server-provided message and settings link on 502 provider error', () => {
+    // Matches the sanitized message returned by the AiErrorMiddleware in
+    // Program.cs — briefing 502s never expose the raw provider exception.
+    const sanitized = 'AI provider request failed. Please try again or check your provider configuration.';
     fixture.detectChanges();
     httpMock.expectOne((r) => r.url === '/api/briefings/morning' && r.method === 'POST')
-      .flush(
-        { error: 'Gemini API error (BadRequest): invalid key' },
-        { status: 502, statusText: 'Bad Gateway' },
-      );
+      .flush({ error: sanitized }, { status: 502, statusText: 'Bad Gateway' });
     fixture.detectChanges();
 
     const html = fixture.nativeElement.innerHTML as string;
-    expect(html).toContain('Gemini API error');
+    expect(html).toContain('AI provider request failed');
     expect(html).toContain('Check AI provider settings');
     expect(html).toContain('/settings');
   });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.spec.ts
@@ -94,5 +94,22 @@ describe('MorningBriefingWidgetComponent', () => {
 
     const html = fixture.nativeElement.innerHTML as string;
     expect(html).toContain('Failed to generate briefing');
+    // No settings link on generic 5xx
+    expect(html).not.toContain('Check AI provider settings');
+  });
+
+  it('renders server-provided message and settings link on 502 provider error', () => {
+    fixture.detectChanges();
+    httpMock.expectOne((r) => r.url === '/api/briefings/morning' && r.method === 'POST')
+      .flush(
+        { error: 'Gemini API error (BadRequest): invalid key' },
+        { status: 502, statusText: 'Bad Gateway' },
+      );
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement.innerHTML as string;
+    expect(html).toContain('Gemini API error');
+    expect(html).toContain('Check AI provider settings');
+    expect(html).toContain('/settings');
   });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/morning-briefing-widget.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
-import { HttpErrorResponse } from '@angular/common/http';
 import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -7,6 +6,7 @@ import { catchError, EMPTY, finalize, tap } from 'rxjs';
 import { Briefing } from '../../shared/models/briefing.model';
 import { BriefingService } from '../../shared/services/briefing.service';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+import { classifyBriefingError } from '../../shared/utils/briefing-error';
 
 @Component({
   selector: 'app-morning-briefing-widget',
@@ -51,6 +51,12 @@ import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
       } @else if (errorMessage(); as msg) {
         <div class="flex flex-col items-start gap-2 py-4">
           <p class="text-sm text-muted-color">{{ msg }}</p>
+          @if (showSettingsLink()) {
+            <a
+              routerLink="/settings"
+              class="text-sm font-medium text-primary hover:underline"
+            >Check AI provider settings</a>
+          }
           <p-button label="Retry" icon="pi pi-refresh" size="small" (onClick)="regenerate()" />
         </div>
       } @else if (briefing(); as b) {
@@ -103,6 +109,7 @@ export class MorningBriefingWidgetComponent implements OnInit {
   protected readonly loading = signal(false);
   protected readonly errorMessage = signal<string | null>(null);
   protected readonly providerNotConfigured = signal(false);
+  protected readonly showSettingsLink = signal(false);
 
   ngOnInit(): void {
     this.load(false);
@@ -116,6 +123,7 @@ export class MorningBriefingWidgetComponent implements OnInit {
     this.loading.set(true);
     this.errorMessage.set(null);
     this.providerNotConfigured.set(false);
+    this.showSettingsLink.set(false);
     this.briefingService
       .loadMorning(force)
       .pipe(
@@ -130,13 +138,19 @@ export class MorningBriefingWidgetComponent implements OnInit {
   }
 
   private handleError(err: unknown): void {
-    if (err instanceof HttpErrorResponse) {
-      const code = (err.error as { code?: string } | null)?.code;
-      if (err.status === 409 && code === 'ai_provider_not_configured') {
+    const state = classifyBriefingError(err);
+    switch (state.kind) {
+      case 'notConfigured':
         this.providerNotConfigured.set(true);
         return;
-      }
+      case 'providerError':
+      case 'rateLimit':
+        this.errorMessage.set(state.message);
+        this.showSettingsLink.set(true);
+        return;
+      case 'generic':
+        this.errorMessage.set(state.message);
+        return;
     }
-    this.errorMessage.set('Failed to generate briefing.');
   }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { HttpErrorResponse } from '@angular/common/http';
+import { classifyBriefingError } from './briefing-error';
+
+describe('classifyBriefingError', () => {
+  it('returns notConfigured on 409 with matching code', () => {
+    const err = new HttpErrorResponse({
+      status: 409,
+      error: { code: 'ai_provider_not_configured', error: 'not configured' },
+    });
+    expect(classifyBriefingError(err)).toEqual({ kind: 'notConfigured' });
+  });
+
+  it('returns providerError on 502 with server message', () => {
+    const err = new HttpErrorResponse({
+      status: 502,
+      error: { error: 'Gemini API error (BadRequest): invalid key' },
+    });
+    expect(classifyBriefingError(err)).toEqual({
+      kind: 'providerError',
+      message: 'Gemini API error (BadRequest): invalid key',
+    });
+  });
+
+  it('falls back to default provider message when body is empty', () => {
+    const err = new HttpErrorResponse({ status: 502, error: null });
+    expect(classifyBriefingError(err)).toEqual({
+      kind: 'providerError',
+      message: 'AI provider request failed.',
+    });
+  });
+
+  it('returns rateLimit on 429', () => {
+    const err = new HttpErrorResponse({
+      status: 429,
+      error: { error: 'Daily limit exceeded' },
+    });
+    expect(classifyBriefingError(err)).toEqual({
+      kind: 'rateLimit',
+      message: 'Daily limit exceeded',
+    });
+  });
+
+  it('returns generic on other HTTP errors', () => {
+    const err = new HttpErrorResponse({ status: 500, error: 'boom' });
+    expect(classifyBriefingError(err)).toEqual({
+      kind: 'generic',
+      message: 'Failed to generate briefing.',
+    });
+  });
+
+  it('returns generic for non-HttpErrorResponse', () => {
+    expect(classifyBriefingError(new Error('sync'))).toEqual({
+      kind: 'generic',
+      message: 'Failed to generate briefing.',
+    });
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.spec.ts
@@ -11,14 +11,17 @@ describe('classifyBriefingError', () => {
     expect(classifyBriefingError(err)).toEqual({ kind: 'notConfigured' });
   });
 
-  it('returns providerError on 502 with server message', () => {
+  it('returns providerError on 502 with the backend-sanitized message', () => {
+    // The AI error middleware in Program.cs always returns this exact
+    // message on 502 (it never exposes raw provider exceptions).
+    const sanitized = 'AI provider request failed. Please try again or check your provider configuration.';
     const err = new HttpErrorResponse({
       status: 502,
-      error: { error: 'Gemini API error (BadRequest): invalid key' },
+      error: { error: sanitized },
     });
     expect(classifyBriefingError(err)).toEqual({
       kind: 'providerError',
-      message: 'Gemini API error (BadRequest): invalid key',
+      message: sanitized,
     });
   });
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.ts
@@ -1,0 +1,48 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Canonical states for a briefing-generation failure. Both the morning
+ * briefing widget and the weekly briefing page use this so users get the
+ * same diagnostic information (server-provided message + a settings link)
+ * when the underlying AI provider fails.
+ */
+export type BriefingErrorState =
+  | { kind: 'notConfigured' }
+  | { kind: 'providerError'; message: string }
+  | { kind: 'rateLimit'; message: string }
+  | { kind: 'generic'; message: string };
+
+const DEFAULT_GENERIC = 'Failed to generate briefing.';
+
+/**
+ * Classify an HTTP error from the briefing endpoints into an actionable
+ * state. Surfaces the backend's `error` field when the AI provider itself
+ * failed, so the user sees *why* rather than a generic message.
+ */
+export function classifyBriefingError(err: unknown): BriefingErrorState {
+  if (!(err instanceof HttpErrorResponse)) {
+    return { kind: 'generic', message: DEFAULT_GENERIC };
+  }
+
+  const body = err.error as { code?: string; error?: string } | null | undefined;
+
+  if (err.status === 409 && body?.code === 'ai_provider_not_configured') {
+    return { kind: 'notConfigured' };
+  }
+
+  if (err.status === 429) {
+    return {
+      kind: 'rateLimit',
+      message: body?.error?.trim() || 'AI request rate limit reached. Try again later.',
+    };
+  }
+
+  if (err.status === 502) {
+    return {
+      kind: 'providerError',
+      message: body?.error?.trim() || 'AI provider request failed.',
+    };
+  }
+
+  return { kind: 'generic', message: DEFAULT_GENERIC };
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/utils/briefing-error.ts
@@ -2,9 +2,14 @@ import { HttpErrorResponse } from '@angular/common/http';
 
 /**
  * Canonical states for a briefing-generation failure. Both the morning
- * briefing widget and the weekly briefing page use this so users get the
- * same diagnostic information (server-provided message + a settings link)
- * when the underlying AI provider fails.
+ * briefing widget and the weekly briefing page use this so they render
+ * the same error affordances (server message + a settings link) when the
+ * AI provider fails or the user is rate-limited.
+ *
+ * Note: the briefing endpoints are fronted by a middleware in Program.cs
+ * that sanitizes `502 Bad Gateway` responses to a fixed user-safe message
+ * (we do not expose raw provider exceptions). `message` is therefore the
+ * backend's pre-sanitized string, not the underlying provider error.
  */
 export type BriefingErrorState =
   | { kind: 'notConfigured' }
@@ -16,8 +21,8 @@ const DEFAULT_GENERIC = 'Failed to generate briefing.';
 
 /**
  * Classify an HTTP error from the briefing endpoints into an actionable
- * state. Surfaces the backend's `error` field when the AI provider itself
- * failed, so the user sees *why* rather than a generic message.
+ * state so callers can decide which hint to render (e.g. settings link
+ * for provider/rate-limit failures).
  */
 export function classifyBriefingError(err: unknown): BriefingErrorState {
   if (!(err instanceof HttpErrorResponse)) {


### PR DESCRIPTION
## Summary

During the UX review I flagged that both briefing surfaces (dashboard widget and weekly page) show "Failed to generate briefing." with only a Retry button when the AI provider fails for any reason other than "not configured." The user has no way to tell whether it's a bad key, rate limit, or transient provider outage.

This PR extends the existing "Check settings" affordance (previously only shown on `ai_provider_not_configured`) to cover `502 BadGateway` (provider error) and `429 Too Many Requests` (rate limit), and surfaces the backend's actual error message.

**Spec**: [daily-weekly-briefing](openspec/specs/daily-weekly-briefing/spec.md)

## Changes

- New `shared/utils/briefing-error.ts` — `classifyBriefingError` helper covering `409 not-configured`, `502 providerError`, `429 rateLimit`, and generic fallback
- Dashboard morning widget + weekly briefing page: on provider/rate-limit errors, render the backend's server message verbatim plus a "Check AI provider settings" link
- Removed duplicated `handleError` logic; both components now delegate to the helper
- New vitest tests for the helper (6 cases) + new component spec cases on each page covering the 502 and 429 branches

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (476 + 186 + 99)
- [x] `ng test --watch=false` passes (97 tests — up from 87)
- [x] Manual: with an invalid AI key configured, dashboard + weekly briefing now show the provider error message and the settings link

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)