### PR TITLE
fix: inject user name into extraction prompt to fix commitment direction (closes #154)

### DIFF
--- a/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
@@ -24,6 +24,7 @@ public sealed class AutoExtractCaptureHandler(
     IPersonRepository personRepository,
     IInitiativeRepository initiativeRepository,
     ICommitmentRepository commitmentRepository,
+    IUserRepository userRepository,
     IAiCompletionService aiCompletionService,
     ITasteBudgetService tasteBudgetService,
     ICurrentUserService currentUserService,
@@ -61,9 +62,13 @@ public sealed class AutoExtractCaptureHandler(
             if (tasteBudgetService.IsEnabled)
                 await tasteBudgetService.DecrementAsync(userId, cancellationToken);
 
-            // 1. Call AI provider
+            // 1. Load user name for prompt context
+            var user = await userRepository.GetByIdAsync(userId, cancellationToken)
+                ?? throw new InvalidOperationException("Authenticated user not found.");
+
+            // 2. Call AI provider
             var aiRequest = new AiCompletionRequest(
-                ExtractionPromptBuilder.SystemPrompt,
+                ExtractionPromptBuilder.BuildSystemPrompt(user.Name),
                 ExtractionPromptBuilder.BuildUserPrompt(capture.RawContent),
                 MaxTokens: 4096,
                 Temperature: 0.1f);

--- a/src/MentalMetal.Application/Captures/AutoExtract/ExtractionPromptBuilder.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/ExtractionPromptBuilder.cs
@@ -5,20 +5,24 @@ namespace MentalMetal.Application.Captures.AutoExtract;
 /// </summary>
 public static class ExtractionPromptBuilder
 {
-    public static string SystemPrompt => """
+    public static string BuildSystemPrompt(string userName) => $$"""
         You are an AI assistant that extracts structured information from meeting transcripts and notes.
         You MUST return ONLY valid JSON — no markdown, no commentary, no code fences.
+
+        These notes were written or recorded by {{userName}}. All commitment directions are
+        from {{userName}}'s perspective.
 
         Extract the following from the provided text:
 
         1. **people_mentioned**: People referenced by name. For each person provide:
            - "raw_name": The name as it appears in the text
            - "context": A brief phrase describing their role or mention context (or null)
+           - Do NOT include {{userName}} in this list — they are the note-taker, not a mentioned person.
 
         2. **commitments**: Action items, promises, or obligations. For each:
            - "description": Clear description of the commitment
-           - "direction": "MineToThem" if the user (the note-taker / meeting organiser) committed to do something for someone else, or "TheirsToMe" if someone else committed to do something for the user
-           - "person_raw_name": The name of the other party involved (or null if unclear)
+           - "direction": "MineToThem" if {{userName}} committed to do something for someone else, or "TheirsToMe" if someone else committed to do something for {{userName}}
+           - "person_raw_name": The name of the OTHER party (not {{userName}}). If {{userName}} is the one who committed, person_raw_name is who they committed TO. If someone else committed, person_raw_name is who committed.
            - "due_date": ISO 8601 date if a deadline was mentioned (or null)
            - "confidence": One of "High", "Medium", or "Low"
              - High = explicit verbal promise with a specific person and timeframe (e.g. "Alice will send the report by Friday")

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
@@ -18,6 +18,7 @@ public class AutoExtractCaptureHandlerTests
     private readonly IPersonRepository _personRepo = Substitute.For<IPersonRepository>();
     private readonly IInitiativeRepository _initiativeRepo = Substitute.For<IInitiativeRepository>();
     private readonly ICommitmentRepository _commitmentRepo = Substitute.For<ICommitmentRepository>();
+    private readonly IUserRepository _userRepo = Substitute.For<IUserRepository>();
     private readonly IAiCompletionService _aiService = Substitute.For<IAiCompletionService>();
     private readonly ITasteBudgetService _tasteBudget = Substitute.For<ITasteBudgetService>();
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
@@ -35,10 +36,12 @@ public class AutoExtractCaptureHandlerTests
             .Returns(new List<Person>());
         _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
             .Returns(new List<Initiative>());
+        _userRepo.GetByIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(User.Register("ext-auth-id", "test@example.com", "Test User", null));
 
         _sut = new AutoExtractCaptureHandler(
             _captureRepo, _personRepo, _initiativeRepo, _commitmentRepo,
-            _aiService, _tasteBudget, _currentUser,
+            _userRepo, _aiService, _tasteBudget, _currentUser,
             new NameResolutionService(), new InitiativeTaggingService(),
             _unitOfWork, _logger);
     }
@@ -344,5 +347,33 @@ public class AutoExtractCaptureHandlerTests
 
         Assert.Equal(ProcessingStatus.Processed, result.ProcessingStatus);
         Assert.Equal("Wrapped in code fences.", result.AiExtraction!.Summary);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SystemPromptIncludesUserName()
+    {
+        var capture = CreateRawCapture();
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "Quick sync.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": []
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        await _aiService.Received(1).CompleteAsync(
+            Arg.Is<AiCompletionRequest>(r => r.SystemPrompt.Contains("Test User")),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
@@ -376,4 +376,27 @@ public class AutoExtractCaptureHandlerTests
             Arg.Is<AiCompletionRequest>(r => r.SystemPrompt.Contains("Test User")),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task HandleAsync_UserNotFound_SetsFailedStatus()
+    {
+        var capture = CreateRawCapture();
+
+        var callCount = 0;
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1) return capture;
+                var fresh = Capture.Create(_userId, "Test meeting notes", CaptureType.MeetingNotes);
+                fresh.BeginProcessing();
+                return fresh;
+            });
+        _userRepo.GetByIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(ProcessingStatus.Failed, result.ProcessingStatus);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes commitment direction (MineToThem / TheirsToMe) being consistently swapped during AI extraction. The extraction prompt referenced "the user (the note-taker)" without identifying who that is, so the AI had to guess — and guessed wrong. Now injects the user's name from their profile so the AI can anchor direction to the correct person.

## Changes

- **`ExtractionPromptBuilder`**: `SystemPrompt` property → `BuildSystemPrompt(string userName)` method. Prompt now names the user explicitly throughout (direction definition, person_raw_name instructions, people_mentioned exclusion)
- **`AutoExtractCaptureHandler`**: Inject `IUserRepository`, load user before calling AI, pass `user.Name` to prompt builder
- **Test**: Verify system prompt includes the user's name via `Arg.Is<>` assertion

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (338 tests: 202 domain + 122 application + 14 integration)
- [x] `ng test --watch=false` passes (41 tests)
- [x] New `HandleAsync_SystemPromptIncludesUserName` test verifies user name injection
- [ ] Re-process an existing transcript and verify commitment directions are correct

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Inject the authenticated user's name into the AI extraction system prompt so commitment directions are interpreted from the correct perspective.

Bug Fixes:
- Correct commitment direction (MineToThem/TheirsToMe) during AI extraction by clarifying the note-taker in the prompt.

Enhancements:
- Update the extraction system prompt to explicitly describe commitments and people relative to the named user, excluding them from people_mentioned.

Tests:
- Add an AutoExtractCaptureHandler test to assert that the AI system prompt includes the current user's name.