### PR TITLE
feat(v2): dashboard, drag-drop upload, and final assembly

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
@@ -6,7 +6,6 @@ import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
-import { ProgressBarModule } from 'primeng/progressbar';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { QuickCaptureUiService } from '../../../shared/services/quick-capture-ui.service';
 import { Capture, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
@@ -24,7 +23,7 @@ interface FileUpload {
   selector: 'app-captures-list',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ProgressBarModule, CaptureRecorderComponent, RecordingPanelComponent],
+  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, CaptureRecorderComponent, RecordingPanelComponent],
   styles: [`
     .drop-zone {
       border: 2px dashed var(--p-content-border-color);
@@ -53,6 +52,7 @@ interface FileUpload {
         role="button"
         tabindex="0"
         (keydown.enter)="fileInput.click()"
+        (keydown.space)="$event.preventDefault(); fileInput.click()"
         aria-label="Upload files"
       >
         <i class="pi pi-cloud-upload text-3xl text-muted-color"></i>
@@ -73,7 +73,7 @@ interface FileUpload {
       @if (uploads().length > 0) {
         <div class="flex flex-col gap-2 p-4 rounded bg-surface-50">
           <h3 class="text-sm font-semibold">Uploading files</h3>
-          @for (u of uploads(); track u.file.name) {
+          @for (u of uploads(); track $index) {
             <div class="flex items-center gap-3">
               <span class="text-sm flex-1 truncate">{{ u.file.name }}</span>
               @if (u.status === 'uploading') {
@@ -184,6 +184,7 @@ export class CapturesListComponent implements OnInit {
   readonly uploads = signal<FileUpload[]>([]);
 
   private readonly acceptedExtensions = ['.docx', '.txt', '.html', '.htm'];
+  private pendingUploads = 0;
 
   protected readonly typeFilterOptions = [
     { label: 'Quick Note', value: 'QuickNote' as CaptureType },
@@ -236,6 +237,7 @@ export class CapturesListComponent implements OnInit {
   }
 
   protected retryUpload(upload: FileUpload): void {
+    this.pendingUploads++;
     this.uploadFile(upload);
   }
 
@@ -252,6 +254,7 @@ export class CapturesListComponent implements OnInit {
     }));
 
     this.uploads.update((current) => [...current, ...newUploads]);
+    this.pendingUploads += newUploads.length;
 
     for (const upload of newUploads) {
       this.uploadFile(upload);
@@ -272,18 +275,30 @@ export class CapturesListComponent implements OnInit {
             u.file === upload.file ? { ...u, status: 'done' as const } : u,
           ),
         );
-        this.loadCaptures();
+        this.onUploadSettled();
       },
-      error: () => {
+      error: (err: unknown) => {
+        const message = (err as { error?: { message?: string } })?.error?.message
+          ?? (err as { message?: string })?.message
+          ?? 'Upload failed';
         this.uploads.update((list) =>
           list.map((u) =>
             u.file === upload.file
-              ? { ...u, status: 'failed' as const, error: 'Upload failed' }
+              ? { ...u, status: 'failed' as const, error: message }
               : u,
           ),
         );
+        this.onUploadSettled();
       },
     });
+  }
+
+  private onUploadSettled(): void {
+    this.pendingUploads--;
+    if (this.pendingUploads <= 0) {
+      this.pendingUploads = 0;
+      this.loadCaptures();
+    }
   }
 
   protected onFilterChange(): void {

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/captures-list/captures-list.component.ts
@@ -6,6 +6,7 @@ import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
+import { ProgressBarModule } from 'primeng/progressbar';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { QuickCaptureUiService } from '../../../shared/services/quick-capture-ui.service';
 import { Capture, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
@@ -13,17 +14,90 @@ import { CaptureRecorderComponent } from '../audio-recorder/capture-recorder.com
 import { RecordingPanelComponent } from '../recording-panel/recording-panel.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
+interface FileUpload {
+  file: File;
+  status: 'pending' | 'uploading' | 'done' | 'failed';
+  error: string | null;
+}
+
 @Component({
   selector: 'app-captures-list',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, CaptureRecorderComponent, RecordingPanelComponent],
+  imports: [FormsModule, DatePipe, ButtonModule, SelectModule, TableModule, TagModule, ProgressBarModule, CaptureRecorderComponent, RecordingPanelComponent],
+  styles: [`
+    .drop-zone {
+      border: 2px dashed var(--p-content-border-color);
+      transition: border-color 0.2s, background-color 0.2s;
+    }
+    .drop-zone-active {
+      border-color: var(--p-primary-color);
+      background-color: var(--p-primary-50);
+    }
+  `],
   template: `
     <div class="flex flex-col gap-6">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-bold">Captures</h1>
         <p-button label="New Capture" icon="pi pi-plus" (onClick)="quickCapture.open()" />
       </div>
+
+      <!-- Drag-Drop Upload Zone -->
+      <div
+        class="drop-zone rounded-lg p-8 flex flex-col items-center gap-3 cursor-pointer"
+        [class.drop-zone-active]="dragOver()"
+        (dragover)="onDragOver($event)"
+        (dragleave)="onDragLeave($event)"
+        (drop)="onDrop($event)"
+        (click)="fileInput.click()"
+        role="button"
+        tabindex="0"
+        (keydown.enter)="fileInput.click()"
+        aria-label="Upload files"
+      >
+        <i class="pi pi-cloud-upload text-3xl text-muted-color"></i>
+        <p class="text-sm text-muted-color">
+          Drag &amp; drop .docx, .txt, or .html files here, or click to browse
+        </p>
+        <input
+          #fileInput
+          type="file"
+          class="hidden"
+          multiple
+          accept=".docx,.txt,.html,.htm"
+          (change)="onFilesSelected($event)"
+        />
+      </div>
+
+      <!-- Upload Progress -->
+      @if (uploads().length > 0) {
+        <div class="flex flex-col gap-2 p-4 rounded bg-surface-50">
+          <h3 class="text-sm font-semibold">Uploading files</h3>
+          @for (u of uploads(); track u.file.name) {
+            <div class="flex items-center gap-3">
+              <span class="text-sm flex-1 truncate">{{ u.file.name }}</span>
+              @if (u.status === 'uploading') {
+                <i class="pi pi-spinner pi-spin text-sm"></i>
+                <span class="text-xs text-muted-color">Uploading...</span>
+              } @else if (u.status === 'done') {
+                <i class="pi pi-check text-sm" style="color: var(--p-green-500)"></i>
+                <span class="text-xs text-muted-color">Done</span>
+              } @else if (u.status === 'failed') {
+                <i class="pi pi-times text-sm" style="color: var(--p-red-500)"></i>
+                <span class="text-xs text-muted-color">{{ u.error ?? 'Failed' }}</span>
+                <p-button
+                  icon="pi pi-refresh"
+                  size="small"
+                  [text]="true"
+                  [rounded]="true"
+                  ariaLabel="Retry upload"
+                  (onClick)="retryUpload(u); $event.stopPropagation()"
+                />
+              }
+            </div>
+          }
+        </div>
+      }
 
       <app-recording-panel (saved)="onCaptureCreated($event)" />
       <app-capture-recorder (uploaded)="onCaptureCreated($event)" />
@@ -106,6 +180,10 @@ export class CapturesListComponent implements OnInit {
   readonly loading = signal(true);
   readonly selectedType = signal<CaptureType | null>(null);
   readonly selectedStatus = signal<ProcessingStatus | null>(null);
+  readonly dragOver = signal(false);
+  readonly uploads = signal<FileUpload[]>([]);
+
+  private readonly acceptedExtensions = ['.docx', '.txt', '.html', '.htm'];
 
   protected readonly typeFilterOptions = [
     { label: 'Quick Note', value: 'QuickNote' as CaptureType },
@@ -122,9 +200,89 @@ export class CapturesListComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadCaptures();
-    // Refresh when captures are authored from anywhere in the app (FAB / Cmd+K / etc.).
     this.quickCapture.captureCreated$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.loadCaptures();
+    });
+  }
+
+  protected onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(true);
+  }
+
+  protected onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(false);
+  }
+
+  protected onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(false);
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.handleFiles(Array.from(files));
+    }
+  }
+
+  protected onFilesSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.handleFiles(Array.from(input.files));
+      input.value = '';
+    }
+  }
+
+  protected retryUpload(upload: FileUpload): void {
+    this.uploadFile(upload);
+  }
+
+  private handleFiles(files: File[]): void {
+    const validFiles = files.filter((f) =>
+      this.acceptedExtensions.some((ext) => f.name.toLowerCase().endsWith(ext)),
+    );
+    if (validFiles.length === 0) return;
+
+    const newUploads: FileUpload[] = validFiles.map((file) => ({
+      file,
+      status: 'pending' as const,
+      error: null,
+    }));
+
+    this.uploads.update((current) => [...current, ...newUploads]);
+
+    for (const upload of newUploads) {
+      this.uploadFile(upload);
+    }
+  }
+
+  private uploadFile(upload: FileUpload): void {
+    this.uploads.update((list) =>
+      list.map((u) =>
+        u.file === upload.file ? { ...u, status: 'uploading' as const, error: null } : u,
+      ),
+    );
+
+    this.capturesService.importFile(upload.file).subscribe({
+      next: () => {
+        this.uploads.update((list) =>
+          list.map((u) =>
+            u.file === upload.file ? { ...u, status: 'done' as const } : u,
+          ),
+        );
+        this.loadCaptures();
+      },
+      error: () => {
+        this.uploads.update((list) =>
+          list.map((u) =>
+            u.file === upload.file
+              ? { ...u, status: 'failed' as const, error: 'Upload failed' }
+              : u,
+          ),
+        );
+      },
     });
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
@@ -125,6 +125,11 @@ import { toLocalDateKey, todayLocalIso } from './widget-shell';
               <p-skeleton height="2.5rem" />
               <p-skeleton height="2.5rem" />
             </div>
+          } @else if (commitmentsError()) {
+            <div class="flex flex-col items-start gap-2 py-3">
+              <p class="text-sm text-muted-color">{{ commitmentsError() }}</p>
+              <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="loadCommitments()" />
+            </div>
           } @else if (commitments().length === 0) {
             <p class="text-sm text-muted-color py-2">No open commitments.</p>
           } @else {
@@ -220,6 +225,11 @@ import { toLocalDateKey, todayLocalIso } from './widget-shell';
               <p-skeleton height="2.5rem" />
               <p-skeleton height="2.5rem" />
             </div>
+          } @else if (peopleError()) {
+            <div class="flex flex-col items-start gap-2 py-3">
+              <p class="text-sm text-muted-color">{{ peopleError() }}</p>
+              <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="loadPeople()" />
+            </div>
           } @else if (people().length === 0) {
             <p class="text-sm text-muted-color py-2">No people added yet.</p>
           } @else {
@@ -253,11 +263,13 @@ export class DashboardPage implements OnInit {
   // Commitments state
   protected readonly commitments = signal<Commitment[]>([]);
   protected readonly commitmentsLoading = signal(true);
+  protected readonly commitmentsError = signal<string | null>(null);
   protected readonly acting = signal<string | null>(null);
 
   // People state
   protected readonly people = signal<Person[]>([]);
   protected readonly peopleLoading = signal(true);
+  protected readonly peopleError = signal<string | null>(null);
 
   // Grouped commitments
   protected readonly overdueCommitments = computed(() =>
@@ -318,6 +330,7 @@ export class DashboardPage implements OnInit {
 
   protected loadCommitments(): void {
     this.commitmentsLoading.set(true);
+    this.commitmentsError.set(null);
     this.commitmentsService.list(undefined, 'Open').subscribe({
       next: (list) => {
         this.commitments.set(
@@ -328,12 +341,16 @@ export class DashboardPage implements OnInit {
         );
         this.commitmentsLoading.set(false);
       },
-      error: () => this.commitmentsLoading.set(false),
+      error: () => {
+        this.commitmentsLoading.set(false);
+        this.commitmentsError.set('Failed to load commitments.');
+      },
     });
   }
 
   protected loadPeople(): void {
     this.peopleLoading.set(true);
+    this.peopleError.set(null);
     this.peopleService.list().subscribe({
       next: (list) => {
         // Show most recently updated first, limit to 10
@@ -344,7 +361,10 @@ export class DashboardPage implements OnInit {
         );
         this.peopleLoading.set(false);
       },
-      error: () => this.peopleLoading.set(false),
+      error: () => {
+        this.peopleLoading.set(false);
+        this.peopleError.set('Failed to load people.');
+      },
     });
   }
 
@@ -393,7 +413,7 @@ export class DashboardPage implements OnInit {
   private getEndOfWeek(): string {
     const now = new Date();
     const dayOfWeek = now.getDay();
-    const daysUntilSunday = 7 - dayOfWeek;
+    const daysUntilSunday = dayOfWeek === 0 ? 0 : 7 - dayOfWeek;
     const endOfWeek = new Date(now);
     endOfWeek.setDate(now.getDate() + daysUntilSunday);
     return toLocalDateKey(endOfWeek) as string;

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/dashboard/dashboard.page.ts
@@ -1,24 +1,401 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TodaysCommitmentsWidgetComponent } from './todays-commitments-widget.component';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { SkeletonModule } from 'primeng/skeleton';
+import { BriefingService } from '../../shared/services/briefing.service';
+import { CommitmentsService } from '../../shared/services/commitments.service';
+import { PeopleService } from '../../shared/services/people.service';
+import { DailyBrief } from '../../shared/models/briefing.model';
+import { Commitment } from '../../shared/models/commitment.model';
+import { Person } from '../../shared/models/person.model';
+import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+import { toLocalDateKey, todayLocalIso } from './widget-shell';
 
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    TodaysCommitmentsWidgetComponent,
+    DatePipe,
+    RouterLink,
+    ButtonModule,
+    TagModule,
+    SkeletonModule,
+    MarkdownPipe,
   ],
   template: `
-    <div class="flex flex-col gap-4 max-w-5xl mx-auto">
+    <div class="flex flex-col gap-6 max-w-5xl mx-auto">
       <header class="flex flex-col gap-1">
         <h1 class="text-2xl font-bold">Dashboard</h1>
         <p class="text-sm text-muted-color">Your day at a glance.</p>
       </header>
 
+      <!-- Daily Brief Section -->
+      <section class="flex flex-col gap-4 p-5 rounded-md bg-surface-50" aria-label="Daily Brief">
+        <header class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold">Daily Brief</h2>
+          <a routerLink="/briefing/daily" class="text-xs font-medium text-primary hover:underline">
+            View Full Brief
+          </a>
+        </header>
+
+        @if (briefLoading()) {
+          <div class="flex flex-col gap-3">
+            <p-skeleton height="1.5rem" width="60%" />
+            <p-skeleton height="1rem" />
+            <p-skeleton height="1rem" width="90%" />
+            <p-skeleton height="1rem" width="80%" />
+          </div>
+        } @else if (brief()) {
+          <div class="text-sm" [innerHTML]="brief()!.narrative | markdown"></div>
+
+          @if (brief()!.freshCommitments.length > 0) {
+            <div class="flex flex-col gap-2">
+              <h3 class="text-sm font-semibold">New Commitments</h3>
+              @for (c of brief()!.freshCommitments; track c.id) {
+                <div class="flex items-center gap-2 p-2 rounded bg-surface-0 text-sm">
+                  <p-tag [value]="c.direction === 'MineToThem' ? 'Mine' : 'Theirs'" severity="secondary" />
+                  <span class="flex-1">{{ c.description }}</span>
+                  @if (c.personName) {
+                    <a [routerLink]="['/people', c.personId]" class="text-xs text-primary">{{ c.personName }}</a>
+                  }
+                </div>
+              }
+            </div>
+          }
+
+          @if (brief()!.dueToday.length > 0) {
+            <div class="flex flex-col gap-2">
+              <h3 class="text-sm font-semibold">Due Today</h3>
+              @for (c of brief()!.dueToday; track c.id) {
+                <div class="flex items-center gap-2 p-2 rounded bg-surface-0 text-sm">
+                  <span class="flex-1">{{ c.description }}</span>
+                  @if (c.personName) {
+                    <a [routerLink]="['/people', c.personId]" class="text-xs text-primary">{{ c.personName }}</a>
+                  }
+                </div>
+              }
+            </div>
+          }
+
+          @if (brief()!.overdue.length > 0) {
+            <div class="flex flex-col gap-2">
+              <h3 class="text-sm font-semibold">Overdue</h3>
+              @for (c of brief()!.overdue; track c.id) {
+                <div class="flex items-center gap-2 p-2 rounded bg-surface-0 text-sm">
+                  <p-tag value="Overdue" severity="danger" />
+                  <span class="flex-1">{{ c.description }}</span>
+                  @if (c.dueDate) {
+                    <span class="text-xs text-muted-color">Due {{ c.dueDate | date: 'mediumDate' }}</span>
+                  }
+                </div>
+              }
+            </div>
+          }
+
+          <div class="flex items-center justify-between">
+            <p class="text-xs text-muted-color">{{ brief()!.captureCount }} capture(s) analyzed</p>
+            <a routerLink="/briefing/weekly" class="text-xs font-medium text-primary hover:underline">
+              View Weekly Brief
+            </a>
+          </div>
+        } @else if (briefError()) {
+          <div class="flex flex-col items-start gap-2 py-3">
+            <p class="text-sm text-muted-color">{{ briefError() }}</p>
+            <p-button label="Retry" icon="pi pi-refresh" size="small" [text]="true" (onClick)="loadBrief()" />
+          </div>
+        }
+      </section>
+
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <app-todays-commitments-widget />
+        <!-- Open Commitments Section -->
+        <section class="flex flex-col gap-3 p-5 rounded-md bg-surface-50" aria-label="Open Commitments">
+          <header class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold">Open Commitments</h2>
+            <a routerLink="/commitments" class="text-xs font-medium text-primary hover:underline">
+              View All
+            </a>
+          </header>
+
+          @if (commitmentsLoading()) {
+            <div class="flex flex-col gap-2">
+              <p-skeleton height="2.5rem" />
+              <p-skeleton height="2.5rem" />
+              <p-skeleton height="2.5rem" />
+            </div>
+          } @else if (commitments().length === 0) {
+            <p class="text-sm text-muted-color py-2">No open commitments.</p>
+          } @else {
+            @if (overdueCommitments().length > 0) {
+              <div class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase text-muted-color">Overdue</span>
+                @for (c of overdueCommitments(); track c.id) {
+                  <div class="flex items-center gap-2 p-2 rounded bg-surface-0">
+                    <p-tag value="Overdue" severity="danger" />
+                    <span class="flex-1 text-sm truncate">{{ c.description }}</span>
+                    <p-button icon="pi pi-check" severity="success" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Complete" [disabled]="acting() === c.id" [loading]="acting() === c.id"
+                      (onClick)="completeCommitment(c)" />
+                    <p-button icon="pi pi-times" severity="secondary" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Dismiss" [disabled]="acting() === c.id"
+                      (onClick)="dismissCommitment(c)" />
+                  </div>
+                }
+              </div>
+            }
+
+            @if (dueTodayCommitments().length > 0) {
+              <div class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase text-muted-color">Due Today</span>
+                @for (c of dueTodayCommitments(); track c.id) {
+                  <div class="flex items-center gap-2 p-2 rounded bg-surface-0">
+                    <span class="flex-1 text-sm truncate">{{ c.description }}</span>
+                    <p-button icon="pi pi-check" severity="success" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Complete" [disabled]="acting() === c.id" [loading]="acting() === c.id"
+                      (onClick)="completeCommitment(c)" />
+                    <p-button icon="pi pi-times" severity="secondary" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Dismiss" [disabled]="acting() === c.id"
+                      (onClick)="dismissCommitment(c)" />
+                  </div>
+                }
+              </div>
+            }
+
+            @if (dueThisWeekCommitments().length > 0) {
+              <div class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase text-muted-color">Due This Week</span>
+                @for (c of dueThisWeekCommitments(); track c.id) {
+                  <div class="flex items-center gap-2 p-2 rounded bg-surface-0">
+                    <span class="flex-1 text-sm truncate">{{ c.description }}</span>
+                    @if (c.dueDate) {
+                      <span class="text-xs text-muted-color">{{ formatDueDate(c.dueDate) }}</span>
+                    }
+                    <p-button icon="pi pi-check" severity="success" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Complete" [disabled]="acting() === c.id" [loading]="acting() === c.id"
+                      (onClick)="completeCommitment(c)" />
+                    <p-button icon="pi pi-times" severity="secondary" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Dismiss" [disabled]="acting() === c.id"
+                      (onClick)="dismissCommitment(c)" />
+                  </div>
+                }
+              </div>
+            }
+
+            @if (laterCommitments().length > 0) {
+              <div class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase text-muted-color">Later</span>
+                @for (c of laterCommitments(); track c.id) {
+                  <div class="flex items-center gap-2 p-2 rounded bg-surface-0">
+                    <span class="flex-1 text-sm truncate">{{ c.description }}</span>
+                    @if (c.dueDate) {
+                      <span class="text-xs text-muted-color">{{ formatDueDate(c.dueDate) }}</span>
+                    }
+                    <p-button icon="pi pi-check" severity="success" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Complete" [disabled]="acting() === c.id" [loading]="acting() === c.id"
+                      (onClick)="completeCommitment(c)" />
+                    <p-button icon="pi pi-times" severity="secondary" [text]="true" [rounded]="true" size="small"
+                      ariaLabel="Dismiss" [disabled]="acting() === c.id"
+                      (onClick)="dismissCommitment(c)" />
+                  </div>
+                }
+              </div>
+            }
+          }
+        </section>
+
+        <!-- People Quick Access Section -->
+        <section class="flex flex-col gap-3 p-5 rounded-md bg-surface-50" aria-label="People Quick Access">
+          <header class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold">People</h2>
+            <a routerLink="/people" class="text-xs font-medium text-primary hover:underline">
+              View All
+            </a>
+          </header>
+
+          @if (peopleLoading()) {
+            <div class="flex flex-col gap-2">
+              <p-skeleton height="2.5rem" />
+              <p-skeleton height="2.5rem" />
+              <p-skeleton height="2.5rem" />
+            </div>
+          } @else if (people().length === 0) {
+            <p class="text-sm text-muted-color py-2">No people added yet.</p>
+          } @else {
+            <ul class="flex flex-col gap-2">
+              @for (p of people(); track p.id) {
+                <li>
+                  <a [routerLink]="['/people', p.id]"
+                     class="flex items-center gap-3 p-2 rounded bg-surface-0 text-sm hover:bg-surface-100">
+                    <span class="font-medium flex-1">{{ p.name }}</span>
+                    <p-tag [value]="formatPersonType(p.type)" severity="info" />
+                  </a>
+                </li>
+              }
+            </ul>
+          }
+        </section>
       </div>
     </div>
   `,
 })
-export class DashboardPage {}
+export class DashboardPage implements OnInit {
+  private readonly briefingService = inject(BriefingService);
+  private readonly commitmentsService = inject(CommitmentsService);
+  private readonly peopleService = inject(PeopleService);
+
+  // Daily Brief state
+  protected readonly brief = signal<DailyBrief | null>(null);
+  protected readonly briefLoading = signal(true);
+  protected readonly briefError = signal<string | null>(null);
+
+  // Commitments state
+  protected readonly commitments = signal<Commitment[]>([]);
+  protected readonly commitmentsLoading = signal(true);
+  protected readonly acting = signal<string | null>(null);
+
+  // People state
+  protected readonly people = signal<Person[]>([]);
+  protected readonly peopleLoading = signal(true);
+
+  // Grouped commitments
+  protected readonly overdueCommitments = computed(() =>
+    this.commitments().filter((c) => c.isOverdue),
+  );
+
+  protected readonly dueTodayCommitments = computed(() => {
+    const today = todayLocalIso();
+    return this.commitments().filter((c) => !c.isOverdue && toLocalDateKey(c.dueDate) === today);
+  });
+
+  protected readonly dueThisWeekCommitments = computed(() => {
+    const today = todayLocalIso();
+    const weekEnd = this.getEndOfWeek();
+    return this.commitments().filter((c) => {
+      if (c.isOverdue) return false;
+      const key = toLocalDateKey(c.dueDate);
+      if (!key) return false;
+      return key > today && key <= weekEnd;
+    });
+  });
+
+  protected readonly laterCommitments = computed(() => {
+    const weekEnd = this.getEndOfWeek();
+    return this.commitments().filter((c) => {
+      if (c.isOverdue) return false;
+      const key = toLocalDateKey(c.dueDate);
+      // No due date or after this week
+      return !key || key > weekEnd;
+    }).filter((c) => {
+      // Exclude those already in dueTodayCommitments
+      const today = todayLocalIso();
+      const key = toLocalDateKey(c.dueDate);
+      return key !== today;
+    });
+  });
+
+  ngOnInit(): void {
+    this.loadBrief();
+    this.loadCommitments();
+    this.loadPeople();
+  }
+
+  protected loadBrief(): void {
+    this.briefLoading.set(true);
+    this.briefError.set(null);
+    this.briefingService.getDailyBrief().subscribe({
+      next: (b) => {
+        this.brief.set(b);
+        this.briefLoading.set(false);
+      },
+      error: () => {
+        this.briefLoading.set(false);
+        this.briefError.set('Failed to load daily brief.');
+      },
+    });
+  }
+
+  protected loadCommitments(): void {
+    this.commitmentsLoading.set(true);
+    this.commitmentsService.list(undefined, 'Open').subscribe({
+      next: (list) => {
+        this.commitments.set(
+          list.sort((a, b) => {
+            if (a.isOverdue !== b.isOverdue) return a.isOverdue ? -1 : 1;
+            return (a.dueDate ?? '\uffff').localeCompare(b.dueDate ?? '\uffff');
+          }),
+        );
+        this.commitmentsLoading.set(false);
+      },
+      error: () => this.commitmentsLoading.set(false),
+    });
+  }
+
+  protected loadPeople(): void {
+    this.peopleLoading.set(true);
+    this.peopleService.list().subscribe({
+      next: (list) => {
+        // Show most recently updated first, limit to 10
+        this.people.set(
+          [...list]
+            .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+            .slice(0, 10),
+        );
+        this.peopleLoading.set(false);
+      },
+      error: () => this.peopleLoading.set(false),
+    });
+  }
+
+  protected completeCommitment(c: Commitment): void {
+    if (this.acting()) return;
+    this.acting.set(c.id);
+    this.commitmentsService.complete(c.id).subscribe({
+      next: () => {
+        this.acting.set(null);
+        this.loadCommitments();
+      },
+      error: () => this.acting.set(null),
+    });
+  }
+
+  protected dismissCommitment(c: Commitment): void {
+    if (this.acting()) return;
+    this.acting.set(c.id);
+    this.commitmentsService.dismiss(c.id).subscribe({
+      next: () => {
+        this.acting.set(null);
+        this.loadCommitments();
+      },
+      error: () => this.acting.set(null),
+    });
+  }
+
+  protected formatDueDate(raw: string): string {
+    const key = toLocalDateKey(raw);
+    if (!key) return '';
+    const [y, m, d] = key.split('-').map(Number);
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeZone: 'UTC' })
+      .format(new Date(Date.UTC(y, m - 1, d)));
+  }
+
+  protected formatPersonType(type: string): string {
+    switch (type) {
+      case 'DirectReport': return 'Direct Report';
+      case 'Peer': return 'Peer';
+      case 'Stakeholder': return 'Stakeholder';
+      case 'External': return 'External';
+      default: return type;
+    }
+  }
+
+  private getEndOfWeek(): string {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const daysUntilSunday = 7 - dayOfWeek;
+    const endOfWeek = new Date(now);
+    endOfWeek.setDate(now.getDate() + daysUntilSunday);
+    return toLocalDateKey(endOfWeek) as string;
+  }
+}


### PR DESCRIPTION
## Summary

Phase F+G — the final phase of the V2 product pivot. Assembles the V2 dashboard with three sections, adds drag-drop bulk upload to the Captures page, and verifies all navigation and tests pass.

## Changes

**Dashboard V2 (F1)**
- 3-section layout replacing the single-widget V1 dashboard:
  - Daily Brief: inline rendering with narrative, commitments due today, overdue items
  - Open Commitments: grouped by urgency (overdue/today/this week/later) with inline Complete/Dismiss
  - People Quick Access: recently active people with links to dossiers
- Loading skeletons, error handling, empty states

**Drag-drop Upload (F2)**
- Upload zone at top of Captures page
- Multi-file .docx/.txt/.html support via drag-drop or file picker
- Per-file progress (uploading/done/failed) with retry
- Auto-refreshes capture list after upload

**Navigation (F3)**
- Verified: Dashboard, Captures, People, Commitments, Initiatives, Daily Brief, Weekly Brief, Settings
- No killed aggregate references remain

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (331 tests)
- [x] `npx ng test --watch=false` passes (41 tests)
- [x] No killed aggregate references in codebase
- [ ] E2E tests pass in CI
- [ ] Manual: dashboard renders 3 sections, upload zone works

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)