### PR TITLE
feat(dashboard): compose briefing with commitments / 1:1s / queue / overdue widgets

### DIFF
--- a/openspec/changes/dashboard-shell/.openspec.yaml
+++ b/openspec/changes/dashboard-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/dashboard-shell/design.md
+++ b/openspec/changes/dashboard-shell/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The dashboard route (`/dashboard`, component `DashboardPage`) currently consists of one child: `<app-morning-briefing-widget />`. The briefing widget handles its own loading / `ai_provider_not_configured` / generic-error states (merged in a prior change). The rest of the "first tab every morning" experience lives on separate routes:
+
+- `/commitments` — open commitments (data via `CommitmentsService` → `GET /api/commitments`)
+- `/people` / person detail — 1:1s (data via `GET /api/one-on-ones`)
+- `/queue` — My Queue ranked items (data via `MyQueueService` → `GET /api/my-queue`)
+- `/delegations` — open delegations (data via `GET /api/delegations`)
+
+All endpoints are user-scoped and already live. The backend has nothing to do.
+
+Zoneless Angular 21 with signals is the rendering model; PrimeNG + `tailwindcss-primeui` own colour. CSS grid is the layout primitive.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Dashboard is useful even when the AI provider is misconfigured or failing.
+- Each widget owns its fetch, loading, error, and empty states in isolation — a failure in one MUST NOT blank the page.
+- Zero new backend code: widgets compose existing endpoints.
+- Layout is responsive: briefing full-width on top; sibling widgets two-column on `lg`+, single column on mobile.
+
+**Non-Goals:**
+- No new API endpoints, DTOs, or aggregates.
+- No change to briefing generation, caching, or synthesis rules.
+- No user-configurable widget visibility / ordering.
+- No rewrite of `/commitments`, `/people`, `/queue`, `/delegations` routes.
+- No drag-and-drop.
+
+## Decisions
+
+### D1: Keep "morning briefing" as the anchor widget; do not move it out of the shell
+The briefing is the narrative summary — its visual prominence (full-width top row) matches its role. Moving it to a sibling slot would dilute the "AI writes your morning for you" product promise. The shell wraps it; it doesn't replace it.
+
+**Alternatives considered:** making all five widgets equal-weight sibling tiles. Rejected — briefing reads like prose and needs horizontal room; the others are lists.
+
+### D2: Widget isolation via per-component fetch boundaries
+Each widget is a standalone component that injects its own service, calls its own endpoint on mount, and renders `loading | error | empty | data` states locally. There is **no** shared dashboard resolver or aggregate fetch. An HTTP 500 on `/api/delegations` degrades only the overdue-summary widget.
+
+**Alternatives considered:** a `DashboardFacadeService` that fans out to all endpoints and exposes a single signal. Rejected — couples widget lifecycles, violates the isolation goal, and would require custom per-source error tracking anyway.
+
+### D3: Reuse existing feature services; do not duplicate HTTP clients
+`CommitmentsService`, `MyQueueService`, `DelegationsService`, and the existing 1:1 list service (under `people-lens` / person-detail area) are already the owners of their endpoints. Widgets call them directly. If a service lacks a "top N" convenience, the widget slices in-memory.
+
+**Alternatives considered:** dedicated `DashboardCommitmentsService` etc. Rejected — duplicates HTTP parsing and caching behaviour.
+
+### D4: Layout uses CSS grid with Tailwind utilities; no custom CSS colours
+```
+grid grid-cols-1 lg:grid-cols-2 gap-6
+  <briefing class="lg:col-span-2" />
+  <commitments /> <one-on-ones />
+  <top-of-queue /> <overdue-summary class="lg:col-span-2" />
+```
+Overdue summary spans full width because it's a one-line count bar. All colours come from PrimeNG tokens (`bg-surface-*`, `text-muted-color`, `text-primary`) per CLAUDE.md.
+
+### D5: Quick-action semantics on commitments widget
+"Mark complete" and "snooze" dispatch via the existing `CommitmentsService` mutation methods used on the commitments page. On success the widget re-fetches its own list; no cross-widget invalidation. Other widgets remain unaffected — matches D2.
+
+### D6: Overdue summary counts, not lists
+This widget is a density signal, not an inbox. It renders `"N commitments overdue · M delegations stale · K unread nudges"` where each number links to the relevant filtered route. If any count source fails, that segment renders `"— commitments overdue"` but the other segments still show. Nudge count degrades gracefully to 0 if nudges-rhythms is not available.
+
+### D7: "Today" is the user-local date
+All widgets that filter by "today" (commitments, 1:1s) compute local date using the browser's timezone at render time. This matches how `daily-weekly-briefing` scopes `scopeKey`, and no backend computation is needed because the endpoints return full datasets that the widgets filter client-side. Acceptable because per-user lists are small (tens to low hundreds).
+
+## Risks / Trade-offs
+
+- **[Fan-out load on dashboard mount]** → Five parallel GETs on first render. Mitigation: all endpoints are already lightweight list reads; widgets render progressively as each response lands.
+- **[Client-side "today" filtering could drift if dataset grows]** → Mitigation: widgets cap to N=5 display items; if datasets exceed ~500 rows, move filtering server-side in a follow-up. Out of scope here.
+- **[Duplicated loading spinners look busy]** → Mitigation: widgets use compact skeleton rows matching their final shape, not spinners, so the page reads as "filling in" rather than "flashing".
+- **[Widget failures can hide important state]** → Mitigation: error state MUST name the failed data source ("Couldn't load commitments") so the user knows to check the full route.
+- **[Regression risk to current briefing widget]** → Mitigation: briefing component is unchanged; only its parent template moves.
+
+## Migration Plan
+
+- Shippable in one PR. No migrations, no feature flag required.
+- Rollback: revert the `dashboard.page.ts` template to the single `<app-morning-briefing-widget />` line; no data implications.
+
+## Open Questions
+
+- Should "Top of queue" show 5 items or follow the user's `TopItemsPerSection` preference if/when we expose one to the frontend? Default **5** for now; revisit if/when `BriefingOptions` is user-configurable.
+- Does the nudges-rhythms capability expose an "unread count" endpoint today? If not, the overdue-summary widget renders "0 unread nudges" as a stub — confirm during apply.
+
+## Dependencies
+
+- `daily-weekly-briefing` (Tier 3) — anchor widget and the capability this delta modifies.
+- `commitment-tracking` (Tier 2) — read-only, `GET /api/commitments`.
+- `delegation-tracking` (Tier 2) — read-only, `GET /api/delegations`.
+- `people-lens` (Tier 2) — read-only, `GET /api/one-on-ones`.
+- `my-queue` (Tier 3) — read-only, `GET /api/my-queue`.
+
+No Tier 1 changes. All dependencies already shipped.

--- a/openspec/changes/dashboard-shell/design.md
+++ b/openspec/changes/dashboard-shell/design.md
@@ -4,7 +4,7 @@ The dashboard route (`/dashboard`, component `DashboardPage`) currently consists
 
 - `/commitments` — open commitments (data via `CommitmentsService` → `GET /api/commitments`)
 - `/people` / person detail — 1:1s (data via `GET /api/one-on-ones`)
-- `/queue` — My Queue ranked items (data via `MyQueueService` → `GET /api/my-queue`)
+- `/my-queue` — My Queue ranked items (data via `MyQueueService` → `GET /api/my-queue`)
 - `/delegations` — open delegations (data via `GET /api/delegations`)
 
 All endpoints are user-scoped and already live. The backend has nothing to do.
@@ -23,7 +23,7 @@ Zoneless Angular 21 with signals is the rendering model; PrimeNG + `tailwindcss-
 - No new API endpoints, DTOs, or aggregates.
 - No change to briefing generation, caching, or synthesis rules.
 - No user-configurable widget visibility / ordering.
-- No rewrite of `/commitments`, `/people`, `/queue`, `/delegations` routes.
+- No rewrite of `/commitments`, `/people`, `/my-queue`, `/delegations` routes.
 - No drag-and-drop.
 
 ## Decisions
@@ -44,16 +44,29 @@ Each widget is a standalone component that injects its own service, calls its ow
 **Alternatives considered:** dedicated `DashboardCommitmentsService` etc. Rejected — duplicates HTTP parsing and caching behaviour.
 
 ### D4: Layout uses CSS grid with Tailwind utilities; no custom CSS colours
-```
-grid grid-cols-1 lg:grid-cols-2 gap-6
-  <briefing class="lg:col-span-2" />
+
+```html
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+  <div class="lg:col-span-2"><briefing /></div>
   <commitments /> <one-on-ones />
-  <top-of-queue /> <overdue-summary class="lg:col-span-2" />
+  <top-of-queue />
+  <div class="lg:col-span-2"><overdue-summary /></div>
+</div>
 ```
-Overdue summary spans full width because it's a one-line count bar. All colours come from PrimeNG tokens (`bg-surface-*`, `text-muted-color`, `text-primary`) per CLAUDE.md.
+
+Overdue summary spans full width because it's a one-line count bar. The
+`lg:col-span-2` utility must live on the grid child (the wrapper), not
+inside the component host, so the browser's grid layout engine sees it.
+All colours come from PrimeNG tokens (`bg-surface-*`, `text-muted-color`,
+`text-primary`) per CLAUDE.md.
 
 ### D5: Quick-action semantics on commitments widget
-"Mark complete" and "snooze" dispatch via the existing `CommitmentsService` mutation methods used on the commitments page. On success the widget re-fetches its own list; no cross-widget invalidation. Other widgets remain unaffected — matches D2.
+Only "Mark complete" is shipped in this change: it calls the existing
+`CommitmentsService.complete(id)` mutation. On success the widget
+re-fetches its own list; no cross-widget invalidation. Snooze was in
+the initial brainstorm but deferred — the commitments API has no first-
+class snooze verb yet, and wiring it here would outpace the backend.
+Filed as a follow-up.
 
 ### D6: Overdue summary counts, not lists
 This widget is a density signal, not an inbox. It renders `"N commitments overdue · M delegations stale · K unread nudges"` where each number links to the relevant filtered route. If any count source fails, that segment renders `"— commitments overdue"` but the other segments still show. Nudge count degrades gracefully to 0 if nudges-rhythms is not available.

--- a/openspec/changes/dashboard-shell/proposal.md
+++ b/openspec/changes/dashboard-shell/proposal.md
@@ -7,7 +7,7 @@ This change turns the dashboard into a composable widget shell: the AI briefing 
 ## What Changes
 
 - Restructure the dashboard route into a responsive widget grid. Morning briefing spans full width at the top; sibling widgets flow in two columns on `lg`+ screens and stack on mobile.
-- Add **Today's commitments** widget — open commitments due today or overdue, with inline "mark complete" / "snooze" actions. Data source: `GET /api/commitments` (already exists, see `commitment-tracking` spec).
+- Add **Today's commitments** widget — open commitments due today or overdue, with an inline "Mark complete" action (Snooze is deferred to a follow-up change). Data source: `GET /api/commitments` (already exists, see `commitment-tracking` spec).
 - Add **Today's 1:1s** widget — OneOnOnes whose `OccurredOnUtc` (local date) equals today. Each row links to the person detail page. Data source: `GET /api/one-on-ones` (already exists, see `people-lens` spec).
 - Add **Top of queue** widget — the top 5 items from My Queue in the queue's existing priority order. Data source: `GET /api/my-queue` (already exists, see `my-queue` spec).
 - Add **Overdue summary** widget — a compact one-line count bar ("N commitments overdue · M delegations stale · K unread nudges"), each count linking to the relevant filtered list. Data source: same endpoints above plus `GET /api/delegations` (already exists, see `delegation-tracking` spec).
@@ -32,7 +32,7 @@ This change turns the dashboard into a composable widget shell: the AI briefing 
 - **Non-goals**:
   - No new API endpoints. All data comes from existing GET endpoints.
   - No change to briefing generation logic, caching rules, or DTOs.
-  - No rewrite of `/commitments`, `/people`, `/queue`, or `/delegations` route layouts — widgets are new views over existing data.
+  - No rewrite of `/commitments`, `/people`, `/my-queue`, or `/delegations` route layouts — widgets are new views over existing data.
   - No drag-and-drop widget reordering, no user-configurable widget visibility.
   - No new aggregates or domain events.
 - **Dependencies** (from spec-plan.md): `daily-weekly-briefing` (anchor), plus read-only consumption of `commitment-tracking`, `delegation-tracking`, `people-lens`, `my-queue`. All already shipped.

--- a/openspec/changes/dashboard-shell/proposal.md
+++ b/openspec/changes/dashboard-shell/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The product brief says the dashboard must be "your first tab every morning" (success criteria #1 and #2). Today the dashboard route renders a single component: `<app-morning-briefing-widget />`. When the user's AI provider is unconfigured or the AI call fails, the page below the error state is blank — nothing actionable. Even on the happy path, every other "what's pulling on me now" signal (commitments due today, 1:1s on the calendar, the top of the queue, overdue counts) lives on a different route the user has to navigate to. The dashboard fails the product promise both when AI works and when it doesn't.
+
+This change turns the dashboard into a composable widget shell: the AI briefing stays as the anchor widget at the top, and four sibling widgets pull live data from existing endpoints so the page is useful on day one, offline-AI or not.
+
+## What Changes
+
+- Restructure the dashboard route into a responsive widget grid. Morning briefing spans full width at the top; sibling widgets flow in two columns on `lg`+ screens and stack on mobile.
+- Add **Today's commitments** widget — open commitments due today or overdue, with inline "mark complete" / "snooze" actions. Data source: `GET /api/commitments` (already exists, see `commitment-tracking` spec).
+- Add **Today's 1:1s** widget — OneOnOnes whose `OccurredOnUtc` (local date) equals today. Each row links to the person detail page. Data source: `GET /api/one-on-ones` (already exists, see `people-lens` spec).
+- Add **Top of queue** widget — the top 5 items from My Queue in the queue's existing priority order. Data source: `GET /api/my-queue` (already exists, see `my-queue` spec).
+- Add **Overdue summary** widget — a compact one-line count bar ("N commitments overdue · M delegations stale · K unread nudges"), each count linking to the relevant filtered list. Data source: same endpoints above plus `GET /api/delegations` (already exists, see `delegation-tracking` spec).
+- Formalise a **widget isolation contract**: every dashboard widget SHALL render its own loading state, its own error state, and a failure in one widget SHALL NOT prevent other widgets from rendering. The briefing widget already does this for HTTP 409 / generic error; this change extends the requirement to all siblings.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. All widget data comes from existing capabilities; this delta composes them on the dashboard route. -->
+
+### Modified Capabilities
+- `daily-weekly-briefing`: adds requirements for a dashboard widget shell that hosts the morning briefing alongside sibling widgets, and a widget-isolation contract. The briefing's existing widget requirement is refined to live inside the shell rather than *be* the dashboard.
+
+## Impact
+
+- **Tier**: Tier 3 delta on `daily-weekly-briefing`. No Tier 1/2 changes.
+- **Affected code**:
+  - `src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts` — replaced inline template with a grid that hosts 5 widgets.
+  - New widget components under `src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/` (one per widget).
+  - Reuses existing services: `CommitmentsService`, `PeopleService` / 1:1 list, `MyQueueService`, `DelegationsService`, `BriefingService`.
+- **No backend changes.** No new endpoints, no DTO changes, no migrations.
+- **Non-goals**:
+  - No new API endpoints. All data comes from existing GET endpoints.
+  - No change to briefing generation logic, caching rules, or DTOs.
+  - No rewrite of `/commitments`, `/people`, `/queue`, or `/delegations` route layouts — widgets are new views over existing data.
+  - No drag-and-drop widget reordering, no user-configurable widget visibility.
+  - No new aggregates or domain events.
+- **Dependencies** (from spec-plan.md): `daily-weekly-briefing` (anchor), plus read-only consumption of `commitment-tracking`, `delegation-tracking`, `people-lens`, `my-queue`. All already shipped.

--- a/openspec/changes/dashboard-shell/specs/daily-weekly-briefing/spec.md
+++ b/openspec/changes/dashboard-shell/specs/daily-weekly-briefing/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: Dashboard widget shell
+
+The frontend SHALL render the authenticated dashboard route (`/dashboard`) as a responsive widget shell rather than a single briefing view. The shell SHALL host the morning briefing widget as a full-width anchor row at the top and SHALL host the following sibling widgets below it: today's commitments, today's 1:1s, top of queue, and overdue summary.
+
+The layout SHALL use CSS grid. On viewports `lg` and wider, sibling widgets SHALL flow in two columns; on narrower viewports, widgets SHALL stack in a single column. The overdue summary widget SHALL span the full width on all breakpoints.
+
+The shell SHALL NOT introduce a shared data-fetch facade: each widget SHALL be a standalone component that owns its own data fetch, loading state, error state, and empty state. Colours SHALL use PrimeNG / `tailwindcss-primeui` tokens; no hardcoded Tailwind colour utilities and no `dark:` prefix. Control flow SHALL use `@if` / `@for` / `@switch`, never `*ngIf` / `*ngFor` / `*ngSwitch`.
+
+#### Scenario: Shell renders all widgets on dashboard load
+
+- **WHEN** an authenticated user navigates to `/dashboard`
+- **THEN** the page renders the morning briefing anchor at the top and the commitments, 1:1s, top-of-queue, and overdue-summary widgets below
+
+#### Scenario: Responsive column behaviour
+
+- **WHEN** the viewport is at least `lg` width
+- **THEN** sibling widgets arrange in two columns and the overdue summary spans both columns
+
+#### Scenario: Mobile stack
+
+- **WHEN** the viewport is narrower than `lg`
+- **THEN** all widgets stack in a single column in the order: briefing, commitments, 1:1s, top of queue, overdue summary
+
+### Requirement: Widget isolation contract
+
+Every widget on the dashboard SHALL be independently resilient: its data fetch, rendering, and error handling MUST be self-contained. A failure (any HTTP error, network failure, or rendering exception) in any one widget MUST NOT prevent any other widget from rendering.
+
+Each widget SHALL render one of four local states: `loading`, `error`, `empty`, or `data`. The `error` state SHALL name the data source that failed so the user can locate it on its full route (for example, "Couldn't load commitments — try the Commitments page"). Widgets MUST NOT share mutable state; actions taken in one widget (for example, marking a commitment complete) MUST refetch only that widget's data.
+
+#### Scenario: Briefing fails, other widgets still render
+
+- **WHEN** the morning briefing endpoint returns HTTP 409 `ai_provider_not_configured`
+- **THEN** the briefing widget renders the "Configure your AI provider" empty state with a settings link, and the commitments, 1:1s, top-of-queue, and overdue-summary widgets render their live data independently
+
+#### Scenario: One sibling widget fails, others still render
+
+- **WHEN** `GET /api/delegations` returns HTTP 500 while the dashboard is loading
+- **THEN** the overdue-summary widget renders "Couldn't load delegations" for the delegations segment, but the commitments, 1:1s, and top-of-queue widgets render their live data and the briefing widget renders its markdown
+
+#### Scenario: Quick action on one widget does not reload others
+
+- **WHEN** the user clicks "Mark complete" on a commitment row in the today's-commitments widget
+- **THEN** only the commitments widget refetches; the briefing, 1:1s, top-of-queue, and overdue-summary widgets do not re-issue their requests
+
+### Requirement: Today's commitments widget
+
+The dashboard SHALL include a "Today's commitments" widget that fetches open commitments from `GET /api/commitments` and displays those whose `DueDate` equals the user's local today OR whose `IsOverdue = true`. The widget SHALL cap the visible list at 5 rows, sorted by (overdue desc, dueDate asc). If more than 5 match, the widget SHALL show a "View all" link to `/commitments`.
+
+Each row SHALL display the commitment description, the counterparty person (if any), the due date, and inline quick actions: "Mark complete" and "Snooze". Actions SHALL call the existing mutation endpoints used on the `/commitments` route. On success the widget SHALL refetch its own list.
+
+When no commitments match, the widget SHALL render an empty-state message ("Nothing due today — nice.").
+
+#### Scenario: Widget lists today's and overdue commitments
+
+- **WHEN** the user has 2 commitments due today and 1 overdue
+- **THEN** the widget renders all 3 rows with overdue first
+
+#### Scenario: Cap at 5 rows with a View all link
+
+- **WHEN** the user has 8 commitments matching today-or-overdue
+- **THEN** the widget renders 5 rows and a "View all" link to `/commitments`
+
+#### Scenario: Mark complete
+
+- **WHEN** the user clicks "Mark complete" on a commitment row
+- **THEN** the mutation fires, the widget refetches, and the row is no longer present
+
+#### Scenario: Empty state
+
+- **WHEN** the user has no commitments due today and none overdue
+- **THEN** the widget renders "Nothing due today — nice."
+
+### Requirement: Today's 1:1s widget
+
+The dashboard SHALL include a "Today's 1:1s" widget that fetches one-on-ones from the existing one-on-ones endpoint and displays those whose `OccurredOnUtc` (or scheduled date equivalent) resolves to the user's local today. Each row SHALL show the person's display name and the scheduled time, and SHALL link to the person detail page.
+
+When no 1:1s are scheduled today, the widget SHALL render an empty-state message ("No 1:1s today.").
+
+#### Scenario: Widget lists today's 1:1s
+
+- **WHEN** the user has 2 OneOnOne records with local-today dates
+- **THEN** the widget renders both rows, each linking to the respective person detail page
+
+#### Scenario: Empty state
+
+- **WHEN** the user has no OneOnOne records for today
+- **THEN** the widget renders "No 1:1s today."
+
+### Requirement: Top of queue widget
+
+The dashboard SHALL include a "Top of queue" widget that fetches `GET /api/my-queue` and renders the top 5 items in the queue's existing priority order (as defined by the `my-queue` capability). Each row SHALL show the item's summary and its queue-rank label, and SHALL link to the item's detail route. The widget SHALL provide a "View all" link to `/queue`.
+
+When the queue is empty, the widget SHALL render an empty-state message ("Queue is empty.").
+
+#### Scenario: Widget shows top 5 queue items
+
+- **WHEN** the user's queue contains 12 items
+- **THEN** the widget renders the top 5 ranked items and a "View all" link to `/queue`
+
+#### Scenario: Empty queue
+
+- **WHEN** the queue has no items
+- **THEN** the widget renders "Queue is empty."
+
+### Requirement: Overdue summary widget
+
+The dashboard SHALL include an "Overdue summary" widget that renders a single compact count bar across three segments: commitments overdue, delegations stale (`IsOverdue = true`), and unread nudges. Counts SHALL be derived from `GET /api/commitments`, `GET /api/delegations`, and the nudges capability respectively. Each count SHALL be a link to the corresponding filtered route.
+
+If a count source fails to load, that segment SHALL render a placeholder ("— commitments overdue") while the other segments continue to render their live values. If the nudges capability is unavailable on the current deployment, the nudges segment SHALL render "0 unread nudges" rather than erroring.
+
+#### Scenario: All counts available
+
+- **WHEN** the user has 3 overdue commitments, 2 stale delegations, and 1 unread nudge
+- **THEN** the widget renders "3 commitments overdue · 2 delegations stale · 1 unread nudge" with each count linking to its filtered route
+
+#### Scenario: Partial source failure
+
+- **WHEN** `GET /api/delegations` returns HTTP 500 and the other sources succeed
+- **THEN** the delegations segment renders "— delegations stale" and the commitments and nudges segments render their live values
+
+## MODIFIED Requirements
+
+### Requirement: Morning briefing dashboard widget
+
+The frontend SHALL render a morning briefing widget on the authenticated dashboard home route, positioned as the full-width anchor row at the top of the dashboard widget shell. The widget SHALL call `POST /api/briefings/morning` on first mount via a signal-based `BriefingService`. The widget SHALL display the rendered markdown, the generated-at timestamp, and a "Regenerate" button that calls the endpoint with `force=true`.
+
+The component SHALL NOT use `*ngIf`, `*ngFor`, `*ngSwitch`, or `[ngClass]`; it SHALL use `@if`, `@for`, `@switch`, `[class.x]` signal-aware syntax. Colours SHALL use PrimeNG / `tailwindcss-primeui` tokens only (no hardcoded Tailwind colour utilities, no `dark:` prefix).
+
+The widget SHALL satisfy the widget isolation contract: its loading, error, and empty states SHALL render locally, and a failure in this widget MUST NOT prevent sibling dashboard widgets from rendering.
+
+#### Scenario: Widget generates a briefing on first visit
+
+- **WHEN** the user lands on the dashboard and no briefing exists yet for today
+- **THEN** the widget displays a loading state, then renders the generated markdown
+
+#### Scenario: Regenerate reuses force=true
+
+- **WHEN** the user clicks "Regenerate"
+- **THEN** the frontend calls `POST /api/briefings/morning?force=true` and re-renders
+
+#### Scenario: Provider-not-configured state
+
+- **WHEN** the endpoint returns HTTP 409 with `ai_provider_not_configured`
+- **THEN** the widget renders a "Configure your AI provider" empty state with a link to settings
+
+#### Scenario: Briefing error does not blank the dashboard
+
+- **WHEN** the briefing endpoint returns any error (409, 500, network failure)
+- **THEN** the widget renders its error or empty state locally and the sibling dashboard widgets (commitments, 1:1s, top of queue, overdue summary) still render their own live data

--- a/openspec/changes/dashboard-shell/specs/daily-weekly-briefing/spec.md
+++ b/openspec/changes/dashboard-shell/specs/daily-weekly-briefing/spec.md
@@ -48,7 +48,9 @@ Each widget SHALL render one of four local states: `loading`, `error`, `empty`, 
 
 The dashboard SHALL include a "Today's commitments" widget that fetches open commitments from `GET /api/commitments` and displays those whose `DueDate` equals the user's local today OR whose `IsOverdue = true`. The widget SHALL cap the visible list at 5 rows, sorted by (overdue desc, dueDate asc). If more than 5 match, the widget SHALL show a "View all" link to `/commitments`.
 
-Each row SHALL display the commitment description, the counterparty person (if any), the due date, and inline quick actions: "Mark complete" and "Snooze". Actions SHALL call the existing mutation endpoints used on the `/commitments` route. On success the widget SHALL refetch its own list.
+Each row SHALL display the commitment description, the due date (if set), an overdue badge when `IsOverdue = true`, and an inline "Mark complete" quick action. The action SHALL call the existing `POST /api/commitments/{id}/complete` endpoint used on the `/commitments` route. On success the widget SHALL refetch its own list. A row's action button SHALL be disabled and show a loading indicator while the mutation is in flight.
+
+(Snooze was considered but is deferred to a follow-up change — the backend has no first-class snooze verb today.)
 
 When no commitments match, the widget SHALL render an empty-state message ("Nothing due today — nice.").
 
@@ -74,7 +76,7 @@ When no commitments match, the widget SHALL render an empty-state message ("Noth
 
 ### Requirement: Today's 1:1s widget
 
-The dashboard SHALL include a "Today's 1:1s" widget that fetches one-on-ones from the existing one-on-ones endpoint and displays those whose `OccurredOnUtc` (or scheduled date equivalent) resolves to the user's local today. Each row SHALL show the person's display name and the scheduled time, and SHALL link to the person detail page.
+The dashboard SHALL include a "Today's 1:1s" widget that fetches one-on-ones from the existing one-on-ones endpoint and displays those whose `OccurredAt` (a `DateOnly`) resolves to the user's local today. Each row SHALL show the person's display name and link to the person detail page. (The underlying aggregate does not carry a scheduled time — date-only suffices.)
 
 When no 1:1s are scheduled today, the widget SHALL render an empty-state message ("No 1:1s today.").
 
@@ -90,14 +92,14 @@ When no 1:1s are scheduled today, the widget SHALL render an empty-state message
 
 ### Requirement: Top of queue widget
 
-The dashboard SHALL include a "Top of queue" widget that fetches `GET /api/my-queue` and renders the top 5 items in the queue's existing priority order (as defined by the `my-queue` capability). Each row SHALL show the item's summary and its queue-rank label, and SHALL link to the item's detail route. The widget SHALL provide a "View all" link to `/queue`.
+The dashboard SHALL include a "Top of queue" widget that fetches `GET /api/my-queue` and renders the top 5 items in the queue's existing priority order (as defined by the `my-queue` capability). Each row SHALL show the item's summary and its queue-rank label, and SHALL link to the item's detail route. The widget SHALL provide a "View all" link to `/my-queue`.
 
 When the queue is empty, the widget SHALL render an empty-state message ("Queue is empty.").
 
 #### Scenario: Widget shows top 5 queue items
 
 - **WHEN** the user's queue contains 12 items
-- **THEN** the widget renders the top 5 ranked items and a "View all" link to `/queue`
+- **THEN** the widget renders the top 5 ranked items and a "View all" link to `/my-queue`
 
 #### Scenario: Empty queue
 
@@ -106,7 +108,7 @@ When the queue is empty, the widget SHALL render an empty-state message ("Queue 
 
 ### Requirement: Overdue summary widget
 
-The dashboard SHALL include an "Overdue summary" widget that renders a single compact count bar across three segments: commitments overdue, delegations stale (`IsOverdue = true`), and unread nudges. Counts SHALL be derived from `GET /api/commitments`, `GET /api/delegations`, and the nudges capability respectively. Each count SHALL be a link to the corresponding filtered route.
+The dashboard SHALL include an "Overdue summary" widget that renders a single compact count bar across three segments: commitments overdue, delegations stale, and unread nudges. Commitments overdue counts are derived from `GET /api/commitments?overdue=true`. A delegation is considered stale when it is not Completed and either (a) its `DueDate` is in the past (local day) or (b) its last follow-up — or its creation time if never followed up — is older than 7 days. Unread-nudge counts come from the nudges capability when available. Each count SHALL be a link to the corresponding filtered route.
 
 If a count source fails to load, that segment SHALL render a placeholder ("— commitments overdue") while the other segments continue to render their live values. If the nudges capability is unavailable on the current deployment, the nudges segment SHALL render "0 unread nudges" rather than erroring.
 

--- a/openspec/changes/dashboard-shell/tasks.md
+++ b/openspec/changes/dashboard-shell/tasks.md
@@ -1,0 +1,49 @@
+## 1. Dashboard shell layout
+
+- [ ] 1.1 Replace the `DashboardPage` template with a responsive CSS-grid shell (`grid grid-cols-1 lg:grid-cols-2 gap-6`) that hosts the briefing as `lg:col-span-2` and reserves slots for the four sibling widgets.
+- [ ] 1.2 Keep `MorningBriefingWidgetComponent` unchanged — only its parent moves. Confirm no colour regressions (PrimeNG tokens only).
+- [ ] 1.3 Verify existing E2E / component tests for the dashboard route still pass; update any selector-specific assertions to account for the new grid wrapper.
+
+## 2. Today's commitments widget
+
+- [ ] 2.1 Create `TodaysCommitmentsWidgetComponent` (standalone, OnPush, signals) under `src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/`.
+- [ ] 2.2 Inject the existing `CommitmentsService`; fetch on mount, filter to `DueDate == local today || IsOverdue`, sort (overdue desc, dueDate asc), cap at 5.
+- [ ] 2.3 Implement `loading | error | empty | data` render states using `@if` / `@switch`; error copy names the source ("Couldn't load commitments").
+- [ ] 2.4 Add inline "Mark complete" and "Snooze" quick actions that call existing `CommitmentsService` mutations and refetch only this widget.
+- [ ] 2.5 Add "View all" link to `/commitments` when more than 5 items match.
+- [ ] 2.6 Add component unit tests: loading/empty/data states, 5-row cap, mark-complete refetches only this widget.
+
+## 3. Today's 1:1s widget
+
+- [ ] 3.1 Create `TodaysOneOnOnesWidgetComponent` (standalone, OnPush, signals).
+- [ ] 3.2 Fetch via the existing one-on-ones service; filter to records whose scheduled/occurred local date equals today.
+- [ ] 3.3 Implement the four local render states; each row links to the person detail route.
+- [ ] 3.4 Add component unit tests for empty and populated states.
+
+## 4. Top of queue widget
+
+- [ ] 4.1 Create `TopOfQueueWidgetComponent` (standalone, OnPush, signals).
+- [ ] 4.2 Inject `MyQueueService`; take the top 5 items in existing queue order.
+- [ ] 4.3 Implement the four local render states; each row links to the queue item detail route; include a "View all" link to `/queue`.
+- [ ] 4.4 Add component unit tests for empty, populated, and error states.
+
+## 5. Overdue summary widget
+
+- [ ] 5.1 Create `OverdueSummaryWidgetComponent` (standalone, OnPush, signals) spanning `lg:col-span-2`.
+- [ ] 5.2 Fetch commitments, delegations, and nudges counts in parallel; track each source's status independently.
+- [ ] 5.3 Render a single count bar: "N commitments overdue · M delegations stale · K unread nudges"; each count is a link.
+- [ ] 5.4 When one source fails, render that segment as "— <label>" while other segments show live values; when nudges capability is unavailable, render "0 unread nudges".
+- [ ] 5.5 Add component unit tests covering all-succeed, partial-failure, and all-fail scenarios.
+
+## 6. Shell composition and isolation tests
+
+- [ ] 6.1 Wire all four widgets into the dashboard shell template alongside the existing briefing widget.
+- [ ] 6.2 Add a shell-level component test that forces the briefing endpoint to 409 and asserts sibling widgets still render their data.
+- [ ] 6.3 Add a shell-level component test that forces one sibling endpoint to 500 and asserts the other four widgets render normally.
+- [ ] 6.4 Add an E2E test (`tests/MentalMetal.E2E.Tests/`) that logs in and asserts all five widget slots render on `/dashboard`.
+
+## 7. Documentation and polish
+
+- [ ] 7.1 Verify CLAUDE.md rules: no `*ngIf` / `*ngFor` / `*ngSwitch` / `[ngClass]`, no hardcoded Tailwind colour utilities, no `dark:` prefix, PrimeNG tokens only.
+- [ ] 7.2 Run `dotnet test src/MentalMetal.slnx`, `npx ng test --watch=false`, and the E2E suite locally.
+- [ ] 7.3 Update `openspec/specs/daily-weekly-briefing/spec.md` via `/opsx:sync` after PR merge (sync is a separate step after archive; noted here for traceability).

--- a/openspec/changes/dashboard-shell/tasks.md
+++ b/openspec/changes/dashboard-shell/tasks.md
@@ -24,7 +24,7 @@
 
 - [ ] 4.1 Create `TopOfQueueWidgetComponent` (standalone, OnPush, signals).
 - [ ] 4.2 Inject `MyQueueService`; take the top 5 items in existing queue order.
-- [ ] 4.3 Implement the four local render states; each row links to the queue item detail route; include a "View all" link to `/queue`.
+- [ ] 4.3 Implement the four local render states; each row links to the queue item detail route; include a "View all" link to `/my-queue`.
 - [ ] 4.4 Add component unit tests for empty, populated, and error states.
 
 ## 5. Overdue summary widget

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard-shell.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard-shell.spec.ts
@@ -1,0 +1,104 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DashboardPage } from './dashboard.page';
+
+/**
+ * Shell-level test: asserts the widget isolation contract. When the
+ * briefing endpoint fails, sibling widgets must still render their
+ * data; when a sibling fails, siblings must still render.
+ */
+describe('Dashboard shell (widget isolation)', () => {
+  let fixture: ComponentFixture<DashboardPage>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardPage],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: '**', children: [] }]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardPage);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  function flush(url: string, body: object | string | null, status = 200): void {
+    const req = http.match((r) => r.url === url || r.url.startsWith(url + '?'));
+    for (const r of req) {
+      if (status >= 400) {
+        r.flush(body as string, { status, statusText: 'Error' });
+      } else {
+        r.flush(body as object);
+      }
+    }
+  }
+
+  it('renders each widget section', () => {
+    fixture.detectChanges();
+
+    // Match and drain each endpoint the widgets fetch from.
+    flush('/api/briefings/morning', { id: 'b', type: 'Morning', markdownBody: '# hi', generatedAtUtc: '2026-04-16T08:00:00Z', model: 'm', inputTokens: 0, outputTokens: 0, factsSummary: {}, scopeKey: 's' });
+    flush('/api/commitments', []);
+    flush('/api/one-on-ones', []);
+    flush('/api/people', []);
+    flush('/api/my-queue', { items: [], counts: { overdue: 0, dueSoon: 0, staleCaptures: 0, staleDelegations: 0, total: 0 }, filters: { scope: 'All', itemType: [], personId: null, initiativeId: null } });
+    flush('/api/delegations', []);
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("Today's commitments");
+    expect(text).toContain("Today's 1:1s");
+    expect(text).toContain('Top of your queue');
+    expect(text).toContain("What's slipping");
+  });
+
+  it('sibling widgets still render data when the briefing endpoint fails', () => {
+    fixture.detectChanges();
+
+    flush('/api/briefings/morning', { error: 'nope' }, 500);
+    flush('/api/commitments', [
+      { id: 'c1', userId: 'u', description: 'Important thing', direction: 'MineToThem', personId: 'p', initiativeId: null, sourceCaptureId: null, dueDate: new Date().toISOString().slice(0, 10), status: 'Open', completedAt: null, notes: null, isOverdue: false, createdAt: '2026-04-01T00:00:00Z', updatedAt: '2026-04-01T00:00:00Z' },
+    ]);
+    flush('/api/one-on-ones', []);
+    flush('/api/people', []);
+    flush('/api/my-queue', { items: [], counts: { overdue: 0, dueSoon: 0, staleCaptures: 0, staleDelegations: 0, total: 0 }, filters: { scope: 'All', itemType: [], personId: null, initiativeId: null } });
+    flush('/api/delegations', []);
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    // Briefing widget shows failure
+    expect(text).toContain('Failed to generate briefing');
+    // Sibling rendered its data
+    expect(text).toContain('Important thing');
+  });
+
+  it('other widgets render even if commitments fails', () => {
+    fixture.detectChanges();
+
+    flush('/api/briefings/morning', { id: 'b', type: 'Morning', markdownBody: '# hi', generatedAtUtc: '2026-04-16T08:00:00Z', model: 'm', inputTokens: 0, outputTokens: 0, factsSummary: {}, scopeKey: 's' });
+    flush('/api/commitments', 'boom', 500);
+    flush('/api/one-on-ones', []);
+    flush('/api/people', []);
+    flush('/api/my-queue', { items: [], counts: { overdue: 0, dueSoon: 0, staleCaptures: 0, staleDelegations: 0, total: 0 }, filters: { scope: 'All', itemType: [], personId: null, initiativeId: null } });
+    flush('/api/delegations', []);
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    // Commitments widget shows its local error
+    expect(text).toContain("Couldn't load commitments");
+    // Other widgets still render headings and empty states
+    expect(text).toContain("Today's 1:1s");
+    expect(text).toContain('Top of your queue');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard-shell.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard-shell.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { DashboardPage } from './dashboard.page';
+import { todayLocalIso } from './widget-shell';
 
 /**
  * Shell-level test: asserts the widget isolation contract. When the
@@ -30,8 +31,11 @@ describe('Dashboard shell (widget isolation)', () => {
 
   afterEach(() => http.verify());
 
+  /** Matches r.url exactly OR r.url with a query string — not prefix soups. */
   function flush(url: string, body: object | string | null, status = 200): void {
-    const req = http.match((r) => r.url === url || r.url.startsWith(url + '?'));
+    const req = http.match(
+      (r) => r.url === url || r.url.startsWith(url + '?'),
+    );
     for (const r of req) {
       if (status >= 400) {
         r.flush(body as string, { status, statusText: 'Error' });
@@ -66,7 +70,7 @@ describe('Dashboard shell (widget isolation)', () => {
 
     flush('/api/briefings/morning', { error: 'nope' }, 500);
     flush('/api/commitments', [
-      { id: 'c1', userId: 'u', description: 'Important thing', direction: 'MineToThem', personId: 'p', initiativeId: null, sourceCaptureId: null, dueDate: new Date().toISOString().slice(0, 10), status: 'Open', completedAt: null, notes: null, isOverdue: false, createdAt: '2026-04-01T00:00:00Z', updatedAt: '2026-04-01T00:00:00Z' },
+      { id: 'c1', userId: 'u', description: 'Important thing', direction: 'MineToThem', personId: 'p', initiativeId: null, sourceCaptureId: null, dueDate: todayLocalIso(), status: 'Open', completedAt: null, notes: null, isOverdue: false, createdAt: '2026-04-01T00:00:00Z', updatedAt: '2026-04-01T00:00:00Z' },
     ]);
     flush('/api/one-on-ones', []);
     flush('/api/people', []);

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
@@ -1,19 +1,47 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MorningBriefingWidgetComponent } from './morning-briefing-widget.component';
+import { TodaysCommitmentsWidgetComponent } from './todays-commitments-widget.component';
+import { TodaysOneOnOnesWidgetComponent } from './todays-one-on-ones-widget.component';
+import { TopOfQueueWidgetComponent } from './top-of-queue-widget.component';
+import { OverdueSummaryWidgetComponent } from './overdue-summary-widget.component';
 
+/**
+ * Dashboard shell: responsive grid that composes independent widgets so
+ * the page is useful even when any one widget (including the AI briefing)
+ * fails. See openspec/specs/daily-weekly-briefing/spec.md and
+ * openspec/changes/dashboard-shell/ for the isolation contract.
+ */
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MorningBriefingWidgetComponent],
+  imports: [
+    MorningBriefingWidgetComponent,
+    TodaysCommitmentsWidgetComponent,
+    TodaysOneOnOnesWidgetComponent,
+    TopOfQueueWidgetComponent,
+    OverdueSummaryWidgetComponent,
+  ],
   template: `
-    <div class="flex flex-col gap-6 max-w-3xl mx-auto">
-      <header class="flex flex-col gap-2">
-        <h1 class="text-2xl font-bold">Dashboard</h1>
+    <div class="flex flex-col gap-4 max-w-5xl mx-auto">
+      <header class="flex flex-col gap-1">
+        <h1 class="text-2xl font-bold">Today</h1>
         <p class="text-sm text-muted-color">Your day at a glance.</p>
       </header>
 
-      <app-morning-briefing-widget />
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Briefing anchors the top, full width -->
+        <div class="lg:col-span-2">
+          <app-morning-briefing-widget />
+        </div>
+
+        <app-todays-commitments-widget />
+        <app-todays-one-on-ones-widget />
+        <app-top-of-queue-widget />
+
+        <!-- Overdue summary spans full width as a one-line glance -->
+        <app-overdue-summary-widget />
+      </div>
     </div>
   `,
 })

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
@@ -39,8 +39,12 @@ import { OverdueSummaryWidgetComponent } from './overdue-summary-widget.componen
         <app-todays-one-on-ones-widget />
         <app-top-of-queue-widget />
 
-        <!-- Overdue summary spans full width as a one-line glance -->
-        <app-overdue-summary-widget />
+        <!-- Overdue summary spans full width as a one-line glance. The
+             lg:col-span-2 must live on the grid child (this wrapper),
+             not inside the component host. -->
+        <div class="lg:col-span-2">
+          <app-overdue-summary-widget />
+        </div>
       </div>
     </div>
   `,

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/overdue-summary-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/overdue-summary-widget.component.ts
@@ -1,0 +1,116 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { catchError, finalize, of, tap } from 'rxjs';
+import { CommitmentsService } from '../../shared/services/commitments.service';
+import { DelegationsService } from '../../shared/services/delegations.service';
+
+interface SummaryCount {
+  loaded: boolean;
+  failed: boolean;
+  value: number;
+}
+
+const emptyCount = (): SummaryCount => ({ loaded: false, failed: false, value: 0 });
+
+/**
+ * Single-row glance of overdue work across sources. Each source tracks
+ * its own status so a failure in one is shown as "—" while the others
+ * keep rendering live values — the isolation contract the dashboard
+ * shell promises.
+ *
+ * Unread nudges is stubbed at 0 until a GET /api/nudges/unread-count (or
+ * equivalent) endpoint is available (tracked in the change's design.md).
+ */
+@Component({
+  selector: 'app-overdue-summary-widget',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  template: `
+    <section
+      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50 lg:col-span-2"
+      aria-label="Overdue summary"
+    >
+      <h2 class="text-lg font-semibold">What's slipping</h2>
+      <p class="text-sm flex flex-wrap items-center gap-x-2">
+        <a
+          routerLink="/commitments"
+          class="text-primary hover:underline font-medium"
+        >{{ display(commitments()) }} commitments overdue</a>
+        <span class="text-muted-color">·</span>
+        <a
+          routerLink="/delegations"
+          class="text-primary hover:underline font-medium"
+        >{{ display(delegations()) }} delegations stale</a>
+        <span class="text-muted-color">·</span>
+        <a
+          routerLink="/nudges"
+          class="text-primary hover:underline font-medium"
+        >{{ display(nudges()) }} unread nudges</a>
+      </p>
+    </section>
+  `,
+})
+export class OverdueSummaryWidgetComponent implements OnInit {
+  private readonly commitmentsService = inject(CommitmentsService);
+  private readonly delegationsService = inject(DelegationsService);
+
+  protected readonly commitments = signal<SummaryCount>(emptyCount());
+  protected readonly delegations = signal<SummaryCount>(emptyCount());
+  // Nudges currently has no unread-count endpoint; render "0" until one
+  // is added. Marked loaded so the UI doesn't show a placeholder.
+  protected readonly nudges = signal<SummaryCount>({ loaded: true, failed: false, value: 0 });
+
+  ngOnInit(): void {
+    this.loadCommitments();
+    this.loadDelegations();
+  }
+
+  protected display(c: SummaryCount): string {
+    if (c.failed) return '—';
+    if (!c.loaded) return '…';
+    return String(c.value);
+  }
+
+  private loadCommitments(): void {
+    this.commitmentsService
+      .list(undefined, 'Open', undefined, undefined, true)
+      .pipe(
+        tap((list) => this.commitments.set({ loaded: true, failed: false, value: list.length })),
+        catchError(() => {
+          this.commitments.set({ loaded: true, failed: true, value: 0 });
+          return of(null);
+        }),
+        finalize(() => undefined),
+      )
+      .subscribe();
+  }
+
+  private loadDelegations(): void {
+    this.delegationsService
+      .list()
+      .pipe(
+        tap((list) => {
+          // "Stale" = active delegation (not completed) that is either
+          // past its due date or hasn't been followed up in >7 days.
+          const sevenDaysAgoMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+          const today = new Date().toISOString().slice(0, 10);
+          const stale = list.filter((d) => {
+            if (d.status === 'Completed') return false;
+            if (d.dueDate && d.dueDate.slice(0, 10) < today) return true;
+            if (d.lastFollowedUpAt) {
+              return new Date(d.lastFollowedUpAt).getTime() < sevenDaysAgoMs;
+            }
+            // No follow-up yet — consider stale if created >7 days ago.
+            return new Date(d.createdAt).getTime() < sevenDaysAgoMs;
+          }).length;
+          this.delegations.set({ loaded: true, failed: false, value: stale });
+        }),
+        catchError(() => {
+          this.delegations.set({ loaded: true, failed: true, value: 0 });
+          return of(null);
+        }),
+      )
+      .subscribe();
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/overdue-summary-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/overdue-summary-widget.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { catchError, finalize, of, tap } from 'rxjs';
+import { catchError, of, tap } from 'rxjs';
 import { CommitmentsService } from '../../shared/services/commitments.service';
 import { DelegationsService } from '../../shared/services/delegations.service';
+import { todayLocalIso, toLocalDateKey } from './widget-shell';
 
 interface SummaryCount {
   loaded: boolean;
@@ -28,7 +29,7 @@ const emptyCount = (): SummaryCount => ({ loaded: false, failed: false, value: 0
   imports: [RouterLink],
   template: `
     <section
-      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50 lg:col-span-2"
+      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50"
       aria-label="Overdue summary"
     >
       <h2 class="text-lg font-semibold">What's slipping</h2>
@@ -81,7 +82,6 @@ export class OverdueSummaryWidgetComponent implements OnInit {
           this.commitments.set({ loaded: true, failed: true, value: 0 });
           return of(null);
         }),
-        finalize(() => undefined),
       )
       .subscribe();
   }
@@ -92,12 +92,13 @@ export class OverdueSummaryWidgetComponent implements OnInit {
       .pipe(
         tap((list) => {
           // "Stale" = active delegation (not completed) that is either
-          // past its due date or hasn't been followed up in >7 days.
+          // past its due date (local day) or hasn't been followed up in >7 days.
           const sevenDaysAgoMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
-          const today = new Date().toISOString().slice(0, 10);
+          const today = todayLocalIso();
           const stale = list.filter((d) => {
             if (d.status === 'Completed') return false;
-            if (d.dueDate && d.dueDate.slice(0, 10) < today) return true;
+            const dueKey = toLocalDateKey(d.dueDate);
+            if (dueKey && dueKey < today) return true;
             if (d.lastFollowedUpAt) {
               return new Date(d.lastFollowedUpAt).getTime() < sevenDaysAgoMs;
             }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TodaysCommitmentsWidgetComponent } from './todays-commitments-widget.component';
+import { Commitment } from '../../shared/models/commitment.model';
+
+describe('TodaysCommitmentsWidgetComponent', () => {
+  let fixture: ComponentFixture<TodaysCommitmentsWidgetComponent>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TodaysCommitmentsWidgetComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: '**', children: [] }]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TodaysCommitmentsWidgetComponent);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  function today(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  function make(overrides: Partial<Commitment> = {}): Commitment {
+    return {
+      id: 'c1',
+      userId: 'u1',
+      description: 'Ship the spec',
+      direction: 'MineToThem',
+      personId: 'p1',
+      initiativeId: null,
+      sourceCaptureId: null,
+      dueDate: today(),
+      status: 'Open',
+      completedAt: null,
+      notes: null,
+      isOverdue: false,
+      createdAt: '2026-04-01T00:00:00Z',
+      updatedAt: '2026-04-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('renders empty state when no commitments match', () => {
+    fixture.detectChanges();
+    http.expectOne((r) => r.url.startsWith('/api/commitments')).flush([]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('clear inbox');
+  });
+
+  it('shows overdue commitments before today-due ones, capped at 5', () => {
+    fixture.detectChanges();
+    const overdue = make({ id: 'a', description: 'Overdue A', isOverdue: true, dueDate: '2026-01-01' });
+    const dueToday = [1, 2, 3, 4, 5, 6].map((n) =>
+      make({ id: 'd' + n, description: `Due ${n}`, isOverdue: false, dueDate: today() }),
+    );
+    http
+      .expectOne((r) => r.url.startsWith('/api/commitments'))
+      .flush([...dueToday, overdue]);
+    fixture.detectChanges();
+
+    const listItems = fixture.nativeElement.querySelectorAll('li');
+    expect(listItems.length).toBe(5);
+    // Overdue always first
+    expect((listItems[0] as HTMLElement).textContent).toContain('Overdue A');
+  });
+
+  it('renders error state on failure and allows retry', () => {
+    fixture.detectChanges();
+    http.expectOne((r) => r.url.startsWith('/api/commitments'))
+      .flush('boom', { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Couldn't load commitments");
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.spec.ts
@@ -5,6 +5,7 @@ import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TodaysCommitmentsWidgetComponent } from './todays-commitments-widget.component';
 import { Commitment } from '../../shared/models/commitment.model';
+import { todayLocalIso } from './widget-shell';
 
 describe('TodaysCommitmentsWidgetComponent', () => {
   let fixture: ComponentFixture<TodaysCommitmentsWidgetComponent>;
@@ -26,8 +27,10 @@ describe('TodaysCommitmentsWidgetComponent', () => {
 
   afterEach(() => http.verify());
 
+  // Local calendar day — matches the widget's filtering so the tests
+  // don't flake around local midnight in non-UTC timezones.
   function today(): string {
-    return new Date().toISOString().slice(0, 10);
+    return todayLocalIso();
   }
 
   function make(overrides: Partial<Commitment> = {}): Commitment {
@@ -55,7 +58,7 @@ describe('TodaysCommitmentsWidgetComponent', () => {
     http.expectOne((r) => r.url.startsWith('/api/commitments')).flush([]);
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).toContain('clear inbox');
+    expect(fixture.nativeElement.textContent).toContain('Nothing due today');
   });
 
   it('shows overdue commitments before today-due ones, capped at 5', () => {
@@ -75,12 +78,40 @@ describe('TodaysCommitmentsWidgetComponent', () => {
     expect((listItems[0] as HTMLElement).textContent).toContain('Overdue A');
   });
 
-  it('renders error state on failure and allows retry', () => {
+  it('renders error state on failure and Retry re-fetches', () => {
     fixture.detectChanges();
     http.expectOne((r) => r.url.startsWith('/api/commitments'))
       .flush('boom', { status: 500, statusText: 'Server Error' });
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain("Couldn't load commitments");
+
+    // Click the Retry button (PrimeNG renders a native <button> inside p-button).
+    const retry = Array.from(fixture.nativeElement.querySelectorAll('button'))
+      .find((b) => ((b as HTMLElement).textContent ?? '').trim().toLowerCase() === 'retry') as HTMLButtonElement | undefined;
+    expect(retry, 'retry button').toBeDefined();
+    retry!.click();
+    fixture.detectChanges();
+
+    // A second request was issued by Retry.
+    http.expectOne((r) => r.url.startsWith('/api/commitments')).flush([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Nothing due today');
+  });
+
+  it('Mark complete posts and re-fetches only this widget', () => {
+    fixture.detectChanges();
+    const row = make({ id: 'c-today', description: 'Finish X', dueDate: today() });
+    http.expectOne((r) => r.url.startsWith('/api/commitments')).flush([row]);
+    fixture.detectChanges();
+
+    const btn = Array.from(fixture.nativeElement.querySelectorAll('button'))
+      .find((b) => (b as HTMLElement).getAttribute('aria-label') === 'Mark complete') as HTMLButtonElement | undefined;
+    expect(btn, 'mark-complete button').toBeDefined();
+    btn!.click();
+
+    http.expectOne((r) => r.url === '/api/commitments/c-today/complete' && r.method === 'POST').flush({});
+    // After complete, the widget re-fetches the list.
+    http.expectOne((r) => r.url.startsWith('/api/commitments')).flush([]);
   });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
-import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
 import { catchError, EMPTY, finalize, tap } from 'rxjs';
 import { CommitmentsService } from '../../shared/services/commitments.service';
 import { Commitment } from '../../shared/models/commitment.model';
-import { isOnOrBeforeToday } from './widget-shell';
+import { isToday, toLocalDateKey } from './widget-shell';
 
 /**
  * Shows up to 5 open commitments that are either due today or already
@@ -16,7 +16,7 @@ import { isOnOrBeforeToday } from './widget-shell';
   selector: 'app-todays-commitments-widget',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, RouterLink, ButtonModule],
+  imports: [RouterLink, ButtonModule, TagModule],
   template: `
     <section
       class="flex flex-col gap-3 p-5 rounded-md bg-surface-50"
@@ -41,19 +41,17 @@ import { isOnOrBeforeToday } from './widget-shell';
           <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="load()" />
         </div>
       } @else if (items().length === 0) {
-        <p class="text-sm text-muted-color py-2">Nothing due today — clear inbox.</p>
+        <p class="text-sm text-muted-color py-2">Nothing due today — nice.</p>
       } @else {
         <ul class="flex flex-col gap-2">
           @for (c of items(); track c.id) {
             <li class="flex items-center gap-3 p-2 rounded bg-surface-0">
               @if (c.isOverdue) {
-                <i class="pi pi-exclamation-circle text-red-500 text-sm" aria-label="Overdue"></i>
-              } @else {
-                <i class="pi pi-circle text-sm" aria-hidden="true"></i>
+                <p-tag value="Overdue" severity="danger" />
               }
               <span class="flex-1 text-sm">{{ c.description }}</span>
               @if (c.dueDate) {
-                <span class="text-xs text-muted-color">{{ c.dueDate | date: 'mediumDate' }}</span>
+                <span class="text-xs text-muted-color">{{ formatDueDate(c.dueDate) }}</span>
               }
               <p-button
                 icon="pi pi-check"
@@ -62,6 +60,8 @@ import { isOnOrBeforeToday } from './widget-shell';
                 [rounded]="true"
                 size="small"
                 ariaLabel="Mark complete"
+                [disabled]="completing() === c.id"
+                [loading]="completing() === c.id"
                 (onClick)="complete(c)"
               />
             </li>
@@ -77,6 +77,17 @@ export class TodaysCommitmentsWidgetComponent implements OnInit {
   protected readonly items = signal<Commitment[]>([]);
   protected readonly loading = signal(true);
   protected readonly error = signal<string | null>(null);
+  /** id of the commitment currently being marked complete (for UI lockout). */
+  protected readonly completing = signal<string | null>(null);
+
+  /** Render a DateOnly (YYYY-MM-DD) as "medium" date without timezone shift. */
+  protected formatDueDate(raw: string): string {
+    const key = toLocalDateKey(raw);
+    if (!key) return '';
+    const [y, m, d] = key.split('-').map(Number);
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeZone: 'UTC' })
+      .format(new Date(Date.UTC(y, m - 1, d)));
+  }
 
   ngOnInit(): void {
     this.load();
@@ -89,8 +100,9 @@ export class TodaysCommitmentsWidgetComponent implements OnInit {
       .list(undefined, 'Open')
       .pipe(
         tap((list) => {
+          // Spec: include anything overdue OR due today (local calendar day).
           const relevant = list
-            .filter((c) => c.isOverdue || isOnOrBeforeToday(c.dueDate))
+            .filter((c) => c.isOverdue || isToday(c.dueDate))
             .sort((a, b) => {
               if (a.isOverdue !== b.isOverdue) return a.isOverdue ? -1 : 1;
               return (a.dueDate ?? '\uffff').localeCompare(b.dueDate ?? '\uffff');
@@ -108,9 +120,17 @@ export class TodaysCommitmentsWidgetComponent implements OnInit {
   }
 
   protected complete(c: Commitment): void {
+    if (this.completing()) return;
+    this.completing.set(c.id);
     this.commitments.complete(c.id).subscribe({
-      next: () => this.load(),
-      error: () => this.error.set('Failed to mark complete.'),
+      next: () => {
+        this.completing.set(null);
+        this.load();
+      },
+      error: () => {
+        this.completing.set(null);
+        this.error.set('Failed to mark complete.');
+      },
     });
   }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-commitments-widget.component.ts
@@ -1,0 +1,116 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { catchError, EMPTY, finalize, tap } from 'rxjs';
+import { CommitmentsService } from '../../shared/services/commitments.service';
+import { Commitment } from '../../shared/models/commitment.model';
+import { isOnOrBeforeToday } from './widget-shell';
+
+/**
+ * Shows up to 5 open commitments that are either due today or already
+ * overdue. Fails in isolation: an error here does not break the rest of
+ * the dashboard.
+ */
+@Component({
+  selector: 'app-todays-commitments-widget',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, RouterLink, ButtonModule],
+  template: `
+    <section
+      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50"
+      aria-label="Today's commitments"
+    >
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Today's commitments</h2>
+        <a
+          routerLink="/commitments"
+          class="text-xs font-medium text-primary hover:underline"
+        >View all</a>
+      </header>
+
+      @if (loading()) {
+        <div class="flex items-center gap-2 py-4 justify-center">
+          <i class="pi pi-spinner pi-spin"></i>
+          <span class="text-sm text-muted-color">Loading…</span>
+        </div>
+      } @else if (error(); as msg) {
+        <div class="flex flex-col items-start gap-2 py-3">
+          <p class="text-sm text-muted-color">{{ msg }}</p>
+          <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="load()" />
+        </div>
+      } @else if (items().length === 0) {
+        <p class="text-sm text-muted-color py-2">Nothing due today — clear inbox.</p>
+      } @else {
+        <ul class="flex flex-col gap-2">
+          @for (c of items(); track c.id) {
+            <li class="flex items-center gap-3 p-2 rounded bg-surface-0">
+              @if (c.isOverdue) {
+                <i class="pi pi-exclamation-circle text-red-500 text-sm" aria-label="Overdue"></i>
+              } @else {
+                <i class="pi pi-circle text-sm" aria-hidden="true"></i>
+              }
+              <span class="flex-1 text-sm">{{ c.description }}</span>
+              @if (c.dueDate) {
+                <span class="text-xs text-muted-color">{{ c.dueDate | date: 'mediumDate' }}</span>
+              }
+              <p-button
+                icon="pi pi-check"
+                severity="secondary"
+                [text]="true"
+                [rounded]="true"
+                size="small"
+                ariaLabel="Mark complete"
+                (onClick)="complete(c)"
+              />
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  `,
+})
+export class TodaysCommitmentsWidgetComponent implements OnInit {
+  private readonly commitments = inject(CommitmentsService);
+
+  protected readonly items = signal<Commitment[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  protected load(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.commitments
+      .list(undefined, 'Open')
+      .pipe(
+        tap((list) => {
+          const relevant = list
+            .filter((c) => c.isOverdue || isOnOrBeforeToday(c.dueDate))
+            .sort((a, b) => {
+              if (a.isOverdue !== b.isOverdue) return a.isOverdue ? -1 : 1;
+              return (a.dueDate ?? '\uffff').localeCompare(b.dueDate ?? '\uffff');
+            })
+            .slice(0, 5);
+          this.items.set(relevant);
+        }),
+        catchError(() => {
+          this.error.set("Couldn't load commitments.");
+          return EMPTY;
+        }),
+        finalize(() => this.loading.set(false)),
+      )
+      .subscribe();
+  }
+
+  protected complete(c: Commitment): void {
+    this.commitments.complete(c.id).subscribe({
+      next: () => this.load(),
+      error: () => this.error.set('Failed to mark complete.'),
+    });
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-one-on-ones-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/todays-one-on-ones-widget.component.ts
@@ -1,0 +1,108 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { catchError, finalize, forkJoin, of, tap } from 'rxjs';
+import { OneOnOnesService } from '../../shared/services/one-on-ones.service';
+import { PeopleService } from '../../shared/services/people.service';
+import { OneOnOne } from '../../shared/models/one-on-one.model';
+import { Person } from '../../shared/models/person.model';
+import { isToday } from './widget-shell';
+
+interface OneOnOneRow {
+  id: string;
+  personId: string;
+  personName: string;
+  occurredAt: string;
+}
+
+/**
+ * Lists the 1:1s scheduled (OccurredAt) for today. Links each row to the
+ * person detail page for 30-second prep. Fails in isolation.
+ */
+@Component({
+  selector: 'app-todays-one-on-ones-widget',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, ButtonModule],
+  template: `
+    <section
+      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50"
+      aria-label="Today's 1:1s"
+    >
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Today's 1:1s</h2>
+        <a
+          routerLink="/one-on-ones"
+          class="text-xs font-medium text-primary hover:underline"
+        >View all</a>
+      </header>
+
+      @if (loading()) {
+        <div class="flex items-center gap-2 py-4 justify-center">
+          <i class="pi pi-spinner pi-spin"></i>
+          <span class="text-sm text-muted-color">Loading…</span>
+        </div>
+      } @else if (error(); as msg) {
+        <div class="flex flex-col items-start gap-2 py-3">
+          <p class="text-sm text-muted-color">{{ msg }}</p>
+          <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="load()" />
+        </div>
+      } @else if (rows().length === 0) {
+        <p class="text-sm text-muted-color py-2">No 1:1s scheduled today.</p>
+      } @else {
+        <ul class="flex flex-col gap-2">
+          @for (row of rows(); track row.id) {
+            <li class="p-2 rounded bg-surface-0">
+              <a
+                [routerLink]="['/people', row.personId]"
+                class="flex items-center gap-3 text-sm hover:underline"
+              >
+                <i class="pi pi-comments text-muted-color" aria-hidden="true"></i>
+                <span class="flex-1 font-medium">{{ row.personName }}</span>
+              </a>
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  `,
+})
+export class TodaysOneOnOnesWidgetComponent implements OnInit {
+  private readonly oneOnOnes = inject(OneOnOnesService);
+  private readonly people = inject(PeopleService);
+
+  protected readonly rows = signal<OneOnOneRow[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  protected load(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    forkJoin({ oneOnOnes: this.oneOnOnes.list(), people: this.people.list() })
+      .pipe(
+        tap(({ oneOnOnes, people }) => {
+          const byId = new Map<string, Person>(people.map((p) => [p.id, p]));
+          const rows: OneOnOneRow[] = oneOnOnes
+            .filter((o) => isToday(o.occurredAt))
+            .sort((a, b) => a.occurredAt.localeCompare(b.occurredAt))
+            .map((o: OneOnOne) => ({
+              id: o.id,
+              personId: o.personId,
+              personName: byId.get(o.personId)?.name ?? '(unknown)',
+              occurredAt: o.occurredAt,
+            }));
+          this.rows.set(rows);
+        }),
+        catchError(() => {
+          this.error.set("Couldn't load 1:1s.");
+          return of(null);
+        }),
+        finalize(() => this.loading.set(false)),
+      )
+      .subscribe();
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/top-of-queue-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/top-of-queue-widget.component.ts
@@ -1,0 +1,79 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { MyQueueService } from '../../features/my-queue/my-queue.service';
+import { QueueItem } from '../../features/my-queue/my-queue.models';
+
+/**
+ * Top 5 items from My Queue, in the service's existing priority order.
+ * Subscribes to the shared `MyQueueService` signals so we inherit its
+ * loading/error state without duplicating fetch logic.
+ */
+@Component({
+  selector: 'app-top-of-queue-widget',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, ButtonModule, TagModule],
+  template: `
+    <section
+      class="flex flex-col gap-3 p-5 rounded-md bg-surface-50"
+      aria-label="Top of queue"
+    >
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Top of your queue</h2>
+        <a
+          routerLink="/my-queue"
+          class="text-xs font-medium text-primary hover:underline"
+        >View all</a>
+      </header>
+
+      @if (queue.loading()) {
+        <div class="flex items-center gap-2 py-4 justify-center">
+          <i class="pi pi-spinner pi-spin"></i>
+          <span class="text-sm text-muted-color">Loading…</span>
+        </div>
+      } @else if (queue.error(); as msg) {
+        <div class="flex flex-col items-start gap-2 py-3">
+          <p class="text-sm text-muted-color">{{ msg }}</p>
+          <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="reload()" />
+        </div>
+      } @else if (top().length === 0) {
+        <p class="text-sm text-muted-color py-2">Queue is empty. Nice work.</p>
+      } @else {
+        <ul class="flex flex-col gap-2">
+          @for (item of top(); track item.id) {
+            <li class="flex items-center gap-3 p-2 rounded bg-surface-0">
+              <p-tag [value]="item.itemType" severity="secondary" />
+              <span class="flex-1 text-sm">{{ item.title }}</span>
+              @if (item.isOverdue) {
+                <p-tag value="Overdue" severity="danger" />
+              }
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  `,
+})
+export class TopOfQueueWidgetComponent {
+  protected readonly queue = inject(MyQueueService);
+
+  protected readonly top = computed<QueueItem[]>(() => {
+    const resp = this.queue.response();
+    return resp ? resp.items.slice(0, 5) : [];
+  });
+
+  constructor() {
+    // Only trigger a fetch if the queue service hasn't already loaded.
+    effect(() => {
+      if (!this.queue.response() && !this.queue.loading() && !this.queue.error()) {
+        this.queue.load();
+      }
+    });
+  }
+
+  protected reload(): void {
+    this.queue.load();
+  }
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/top-of-queue-widget.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/top-of-queue-widget.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
@@ -56,7 +56,7 @@ import { QueueItem } from '../../features/my-queue/my-queue.models';
     </section>
   `,
 })
-export class TopOfQueueWidgetComponent {
+export class TopOfQueueWidgetComponent implements OnInit {
   protected readonly queue = inject(MyQueueService);
 
   protected readonly top = computed<QueueItem[]>(() => {
@@ -64,16 +64,14 @@ export class TopOfQueueWidgetComponent {
     return resp ? resp.items.slice(0, 5) : [];
   });
 
-  constructor() {
-    // Only trigger a fetch if the queue service hasn't already loaded.
-    effect(() => {
-      if (!this.queue.response() && !this.queue.loading() && !this.queue.error()) {
-        this.queue.load();
-      }
-    });
+  ngOnInit(): void {
+    // Always refetch on mount with the default scope — the singleton
+    // MyQueueService is shared with the /my-queue page which may have
+    // applied filters, so we reset to a clean load here.
+    this.queue.load({ scope: 'All' });
   }
 
   protected reload(): void {
-    this.queue.load();
+    this.queue.load({ scope: 'All' });
   }
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/widget-shell.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/widget-shell.ts
@@ -8,26 +8,46 @@
 
 /** Local-time "today" as a YYYY-MM-DD string. */
 export function todayLocalIso(): string {
-  const d = new Date();
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
+  // new Date() always yields a valid date, so this narrowing is safe.
+  return toLocalDateKey(new Date()) as string;
+}
+
+/**
+ * Convert an arbitrary ISO string or Date into a local YYYY-MM-DD key.
+ *
+ * DateOnly strings (`YYYY-MM-DD`) are returned verbatim because they
+ * carry no timezone information — they are what the user typed. Full
+ * ISO datetimes (`YYYY-MM-DDTHH:mm:ssZ`) are re-projected into the
+ * browser's local calendar day, since slicing them raw would compare the
+ * UTC calendar day instead.
+ */
+export function toLocalDateKey(input: string | Date | null | undefined): string | null {
+  if (!input) return null;
+  if (typeof input === 'string') {
+    // Plain YYYY-MM-DD — treat as user-local calendar day.
+    if (/^\d{4}-\d{2}-\d{2}$/.test(input)) return input;
+    const parsed = new Date(input);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return toLocalDateKey(parsed);
+  }
+  const y = input.getFullYear();
+  const m = String(input.getMonth() + 1).padStart(2, '0');
+  const day = String(input.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
 }
 
 /**
- * True if an ISO date-only or date-time string falls on or before today
- * (local). Used by the "today's commitments" widget to include anything
- * overdue alongside the items due today.
+ * True if the provided date (or datetime) falls on or before today in
+ * the user's local timezone. Used to include anything overdue alongside
+ * items due today.
  */
-export function isOnOrBeforeToday(isoDate: string | null | undefined): boolean {
-  if (!isoDate) return false;
-  const today = todayLocalIso();
-  return isoDate.slice(0, 10) <= today;
+export function isOnOrBeforeToday(iso: string | null | undefined): boolean {
+  const key = toLocalDateKey(iso);
+  return !!key && key <= todayLocalIso();
 }
 
-/** True if the calendar day portion of an ISO string is today (local). */
-export function isToday(isoDate: string | null | undefined): boolean {
-  if (!isoDate) return false;
-  return isoDate.slice(0, 10) === todayLocalIso();
+/** True if the calendar day portion of the provided date is today (local). */
+export function isToday(iso: string | null | undefined): boolean {
+  const key = toLocalDateKey(iso);
+  return key === todayLocalIso();
 }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/widget-shell.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/widget-shell.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared helpers for the dashboard widgets. Keeping them here (rather than
+ * sprinkled across widget files) makes it obvious that every widget
+ * honours the same isolation contract: loading / error / empty / data
+ * states, each widget fails independently, and each filters/sorts its
+ * own slice of data.
+ */
+
+/** Local-time "today" as a YYYY-MM-DD string. */
+export function todayLocalIso(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * True if an ISO date-only or date-time string falls on or before today
+ * (local). Used by the "today's commitments" widget to include anything
+ * overdue alongside the items due today.
+ */
+export function isOnOrBeforeToday(isoDate: string | null | undefined): boolean {
+  if (!isoDate) return false;
+  const today = todayLocalIso();
+  return isoDate.slice(0, 10) <= today;
+}
+
+/** True if the calendar day portion of an ISO string is today (local). */
+export function isToday(isoDate: string | null | undefined): boolean {
+  if (!isoDate) return false;
+  return isoDate.slice(0, 10) === todayLocalIso();
+}


### PR DESCRIPTION
## Summary

Ships the spec delta in `openspec/changes/dashboard-shell/`. Previously the dashboard was **just** the AI morning-briefing widget, so a failing AI provider left the page blank — badly missing the product brief's *"you open it every morning"* target. This reshapes it as a composition of independent widgets so the page stays useful even when AI is down.

Each widget honours an isolation contract: its own loading / error / empty / data states, and a failure in one does not affect siblings.

**Spec**: [daily-weekly-briefing](openspec/specs/daily-weekly-briefing/spec.md) · [change](openspec/changes/dashboard-shell/)

## Changes

**New widgets** (`src/.../pages/dashboard/`):
- `todays-commitments-widget` — up to 5 open commitments due today / overdue, sorted overdue-first; inline "mark complete" action that re-fetches only this widget.
- `todays-one-on-ones-widget` — 1:1s where `OccurredAt === today`, each row links to person detail.
- `top-of-queue-widget` — top 5 items from My Queue in priority order; reuses the shared `MyQueueService` signals.
- `overdue-summary-widget` — "3 commitments overdue · 1 delegation stale · 0 unread nudges" bar; each source tracked independently so one failure renders as `—` while others show live values. Nudges stubbed at 0 until an unread-count endpoint exists (see `design.md`).

**Shell composition** (`dashboard.page.ts`): responsive CSS grid — briefing spans full width, the three body widgets flow 2-col on `lg`+, the overdue summary spans full width.

**No backend changes.** Only existing endpoints are consumed (`/api/commitments`, `/api/one-on-ones`, `/api/people`, `/api/my-queue`, `/api/delegations`, `/api/briefings/morning`).

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` — green (zero backend edits)
- [x] `ng test --watch=false` — 120 green (6 new: widget units + shell isolation tests forcing 500 on briefing/commitments)
- [x] Manual: dashboard renders every widget; with AI provider broken, briefing shows error + settings link while commitments / 1:1s / queue / overdue summary all render with live data

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard redesigned as a responsive widget shell featuring the morning briefing as a full-width anchor with four new sibling widgets: today's commitments, today's 1:1s, top of queue, and overdue summary.
  * Widget isolation ensures individual widgets render independently—if one widget fails to load, others remain visible.
  * Quick actions added to commitments widget (mark complete, snooze).

* **Documentation**
  * Added comprehensive design and specification documents detailing widget behavior, layout, and data sources.

* **Tests**
  * Added test suites validating widget isolation and dashboard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->