### PR TITLE
fix: return 422 when AI not configured (closes #142)

### DIFF
--- a/src/MentalMetal.Application/Common/Ai/AiProviderException.cs
+++ b/src/MentalMetal.Application/Common/Ai/AiProviderException.cs
@@ -13,3 +13,6 @@ public class AiProviderException(
 
 public class TasteLimitExceededException()
     : Exception("Daily free AI operation limit reached. Add your own AI provider key for unlimited access.");
+
+public class AiNotConfiguredException()
+    : Exception("AI provider is not configured. Configure your AI provider in Settings to enable this feature.");

--- a/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
+++ b/src/MentalMetal.Infrastructure/Ai/AiCompletionService.cs
@@ -76,12 +76,10 @@ public sealed class AiCompletionService(
 
         // Fall back to taste key
         if (_settings.TasteKey is null)
-            throw new InvalidOperationException(
-                "AI provider is not configured. Please set up your AI provider in settings.");
+            throw new AiNotConfiguredException();
 
         if (!tasteBudgetService.IsEnabled)
-            throw new InvalidOperationException(
-                "AI provider is not configured. Please set up your AI provider in settings.");
+            throw new AiNotConfiguredException();
 
         var remaining = await tasteBudgetService.GetRemainingAsync(user.Id, cancellationToken);
         if (remaining <= 0)

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/daily-brief.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/daily-brief.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
@@ -138,7 +139,11 @@ import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
       } @else if (error()) {
         <div class="p-8 text-center rounded bg-surface-50">
           <p class="text-muted-color">{{ error() }}</p>
-          <p-button label="Try Again" size="small" [outlined]="true" (onClick)="load()" class="mt-4" />
+          @if (aiNotConfigured()) {
+            <a routerLink="/settings" class="inline-block mt-4 text-sm text-primary font-medium">Go to Settings</a>
+          } @else {
+            <p-button label="Try Again" size="small" [outlined]="true" (onClick)="load()" class="mt-4" />
+          }
         </div>
       }
     </div>
@@ -150,6 +155,7 @@ export class DailyBriefComponent implements OnInit {
   readonly brief = signal<DailyBrief | null>(null);
   readonly loading = signal(false);
   readonly error = signal<string | null>(null);
+  readonly aiNotConfigured = signal(false);
 
   ngOnInit(): void {
     this.load();
@@ -158,14 +164,20 @@ export class DailyBriefComponent implements OnInit {
   protected load(): void {
     this.loading.set(true);
     this.error.set(null);
+    this.aiNotConfigured.set(false);
     this.briefingService.getDailyBrief().subscribe({
       next: (b) => {
         this.brief.set(b);
         this.loading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.loading.set(false);
-        this.error.set('Failed to generate daily brief. Is your AI provider configured?');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.aiNotConfigured.set(true);
+          this.error.set(err.error.error);
+        } else {
+          this.error.set('Failed to generate daily brief.');
+        }
       },
     });
   }
@@ -173,14 +185,20 @@ export class DailyBriefComponent implements OnInit {
   protected refresh(): void {
     this.loading.set(true);
     this.error.set(null);
+    this.aiNotConfigured.set(false);
     this.briefingService.refreshDailyBrief().subscribe({
       next: (b) => {
         this.brief.set(b);
         this.loading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.loading.set(false);
-        this.error.set('Failed to refresh daily brief.');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.aiNotConfigured.set(true);
+          this.error.set(err.error.error);
+        } else {
+          this.error.set('Failed to refresh daily brief.');
+        }
       },
     });
   }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-brief.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/briefings/weekly-brief.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
@@ -148,7 +149,11 @@ import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
       } @else if (error()) {
         <div class="p-8 text-center rounded bg-surface-50">
           <p class="text-muted-color">{{ error() }}</p>
-          <p-button label="Try Again" size="small" [outlined]="true" (onClick)="load()" class="mt-4" />
+          @if (aiNotConfigured()) {
+            <a routerLink="/settings" class="inline-block mt-4 text-sm text-primary font-medium">Go to Settings</a>
+          } @else {
+            <p-button label="Try Again" size="small" [outlined]="true" (onClick)="load()" class="mt-4" />
+          }
         </div>
       }
     </div>
@@ -160,6 +165,7 @@ export class WeeklyBriefComponent implements OnInit {
   readonly brief = signal<WeeklyBrief | null>(null);
   readonly loading = signal(false);
   readonly error = signal<string | null>(null);
+  readonly aiNotConfigured = signal(false);
 
   ngOnInit(): void {
     this.load();
@@ -168,14 +174,20 @@ export class WeeklyBriefComponent implements OnInit {
   protected load(): void {
     this.loading.set(true);
     this.error.set(null);
+    this.aiNotConfigured.set(false);
     this.briefingService.getWeeklyBrief().subscribe({
       next: (b) => {
         this.brief.set(b);
         this.loading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.loading.set(false);
-        this.error.set('Failed to generate weekly brief. Is your AI provider configured?');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.aiNotConfigured.set(true);
+          this.error.set(err.error.error);
+        } else {
+          this.error.set('Failed to generate weekly brief.');
+        }
       },
     });
   }
@@ -183,14 +195,20 @@ export class WeeklyBriefComponent implements OnInit {
   protected refresh(): void {
     this.loading.set(true);
     this.error.set(null);
+    this.aiNotConfigured.set(false);
     this.briefingService.refreshWeeklyBrief().subscribe({
       next: (b) => {
         this.brief.set(b);
         this.loading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.loading.set(false);
-        this.error.set('Failed to refresh weekly brief.');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.aiNotConfigured.set(true);
+          this.error.set(err.error.error);
+        } else {
+          this.error.set('Failed to refresh weekly brief.');
+        }
       },
     });
   }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/people/person-detail/person-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/people/person-detail/person-detail.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
@@ -171,7 +172,11 @@ import { MarkdownPipe } from '../../../shared/pipes/markdown.pipe';
           } @else if (dossierError()) {
             <div class="p-4 rounded bg-surface-50 text-center">
               <p class="text-sm text-muted-color">{{ dossierError() }}</p>
-              <p-button label="Try Again" size="small" [outlined]="true" (onClick)="loadDossier()" class="mt-2" />
+              @if (dossierAiNotConfigured()) {
+                <a routerLink="/settings" class="inline-block mt-2 text-sm text-primary font-medium">Go to Settings</a>
+              } @else {
+                <p-button label="Try Again" size="small" [outlined]="true" (onClick)="loadDossier()" class="mt-2" />
+              }
             </div>
           }
         </section>
@@ -332,6 +337,7 @@ export class PersonDetailComponent implements OnInit {
   readonly dossier = signal<PersonDossier | null>(null);
   readonly dossierLoading = signal(false);
   readonly dossierError = signal<string | null>(null);
+  readonly dossierAiNotConfigured = signal(false);
   readonly dossierMode = signal<'default' | 'prep'>('default');
 
   // Profile fields
@@ -381,14 +387,20 @@ export class PersonDetailComponent implements OnInit {
 
     this.dossierLoading.set(true);
     this.dossierError.set(null);
+    this.dossierAiNotConfigured.set(false);
     this.briefingService.refreshDossier(p.id, this.dossierMode()).subscribe({
       next: (d) => {
         this.dossier.set(d);
         this.dossierLoading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.dossierLoading.set(false);
-        this.dossierError.set('Failed to generate dossier. Is your AI provider configured?');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.dossierAiNotConfigured.set(true);
+          this.dossierError.set(err.error.error);
+        } else {
+          this.dossierError.set('Failed to generate dossier.');
+        }
       },
     });
   }
@@ -399,14 +411,20 @@ export class PersonDetailComponent implements OnInit {
 
     this.dossierLoading.set(true);
     this.dossierError.set(null);
+    this.dossierAiNotConfigured.set(false);
     this.briefingService.getDossier(p.id, this.dossierMode()).subscribe({
       next: (d) => {
         this.dossier.set(d);
         this.dossierLoading.set(false);
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.dossierLoading.set(false);
-        this.dossierError.set('Failed to generate dossier. Is your AI provider configured?');
+        if (err.status === 422 && err.error?.code === 'ai.notConfigured') {
+          this.dossierAiNotConfigured.set(true);
+          this.dossierError.set(err.error.error);
+        } else {
+          this.dossierError.set('Failed to generate dossier.');
+        }
       },
     });
   }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -178,12 +178,12 @@ app.Use(async (context, next) =>
     {
         await next();
     }
-    catch (AiNotConfiguredException) when (!context.Response.HasStarted)
+    catch (AiNotConfiguredException ex) when (!context.Response.HasStarted)
     {
         context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
         await context.Response.WriteAsJsonAsync(new
         {
-            error = "AI provider not configured. Configure your AI provider in Settings to enable this feature.",
+            error = ex.Message,
             code = "ai.notConfigured"
         });
     }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -178,6 +178,15 @@ app.Use(async (context, next) =>
     {
         await next();
     }
+    catch (AiNotConfiguredException) when (!context.Response.HasStarted)
+    {
+        context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+        await context.Response.WriteAsJsonAsync(new
+        {
+            error = "AI provider not configured. Configure your AI provider in Settings to enable this feature.",
+            code = "ai.notConfigured"
+        });
+    }
     catch (TasteLimitExceededException ex) when (!context.Response.HasStarted)
     {
         context.Response.StatusCode = StatusCodes.Status429TooManyRequests;


### PR DESCRIPTION
## Summary

Briefing and dossier endpoints now return HTTP 422 with a helpful error message when the AI provider is not configured, instead of a generic 502.

Closes #142

## Changes

- New `AiNotConfiguredException` for clear "not configured" signaling
- `AiCompletionService` throws it instead of generic `InvalidOperationException`
- Global error middleware catches it and returns 422 with `code: "ai.notConfigured"`
- Frontend briefing/dossier components show "Configure AI provider in Settings" with link

## Test Plan

- [x] `dotnet test` passes (332 tests)
- [x] `npx ng test --watch=false` passes (41 tests)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle unconfigured AI provider errors explicitly and surface clearer guidance in both backend responses and frontend briefing/dossier UIs.

New Features:
- Expose a dedicated AiNotConfiguredException to represent missing AI provider configuration.
- Add user-facing messaging that links to Settings when AI-backed briefings or dossiers fail due to missing configuration.

Bug Fixes:
- Return HTTP 422 with a specific error payload when the AI provider is not configured instead of generic failures in AI completion flows.

Enhancements:
- Update global error handling middleware to translate AiNotConfiguredException into a structured 422 JSON response with a stable error code.
- Adjust daily/weekly brief and person dossier components to detect ai.notConfigured responses and adapt UI actions and error text accordingly.