### PR TITLE
fix: align sidebar header with main content header

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/components/sidebar.component.ts
@@ -42,7 +42,7 @@ import { ThemeService } from '../services/theme.service';
     }
   `],
   template: `
-    <div class="flex items-center gap-3 p-5 border-b sidebar-border">
+    <div class="flex items-center gap-3 h-14 px-4 border-b sidebar-border shrink-0">
       <i class="pi pi-bolt text-xl sidebar-brand"></i>
       <span class="text-lg font-semibold">Mental Metal</span>
     </div>


### PR DESCRIPTION
## Summary

The sidebar brand header ("Mental Metal") and the main content header (page title/breadcrumb) were not horizontally aligned because they used different height and padding classes. Updated the sidebar header to use `h-14 px-4 shrink-0` to match the main content header.

## Changes

- Changed sidebar brand `<div>` from `p-5` to `h-14 px-4 shrink-0` to match `app.html` header

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (332 tests)
- [x] `ng test --watch=false` passes (41 tests)
- [ ] Visual verification: sidebar "Mental Metal" and main content breadcrumb are horizontally aligned

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Adjust the sidebar header container sizing and spacing classes to match the main content header styling.