### PR TITLE
fix: set CaptureSource.Typed for POST /api/captures (closes #141)

### DIFF
--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -819,7 +819,11 @@ app.MapPost("/api/captures", async (
 {
     try
     {
-        var created = await handler.HandleAsync(request, cancellationToken);
+        // Default to Typed source when not explicitly provided
+        var effectiveRequest = request.Source is null
+            ? request with { Source = CaptureSource.Typed }
+            : request;
+        var created = await handler.HandleAsync(effectiveRequest, cancellationToken);
 
         // Auto-trigger extraction synchronously (best-effort — failures are recorded on the capture)
         var response = await extractHandler.HandleAsync(created.Id, cancellationToken);

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -41,6 +41,15 @@ public class CaptureTests
         Assert.Equal(CaptureSource.Upload, capture.CaptureSource);
     }
 
+    [Fact]
+    public void Create_WithTypedSource_SetsCaptureSourceToTyped()
+    {
+        var capture = Capture.Create(UserId, "some typed note", CaptureType.QuickNote,
+            source: CaptureSource.Typed);
+
+        Assert.Equal(CaptureSource.Typed, capture.CaptureSource);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]


### PR DESCRIPTION
## Summary

Captures created via `POST /api/captures` had `captureSource: null`. Now defaults to `CaptureSource.Typed`.

Closes #141

## Changes

- `Program.cs`: default `Source` to `CaptureSource.Typed` when null in the create capture endpoint
- New domain test verifying source is stored correctly

## Test Plan

- [x] `dotnet test` passes (332 tests)
- [x] `npx ng test --watch=false` passes (41 tests)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure captures created via the public API are assigned a typed capture source when none is provided.

Bug Fixes:
- Set a default CaptureSource.Typed for captures created via POST /api/captures when the source is omitted.

Tests:
- Add a domain test confirming captures created with a typed source persist CaptureSource.Typed correctly.