### PR TITLE
refactor(sidebar): collapse 16 nav items into 6 verbs + grouped More

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { SidebarComponent } from './sidebar.component';
+
+describe('SidebarComponent', () => {
+  let fixture: ComponentFixture<SidebarComponent>;
+  let router: Router;
+
+  beforeAll(() => {
+    // ThemeService reads window.matchMedia at construction time; the
+    // happy-dom test environment doesn't implement it.
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        value: (query: string) => ({
+          matches: false,
+          media: query,
+          addEventListener: () => undefined,
+          removeEventListener: () => undefined,
+          addListener: () => undefined,
+          removeListener: () => undefined,
+          dispatchEvent: () => false,
+          onchange: null,
+        }),
+      });
+    }
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SidebarComponent],
+      providers: [provideRouter([{ path: '**', children: [] }])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SidebarComponent);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  function html(): string {
+    return fixture.nativeElement.innerHTML as string;
+  }
+
+  it('renders the six primary verbs', () => {
+    const primary = html();
+    expect(primary).toContain('Today');
+    expect(primary).toContain('Chat');
+    expect(primary).toContain('Capture');
+    expect(primary).toContain('People');
+    expect(primary).toContain('Initiatives');
+    expect(primary).toContain('Work');
+  });
+
+  it('hides Work-group children until the group is expanded', () => {
+    expect(html()).not.toContain('My Queue');
+
+    const workToggle = fixture.nativeElement.querySelector(
+      'button[aria-controls="work-group"]',
+    ) as HTMLButtonElement;
+    expect(workToggle).toBeTruthy();
+    workToggle.click();
+    fixture.detectChanges();
+
+    expect(html()).toContain('My Queue');
+    expect(html()).toContain('Commitments');
+    expect(html()).toContain('Delegations');
+    expect(html()).toContain('Nudges');
+    expect(html()).toContain('Close-out');
+  });
+
+  it('hides More-group children until the group is expanded', () => {
+    expect(html()).not.toContain('Observations');
+
+    const moreToggle = fixture.nativeElement.querySelector(
+      'button[aria-controls="more-group"]',
+    ) as HTMLButtonElement;
+    moreToggle.click();
+    fixture.detectChanges();
+
+    expect(html()).toContain('1:1s');
+    expect(html()).toContain('Observations');
+    expect(html()).toContain('Goals');
+    expect(html()).toContain('Interviews');
+    expect(html()).toContain('Weekly Briefing');
+  });
+
+  it('auto-expands the Work group when navigating to a Work child route', async () => {
+    await router.navigateByUrl('/commitments');
+    fixture.detectChanges();
+    // Allow the effect to run
+    fixture.detectChanges();
+
+    expect(html()).toContain('My Queue');
+    expect(html()).toContain('Commitments');
+    expect(html()).not.toContain('Observations');
+  });
+
+  it('auto-expands the More group when navigating to a More child route', async () => {
+    await router.navigateByUrl('/observations');
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    expect(html()).toContain('Observations');
+    expect(html()).toContain('Goals');
+    expect(html()).not.toContain('My Queue');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.spec.ts
@@ -9,9 +9,12 @@ describe('SidebarComponent', () => {
 
   beforeAll(() => {
     // ThemeService reads window.matchMedia at construction time; the
-    // happy-dom test environment doesn't implement it.
+    // happy-dom test environment doesn't implement it. Define as
+    // writable/configurable so other suites can spy on / stub it.
     if (!window.matchMedia) {
       Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
         value: (query: string) => ({
           matches: false,
           media: query,
@@ -37,71 +40,77 @@ describe('SidebarComponent', () => {
     fixture.detectChanges();
   });
 
-  function html(): string {
-    return fixture.nativeElement.innerHTML as string;
+  /** Visible text only — ignores HTML comments / attribute values. */
+  function text(): string {
+    return (fixture.nativeElement.textContent ?? '') as string;
   }
-
-  it('renders the six primary verbs', () => {
-    const primary = html();
-    expect(primary).toContain('Today');
-    expect(primary).toContain('Chat');
-    expect(primary).toContain('Capture');
-    expect(primary).toContain('People');
-    expect(primary).toContain('Initiatives');
-    expect(primary).toContain('Work');
-  });
-
-  it('hides Work-group children until the group is expanded', () => {
-    expect(html()).not.toContain('My Queue');
-
-    const workToggle = fixture.nativeElement.querySelector(
+  function workToggle(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector(
       'button[aria-controls="work-group"]',
     ) as HTMLButtonElement;
-    expect(workToggle).toBeTruthy();
-    workToggle.click();
-    fixture.detectChanges();
-
-    expect(html()).toContain('My Queue');
-    expect(html()).toContain('Commitments');
-    expect(html()).toContain('Delegations');
-    expect(html()).toContain('Nudges');
-    expect(html()).toContain('Close-out');
-  });
-
-  it('hides More-group children until the group is expanded', () => {
-    expect(html()).not.toContain('Observations');
-
-    const moreToggle = fixture.nativeElement.querySelector(
+  }
+  function moreToggle(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector(
       'button[aria-controls="more-group"]',
     ) as HTMLButtonElement;
-    moreToggle.click();
+  }
+  function hasChild(label: string): boolean {
+    const links = Array.from(
+      fixture.nativeElement.querySelectorAll('nav a') as NodeListOf<HTMLElement>,
+    );
+    return links.some((a) => (a.textContent ?? '').trim() === label);
+  }
+
+  it('renders the six primary verbs in visible text', () => {
+    const t = text();
+    for (const label of ['Today', 'Chat', 'Capture', 'People', 'Initiatives', 'Work']) {
+      expect(t).toContain(label);
+    }
+  });
+
+  it('toggles aria-expanded and reveals Work children when expanded', () => {
+    expect(hasChild('My Queue')).toBe(false);
+    expect(workToggle().getAttribute('aria-expanded')).toBe('false');
+
+    workToggle().click();
     fixture.detectChanges();
 
-    expect(html()).toContain('1:1s');
-    expect(html()).toContain('Observations');
-    expect(html()).toContain('Goals');
-    expect(html()).toContain('Interviews');
-    expect(html()).toContain('Weekly Briefing');
+    expect(workToggle().getAttribute('aria-expanded')).toBe('true');
+    for (const label of ['My Queue', 'Commitments', 'Delegations', 'Nudges', 'Close-out']) {
+      expect(hasChild(label)).toBe(true);
+    }
+  });
+
+  it('toggles aria-expanded and reveals More children when expanded', () => {
+    expect(hasChild('Observations')).toBe(false);
+    expect(moreToggle().getAttribute('aria-expanded')).toBe('false');
+
+    moreToggle().click();
+    fixture.detectChanges();
+
+    expect(moreToggle().getAttribute('aria-expanded')).toBe('true');
+    for (const label of ['1:1s', 'Observations', 'Goals', 'Interviews', 'Weekly Briefing']) {
+      expect(hasChild(label)).toBe(true);
+    }
   });
 
   it('auto-expands the Work group when navigating to a Work child route', async () => {
     await router.navigateByUrl('/commitments');
     fixture.detectChanges();
-    // Allow the effect to run
     fixture.detectChanges();
 
-    expect(html()).toContain('My Queue');
-    expect(html()).toContain('Commitments');
-    expect(html()).not.toContain('Observations');
+    expect(workToggle().getAttribute('aria-expanded')).toBe('true');
+    expect(hasChild('Commitments')).toBe(true);
+    expect(hasChild('Observations')).toBe(false);
   });
 
-  it('auto-expands the More group when navigating to a More child route', async () => {
-    await router.navigateByUrl('/observations');
+  it('auto-expands the More group when navigating with a query string', async () => {
+    await router.navigateByUrl('/observations?personId=abc');
     fixture.detectChanges();
     fixture.detectChanges();
 
-    expect(html()).toContain('Observations');
-    expect(html()).toContain('Goals');
-    expect(html()).not.toContain('My Queue');
+    expect(moreToggle().getAttribute('aria-expanded')).toBe('true');
+    expect(hasChild('Observations')).toBe(true);
+    expect(hasChild('My Queue')).toBe(false);
   });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -57,7 +57,7 @@ import { ThemeService } from '../services/theme.service';
       <span class="text-lg font-semibold">Mental Metal</span>
     </div>
 
-    <nav class="flex-1 overflow-y-auto p-3 flex flex-col gap-1">
+    <nav class="flex-1 overflow-y-auto p-3 flex flex-col gap-1" aria-label="Primary">
       <!-- Primary verbs -->
       <a routerLink="/dashboard" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
@@ -213,12 +213,14 @@ export class SidebarComponent {
     { initialValue: this.router.url },
   );
 
+  // Match the group's root segment whether the URL is exact, nested,
+  // or carries a query string / fragment (e.g. /delegations?personId=...).
   private readonly workActive = computed(() =>
-    /^\/(my-queue|commitments|delegations|nudges|close-out)(\/|$)/.test(this.currentUrl()),
+    /^\/(my-queue|commitments|delegations|nudges|close-out)(\/|\?|#|$)/.test(this.currentUrl()),
   );
 
   private readonly moreActive = computed(() =>
-    /^\/(one-on-ones|observations|goals|interviews|briefings)(\/|$)/.test(this.currentUrl()),
+    /^\/(one-on-ones|observations|goals|interviews|briefings)(\/|\?|#|$)/.test(this.currentUrl()),
   );
 
   protected readonly workOpen = signal(false);

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, output, signal } from '@angular/core';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { filter, map, startWith } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ThemeService } from '../services/theme.service';
 
 @Component({
@@ -23,7 +25,7 @@ import { ThemeService } from '../services/theme.service';
       color: var(--p-primary-color);
     }
 
-    nav a {
+    nav a, nav button {
       color: var(--p-text-color);
       transition: background-color 0.15s ease, border-color 0.15s ease;
     }
@@ -37,6 +39,14 @@ import { ThemeService } from '../services/theme.service';
       background-color: var(--p-primary-950);
     }
 
+    .sidebar-group-header {
+      color: var(--p-text-muted-color, var(--p-text-color));
+    }
+
+    .sidebar-child {
+      padding-left: 2.5rem;
+    }
+
     .theme-toggle {
       color: var(--p-text-color);
     }
@@ -47,12 +57,13 @@ import { ThemeService } from '../services/theme.service';
       <span class="text-lg font-semibold">Mental Metal</span>
     </div>
 
-    <nav class="flex-1 p-3 flex flex-col gap-1">
+    <nav class="flex-1 overflow-y-auto p-3 flex flex-col gap-1">
+      <!-- Primary verbs -->
       <a routerLink="/dashboard" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
          (click)="navClick.emit()">
         <i class="pi pi-home"></i>
-        <span>Dashboard</span>
+        <span>Today</span>
       </a>
       <a routerLink="/chat" routerLinkActive="font-semibold sidebar-link-active"
          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
@@ -78,66 +89,96 @@ import { ThemeService } from '../services/theme.service';
         <i class="pi pi-flag"></i>
         <span>Initiatives</span>
       </a>
-      <a routerLink="/commitments" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
+
+      <!-- Work group (queue, commitments, delegations, nudges, close-out) -->
+      <button type="button"
+        class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-group-header"
+        [attr.aria-expanded]="workOpen()"
+        aria-controls="work-group"
+        (click)="workOpen.set(!workOpen())">
         <i class="pi pi-check-square"></i>
-        <span>Commitments</span>
-      </a>
-      <a routerLink="/delegations" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-send"></i>
-        <span>Delegations</span>
-      </a>
-      <a routerLink="/one-on-ones" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-comments"></i>
-        <span>1:1s</span>
-      </a>
-      <a routerLink="/observations" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-eye"></i>
-        <span>Observations</span>
-      </a>
-      <a routerLink="/goals" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-flag"></i>
-        <span>Goals</span>
-      </a>
-      <a routerLink="/interviews" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-briefcase"></i>
-        <span>Interviews</span>
-      </a>
-      <a routerLink="/nudges" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-clock"></i>
-        <span>Nudges</span>
-      </a>
-      <a routerLink="/my-queue" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-list-check"></i>
-        <span>My Queue</span>
-      </a>
-      <a routerLink="/briefings/weekly" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-calendar"></i>
-        <span>Weekly Briefing</span>
-      </a>
-      <a routerLink="/close-out" routerLinkActive="font-semibold sidebar-link-active"
-         class="flex items-center gap-3 px-3 py-2 rounded-md text-sm"
-         (click)="navClick.emit()">
-        <i class="pi pi-inbox"></i>
-        <span>Close-out</span>
-      </a>
+        <span class="flex-1 text-left">Work</span>
+        <i [class]="workOpen() ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" class="text-xs"></i>
+      </button>
+      @if (workOpen()) {
+        <div id="work-group" class="flex flex-col gap-1">
+          <a routerLink="/my-queue" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-list-check"></i>
+            <span>My Queue</span>
+          </a>
+          <a routerLink="/commitments" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-check-square"></i>
+            <span>Commitments</span>
+          </a>
+          <a routerLink="/delegations" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-send"></i>
+            <span>Delegations</span>
+          </a>
+          <a routerLink="/nudges" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-clock"></i>
+            <span>Nudges</span>
+          </a>
+          <a routerLink="/close-out" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-inbox"></i>
+            <span>Close-out</span>
+          </a>
+        </div>
+      }
+
+      <!-- More group (1:1s, observations, goals, interviews, weekly briefing) -->
+      <button type="button"
+        class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-group-header"
+        [attr.aria-expanded]="moreOpen()"
+        aria-controls="more-group"
+        (click)="moreOpen.set(!moreOpen())">
+        <i class="pi pi-ellipsis-h"></i>
+        <span class="flex-1 text-left">More</span>
+        <i [class]="moreOpen() ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" class="text-xs"></i>
+      </button>
+      @if (moreOpen()) {
+        <div id="more-group" class="flex flex-col gap-1">
+          <a routerLink="/one-on-ones" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-comments"></i>
+            <span>1:1s</span>
+          </a>
+          <a routerLink="/observations" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-eye"></i>
+            <span>Observations</span>
+          </a>
+          <a routerLink="/goals" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-flag"></i>
+            <span>Goals</span>
+          </a>
+          <a routerLink="/interviews" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-briefcase"></i>
+            <span>Interviews</span>
+          </a>
+          <a routerLink="/briefings/weekly" routerLinkActive="font-semibold sidebar-link-active"
+             class="flex items-center gap-3 px-3 py-2 rounded-md text-sm sidebar-child"
+             (click)="navClick.emit()">
+            <i class="pi pi-calendar"></i>
+            <span>Weekly Briefing</span>
+          </a>
+        </div>
+      }
     </nav>
 
     <nav class="p-3 border-t sidebar-border flex flex-col gap-1" aria-label="Secondary">
@@ -158,6 +199,37 @@ import { ThemeService } from '../services/theme.service';
   `,
 })
 export class SidebarComponent {
+  private readonly router = inject(Router);
   protected readonly themeService = inject(ThemeService);
   readonly navClick = output<void>();
+
+  /** Current URL, updated on every NavigationEnd. */
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => e.urlAfterRedirects),
+      startWith(this.router.url),
+    ),
+    { initialValue: this.router.url },
+  );
+
+  private readonly workActive = computed(() =>
+    /^\/(my-queue|commitments|delegations|nudges|close-out)(\/|$)/.test(this.currentUrl()),
+  );
+
+  private readonly moreActive = computed(() =>
+    /^\/(one-on-ones|observations|goals|interviews|briefings)(\/|$)/.test(this.currentUrl()),
+  );
+
+  protected readonly workOpen = signal(false);
+  protected readonly moreOpen = signal(false);
+
+  constructor() {
+    // Auto-expand the group when the current route is inside it, so direct
+    // navigation (or a page refresh) shows the active child highlighted.
+    effect(() => {
+      if (this.workActive()) this.workOpen.set(true);
+      if (this.moreActive()) this.moreOpen.set(true);
+    });
+  }
 }


### PR DESCRIPTION
## Summary

UX-review finding #5: the sidebar surfaced all 16 feature pages at the top level, exposing the underlying data model (Observations, Goals, 1:1s, Nudges, Close-out, Weekly Briefing, …) rather than the verbs a manager actually thinks in ("prep for a 1:1", "what's overdue?").

This reorganizes navigation into six primary verbs plus two collapsible groups. **No route changes** — every URL continues to work exactly as before.

## Changes

- **Primary (6 verbs):** Today (Dashboard), Chat, Capture, People, Initiatives, Work
- **Work group** (closed by default): My Queue, Commitments, Delegations, Nudges, Close-out
- **More group** (closed by default): 1:1s, Observations, Goals, Interviews, Weekly Briefing
- **Secondary** (unchanged): Settings, Dark-mode toggle
- Each group **auto-expands** when the current URL matches one of its children, so refreshing on e.g. `/commitments` still highlights the active child.
- `aria-expanded` and `aria-controls` on the group toggles for assistive tech.

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (476 + 186 + 99)
- [x] `ng test --watch=false` passes (102 — includes 5 new sidebar tests covering rendering, toggle-to-expand, and auto-expand on navigation)
- [x] Manual: visit `/commitments` on fresh load → Work group auto-expanded with Commitments highlighted. Visit `/observations` → More group auto-expanded. Click a group header → toggles open/closed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar navigation reorganized into collapsible "Work" and "More" groups for improved organization
  * Navigation groups automatically expand when visiting their associated sections
  * "Dashboard" link renamed to "Today"

* **Tests**
  * Added comprehensive test suite for sidebar component navigation and interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->