### PR TITLE
fix: add direction toggle to commitment detail page

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
@@ -6,6 +6,7 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import { MessageService } from 'primeng/api';
+import { finalize } from 'rxjs';
 import { CommitmentsService } from '../../../shared/services/commitments.service';
 import { PeopleService } from '../../../shared/services/people.service';
 import { InitiativesService } from '../../../shared/services/initiatives.service';
@@ -198,16 +199,14 @@ export class CommitmentDetailComponent implements OnInit {
     if (!c) return;
     const newDirection = c.direction === 'MineToThem' ? 'TheirsToMe' : 'MineToThem';
     this.togglingDirection.set(true);
-    this.commitmentsService.update(c.id, { direction: newDirection }).subscribe({
+    this.commitmentsService.update(c.id, { direction: newDirection }).pipe(
+      finalize(() => this.togglingDirection.set(false)),
+    ).subscribe({
       next: (updated) => {
         this.commitment.set(updated);
-        this.togglingDirection.set(false);
         this.messageService.add({ severity: 'success', summary: 'Direction updated' });
       },
-      error: () => {
-        this.togglingDirection.set(false);
-        this.messageService.add({ severity: 'error', summary: 'Failed to update direction' });
-      },
+      error: () => this.messageService.add({ severity: 'error', summary: 'Failed to update direction' }),
     });
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/commitments/commitment-detail/commitment-detail.component.ts
@@ -4,6 +4,7 @@ import { DatePipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
 import { MessageService } from 'primeng/api';
 import { CommitmentsService } from '../../../shared/services/commitments.service';
 import { PeopleService } from '../../../shared/services/people.service';
@@ -14,7 +15,7 @@ import { Commitment, CommitmentConfidence, CommitmentDirection, CommitmentStatus
   selector: 'app-commitment-detail',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, ButtonModule, TagModule, ToastModule, RouterLink],
+  imports: [DatePipe, ButtonModule, TagModule, ToastModule, TooltipModule, RouterLink],
   providers: [MessageService],
   styles: [`
     .detail-row {
@@ -60,9 +61,23 @@ import { Commitment, CommitmentConfidence, CommitmentDirection, CommitmentStatus
               <span class="text-sm font-medium text-muted-color w-32">Person</span>
               <span class="text-sm">{{ personName() }}</span>
             </div>
-            <div class="flex gap-4 py-2 border-b detail-row">
+            <div class="flex gap-4 py-2 border-b detail-row items-center">
               <span class="text-sm font-medium text-muted-color w-32">Direction</span>
-              <span class="text-sm">{{ formatDirection(commitment()!.direction) }}</span>
+              <div class="flex items-center gap-2">
+                <p-tag
+                  [value]="formatDirection(commitment()!.direction)"
+                  [severity]="directionSeverity(commitment()!.direction)"
+                />
+                <p-button
+                  icon="pi pi-arrow-right-arrow-left"
+                  [text]="true"
+                  size="small"
+                  pTooltip="Switch direction"
+                  ariaLabel="Switch direction"
+                  [loading]="togglingDirection()"
+                  (onClick)="onToggleDirection()"
+                />
+              </div>
             </div>
             <div class="flex gap-4 py-2 border-b detail-row">
               <span class="text-sm font-medium text-muted-color w-32">Confidence</span>
@@ -129,6 +144,7 @@ export class CommitmentDetailComponent implements OnInit {
 
   readonly commitment = signal<Commitment | null>(null);
   readonly loading = signal(true);
+  readonly togglingDirection = signal(false);
   readonly personName = signal('Loading...');
   readonly initiativeName = signal('');
   readonly sourceHighlightParams = computed(() => {
@@ -174,6 +190,24 @@ export class CommitmentDetailComponent implements OnInit {
         this.messageService.add({ severity: 'success', summary: 'Commitment dismissed' });
       },
       error: () => this.messageService.add({ severity: 'error', summary: 'Failed to dismiss' }),
+    });
+  }
+
+  protected onToggleDirection(): void {
+    const c = this.commitment();
+    if (!c) return;
+    const newDirection = c.direction === 'MineToThem' ? 'TheirsToMe' : 'MineToThem';
+    this.togglingDirection.set(true);
+    this.commitmentsService.update(c.id, { direction: newDirection }).subscribe({
+      next: (updated) => {
+        this.commitment.set(updated);
+        this.togglingDirection.set(false);
+        this.messageService.add({ severity: 'success', summary: 'Direction updated' });
+      },
+      error: () => {
+        this.togglingDirection.set(false);
+        this.messageService.add({ severity: 'error', summary: 'Failed to update direction' });
+      },
     });
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/commitment.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/commitment.model.ts
@@ -28,3 +28,12 @@ export interface Commitment {
 export interface CompleteCommitmentRequest {
   notes?: string;
 }
+
+export interface UpdateCommitmentRequest {
+  description?: string;
+  direction?: CommitmentDirection;
+  dueDate?: string;
+  clearDueDate?: boolean;
+  notes?: string;
+  clearNotes?: boolean;
+}

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/commitments.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/commitments.service.ts
@@ -6,6 +6,7 @@ import {
   CommitmentDirection,
   CommitmentStatus,
   CompleteCommitmentRequest,
+  UpdateCommitmentRequest,
 } from '../models/commitment.model';
 
 @Injectable({ providedIn: 'root' })
@@ -53,5 +54,9 @@ export class CommitmentsService {
 
   reopen(id: string): Observable<Commitment> {
     return this.http.post<Commitment>(`${this.baseUrl}/${id}/reopen`, {});
+  }
+
+  update(id: string, request: UpdateCommitmentRequest): Observable<Commitment> {
+    return this.http.put<Commitment>(`${this.baseUrl}/${id}`, request);
   }
 }


### PR DESCRIPTION
## Summary

The commitment detail page had no UI to change direction (I owe them vs They owe me). This adds a swap button next to the direction tag that calls the existing `PUT /api/commitments/{id}` endpoint added in PR #157.

## Changes

- Add `UpdateCommitmentRequest` interface to `commitment.model.ts`
- Add `update()` method to `CommitmentsService`
- Add direction swap button (arrow icon) with loading state and tooltip to commitment detail page
- Import `TooltipModule` for the new button

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (356 tests)
- [x] `npx ng test --watch=false` passes (41 tests)
- [ ] Clicking the swap button toggles "I owe them" ↔ "They owe me" and persists
- [ ] Button shows loading spinner during the API call
- [ ] Header tag and detail row both update after toggle

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for changing a commitment's direction directly from the commitment detail page and wiring it to the existing backend update endpoint.

New Features:
- Add a direction swap button on the commitment detail page with tooltip and loading state to toggle between directions.

Enhancements:
- Introduce an UpdateCommitmentRequest model and update method on CommitmentsService to call the existing commitment update API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to toggle a commitment's direction directly from the detail view. A new direction toggle button provides visual feedback during updates and displays success or error notifications upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->