### PR TITLE
chore: archive async-capture-processing change and sync specs

### DIFF
--- a/openspec/changes/archive/2026-04-20-async-capture-processing/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/design.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/design.md
@@ -1,0 +1,64 @@
+## Context
+
+Capture creation currently runs the full AI extraction pipeline synchronously within the HTTP request handler. The pipeline (AI completion → name resolution → initiative tagging → commitment spawning) takes 5–30 seconds depending on content length and AI provider latency. During this time the frontend is blocked — the submit button shows a spinner and the user cannot navigate or do anything else.
+
+The app is single-tenant (one user per deployment) running on Google Cloud Run. There is no job queue infrastructure (Hangfire, Cloud Tasks, etc.) and adding one is out of scope.
+
+**Dependencies**: capture-text, capture-ai-extraction (both already implemented).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Capture creation endpoints return in <500ms with the capture in `Raw` status
+- Extraction runs as a fire-and-forget background task within the same process
+- Users see real-time processing status on the captures list page
+- Users get notified when extraction completes, regardless of which page they're on
+
+**Non-Goals:**
+- Durable job queue infrastructure (Hangfire, Cloud Tasks) — overkill for single-tenant
+- WebSocket/SSE push notifications — polling is simpler and sufficient
+- Retry logic beyond what already exists on the capture detail page
+- Changes to the quick-capture dialog layout
+
+## Decisions
+
+### 1. Fire-and-forget background extraction via `IHostedService` scope
+
+**Decision**: Use `Task.Run` with a manually-created DI scope to fire the extraction pipeline after the HTTP response returns.
+
+**Why**: Cloud Run processes are ephemeral but long-lived enough for our use case (requests complete in <30s). A full job queue adds deployment complexity (Redis, Hangfire dashboard, etc.) that isn't justified for a single-tenant app. The `IServiceScopeFactory` pattern gives us a proper DI scope with its own `DbContext` and `ICurrentUserService` — critical since the HTTP request scope is disposed before extraction completes.
+
+**Alternative considered**: `IHostedService` with a `Channel<T>` — more structured but adds complexity for no benefit when we only need fire-and-forget.
+
+**Risk mitigation**: The `IBackgroundUserScope.SetUserId()` mechanism already exists for setting the user context outside of HTTP requests. If the process terminates mid-extraction, the capture remains in `Processing` status and the user can retry from the detail page.
+
+### 2. Polling via existing GET /api/captures endpoint
+
+**Decision**: The frontend polls `GET /api/captures?status=Processing` on a 3-second interval when there are items in the processing queue. No new polling endpoint needed.
+
+**Why**: The existing endpoint already returns `processingStatus` for each capture. Filtering by `status=Processing` is already supported. Adding a dedicated polling endpoint would be redundant.
+
+**Polling lifecycle**: Start polling when a capture is submitted or when the page loads with processing items visible. Stop when no items have `Processing` status for 2 consecutive polls. Use `setInterval` with cleanup on component destroy.
+
+**Alternative considered**: New `GET /api/captures/processing-status` lightweight endpoint — cleaner but adds API surface for marginal performance gain.
+
+### 3. Global toast service for completion notifications
+
+**Decision**: Create a singleton `CaptureProcessingService` in the frontend that tracks in-flight capture IDs. It polls for status changes and emits completion events. The app shell subscribes and shows PrimeNG `Toast` notifications.
+
+**Why**: Toasts must appear from any page, not just the captures list. A global service that polls for recently-submitted captures gives us cross-page notifications without WebSockets.
+
+**Lifecycle**: When a capture is created (from quick-capture dialog or captures page), its ID is added to the tracking set. The service polls every 5 seconds. When a tracked capture transitions to `Processed` or `Failed`, a toast is shown and the ID is removed from tracking. Tracking state lives in memory (no persistence needed — refresh = re-discover from API).
+
+### 4. Inline processing queue UI (Option 5 from mockups)
+
+**Decision**: Add a "Currently Processing" section at the top of the captures list component. Items in this section show a spinner with the current stage label. When processing completes, items animate into the main table.
+
+**Why**: User selected this approach from 10 mockup options. It's contextually appropriate (visible on the page where captures live), doesn't add permanent UI chrome to other pages, and complements the toast notifications for cross-page awareness.
+
+## Risks / Trade-offs
+
+- **[Process termination during extraction]** → Capture stays in `Processing` forever. Mitigation: existing "Retry" button on capture detail page; future enhancement could add a stale-processing detector.
+- **[Polling battery/network cost]** → 3s interval is aggressive. Mitigation: only poll when processing items exist; stop after 2 clean polls; only poll on captures list page. Global service polls at 5s, only for tracked IDs.
+- **[Race condition: capture created but not yet visible]** → Between HTTP response and first poll, the capture might not appear in the inline queue. Mitigation: optimistically add the capture to the queue from the creation response (Raw status).
+- **[DI scope leak in background task]** → The background task must create its own scope and not capture any request-scoped services. Mitigation: only pass primitive values (captureId, userId) to the background task; resolve all services from the new scope.

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/proposal.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Capture creation (text paste, file upload, audio recording) currently runs AI extraction synchronously within the HTTP request, blocking the UI for 5–30 seconds while the pipeline completes. Users cannot interact with the app during this time — no navigation, no parallel work. This makes the tool feel sluggish and discourages frequent capture, which is the core value loop.
+
+## What Changes
+
+- **Decouple extraction from the HTTP response**: API endpoints return immediately after saving the capture in `Raw` status. Extraction runs as a background task on the server.
+- **Add "Currently Processing" inline queue**: A dedicated section at the top of the captures list page shows each in-flight capture with its current stage (Uploading → Transcribing → Extracting → Resolving) and a spinner. Items move to the main table once processing completes.
+- **Add completion toasts**: When a capture finishes processing (from any page), a toast notification appears with an extraction summary (e.g. "3 commitments · 2 people found") and a View link.
+- **Frontend polling**: The captures list page polls for status updates on processing items so the inline queue reflects real-time progress.
+
+## Non-goals
+
+- WebSocket/SSE for real-time push — polling is sufficient for this use case and far simpler to implement on Cloud Run.
+- Retry UI for failed extractions — the existing "Retry" button on the capture detail page is sufficient.
+- Background job queue infrastructure (Hangfire, Cloud Tasks) — a simple `Task.Run` fire-and-forget within the request scope is adequate given the single-user architecture.
+- Changes to the quick-capture dialog UX — it already closes on submit; we just make it close faster.
+
+## Capabilities
+
+### New Capabilities
+- `async-capture-pipeline`: Background extraction pipeline, polling endpoint, and inline processing queue UI with completion toasts.
+
+### Modified Capabilities
+- `capture-text`: POST /api/captures, POST /api/captures/import, and POST /api/captures/audio now return immediately with `Raw` status instead of waiting for extraction.
+- `capture-ai-extraction`: Extraction is triggered as a background task rather than inline in the HTTP request.
+
+## Impact
+
+- **Backend**: `POST /api/captures`, `POST /api/captures/import`, `POST /api/captures/audio` endpoints change response behavior (return Raw instead of Processed). New or modified endpoint for polling processing status.
+- **Frontend**: Captures list component gains inline queue section and polling logic. New global toast service for extraction completion notifications.
+- **Aggregates affected**: Capture (status transitions), no schema changes needed.
+- **API contract**: Response shape unchanged, but `processingStatus` in the response will now be `Raw` instead of `Processed` on creation. Existing clients that relied on extraction results being present in the creation response will need updating.
+- **Tier**: Cross-cuts Tier 2 (capture-text, capture-ai-extraction). No new dependencies.

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/specs/async-capture-pipeline/spec.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/specs/async-capture-pipeline/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Inline processing queue on captures list page
+
+The captures list page SHALL display a "Currently Processing" section above the main captures table when one or more captures have `processingStatus` of `Raw` or `Processing`. Each item in the queue SHALL show the capture title (or a truncated preview of raw content if no title), a spinner icon, and the current processing stage label. When no captures are processing, the section SHALL be hidden entirely.
+
+#### Scenario: Processing queue visible with active items
+
+- **WHEN** the user navigates to the captures list page and 2 captures have status `Processing`
+- **THEN** a "Currently Processing" section appears above the captures table showing both items with spinners and stage labels
+
+#### Scenario: Processing queue hidden when empty
+
+- **WHEN** the user navigates to the captures list page and no captures have status `Raw` or `Processing`
+- **THEN** the "Currently Processing" section is not rendered
+
+#### Scenario: Item transitions from queue to table
+
+- **WHEN** a capture in the processing queue transitions to `Processed` status
+- **THEN** the item is removed from the "Currently Processing" section and appears in the main captures table on the next poll cycle
+
+#### Scenario: Failed item in queue
+
+- **WHEN** a capture in the processing queue transitions to `Failed` status
+- **THEN** the item is removed from the processing queue and appears in the main table with a `Failed` status badge
+
+### Requirement: Captures list polls for status updates
+
+The captures list page SHALL poll `GET /api/captures` on a 3-second interval when the "Currently Processing" section is visible. Polling SHALL stop after 2 consecutive responses with no `Raw` or `Processing` captures. Polling SHALL restart when a new capture is created.
+
+#### Scenario: Polling starts on page load with processing items
+
+- **WHEN** the user loads the captures list page and 1 capture has status `Processing`
+- **THEN** the page begins polling every 3 seconds
+
+#### Scenario: Polling stops when queue empties
+
+- **WHEN** all processing captures complete and 2 consecutive polls return no processing items
+- **THEN** polling stops
+
+#### Scenario: Polling restarts on new capture
+
+- **WHEN** polling has stopped and the user creates a new capture
+- **THEN** polling restarts at a 3-second interval
+
+### Requirement: Global capture completion toast
+
+A global service SHALL track capture IDs submitted during the current session. The service SHALL poll `GET /api/captures` every 5 seconds when tracking active captures. When a tracked capture transitions to `Processed`, the service SHALL display a PrimeNG success toast with the capture title and an extraction summary (commitment count, people count). When a tracked capture transitions to `Failed`, the service SHALL display an error toast. The toast SHALL include a "View" link that navigates to the capture detail page.
+
+#### Scenario: Success toast on completion
+
+- **WHEN** the user submits a capture from the quick-capture dialog and navigates to the dashboard
+- **AND** the capture finishes processing in the background
+- **THEN** a success toast appears showing the capture title, extraction summary, and a "View" link
+
+#### Scenario: Failure toast on error
+
+- **WHEN** a tracked capture transitions to `Failed` status
+- **THEN** an error toast appears with the capture title and failure reason
+
+#### Scenario: Toast navigation
+
+- **WHEN** the user clicks the "View" link in a completion toast
+- **THEN** the app navigates to `/capture/{id}` for that capture
+
+#### Scenario: Tracking clears on completion
+
+- **WHEN** a toast is shown for a tracked capture
+- **THEN** the capture ID is removed from the tracking set and no further polls check for it
+
+### Requirement: Optimistic queue entry on capture creation
+
+When a capture is created via any method (text, file import, audio upload), the captures list (if mounted) SHALL optimistically add the new capture to the "Currently Processing" section using the data from the creation API response, without waiting for the next poll.
+
+#### Scenario: Immediate queue entry after text capture
+
+- **WHEN** the user submits a text capture via the quick-capture dialog while on the captures list page
+- **THEN** the capture appears immediately in the "Currently Processing" section with status `Raw`

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/specs/capture-ai-extraction/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Begin processing a capture
+
+The system SHALL automatically trigger AI processing on a Capture after it is created, as a background task outside the HTTP request lifecycle. The extraction SHALL run within a new DI scope using `IServiceScopeFactory`, with the user context set via `IBackgroundUserScope.SetUserId()`. The capture's status SHALL transition from `Raw` to `Processing` at the start of extraction and to `Processed` or `Failed` upon completion. If the background task fails to start or the process terminates during extraction, the capture SHALL remain in its current status (`Raw` or `Processing`) and the user MAY retry via the existing retry mechanism.
+
+#### Scenario: Background extraction triggered after capture creation
+
+- **WHEN** a capture is created via POST /api/captures
+- **THEN** the HTTP response returns immediately with the capture in `Raw` status
+- **AND** a background task begins extraction within the same server process
+
+#### Scenario: Background extraction completes successfully
+
+- **WHEN** the background extraction task runs on a capture
+- **THEN** the capture transitions from `Raw` → `Processing` → `Processed`
+- **AND** extracted commitments, people mentions, and initiative tags are persisted
+
+#### Scenario: Background extraction fails
+
+- **WHEN** the AI provider call fails during background extraction
+- **THEN** the capture transitions to `Failed` with the error message as the failure reason
+- **AND** the capture is available for retry via the existing capture detail page
+
+#### Scenario: Process termination during extraction
+
+- **WHEN** the server process terminates while extraction is in progress
+- **THEN** the capture remains in `Processing` status
+- **AND** the user can retry extraction from the capture detail page
+
+#### Scenario: DI scope isolation
+
+- **WHEN** the background extraction task runs
+- **THEN** it uses its own DI scope independent of the HTTP request scope
+- **AND** the HTTP request scope is not kept alive by the background task

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/specs/capture-text/spec.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/specs/capture-text/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Create a capture
+
+The system SHALL allow an authenticated user to create a new Capture with raw text content and a capture type (QuickNote, Transcript, or MeetingNotes). RawContent MUST NOT be empty. The system SHALL set ProcessingStatus to `Raw`, set CapturedAt to the current time, and scope the Capture to the authenticated user's UserId. The system SHALL raise a `CaptureCreated` domain event. The API SHALL return HTTP 201 immediately with the capture in `Raw` status. The system SHALL trigger AI extraction as a background task after the response is sent — the HTTP response MUST NOT wait for extraction to complete.
+
+#### Scenario: Create a quick note
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent "Follow up with Sarah on Q3 roadmap" and type "QuickNote"
+- **THEN** the system creates a Capture with the given content, type QuickNote, status Raw, and returns HTTP 201 with the created capture
+- **AND** AI extraction begins asynchronously in the background
+
+#### Scenario: Create a transcript capture with optional fields
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing a pasted transcript, type "Transcript", title "Leadership sync 2026-04-10", and source "leadership sync"
+- **THEN** the system creates a Capture with all provided fields, returns HTTP 201
+- **AND** the response returns within 500ms (extraction runs in background)
+
+#### Scenario: Create a meeting notes capture
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing meeting notes and type "MeetingNotes"
+- **THEN** the system creates a Capture with type MeetingNotes, returns HTTP 201 with status `Raw`
+- **AND** the capture transitions to `Processed` asynchronously after extraction completes
+
+#### Scenario: Empty content rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/captures` with empty or whitespace-only rawContent
+- **THEN** the system returns HTTP 400 with a validation error
+
+#### Scenario: User isolation
+
+- **WHEN** User A creates a capture and User B creates a capture
+- **THEN** each capture is scoped to its respective user's UserId

--- a/openspec/changes/archive/2026-04-20-async-capture-processing/tasks.md
+++ b/openspec/changes/archive/2026-04-20-async-capture-processing/tasks.md
@@ -1,0 +1,33 @@
+## 1. Backend — Decouple extraction from HTTP request
+
+- [x] 1.1 Extract background extraction logic: create `BackgroundExtractionTrigger` service that accepts `(captureId, userId)`, creates a new DI scope via `IServiceScopeFactory`, sets user context via `IBackgroundUserScope.SetUserId()`, and calls `AutoExtractCaptureHandler.HandleAsync()`
+- [x] 1.2 Modify `POST /api/captures` endpoint in `Program.cs` to return `201 Created` immediately with the capture in `Raw` status, then fire extraction via `BackgroundExtractionTrigger` (no await)
+- [x] 1.3 Modify `POST /api/captures/import` endpoint to return immediately after capture creation, fire extraction in background
+- [x] 1.4 Modify `POST /api/captures/audio` (UploadAudioCapture) to fire extraction in background after transcription completes (transcription itself may remain synchronous since it writes to the capture)
+- [x] 1.5 Add unit tests for `BackgroundExtractionTrigger` verifying scope creation, user context setup, and error handling (capture marked `Failed` on exception)
+
+## 2. Frontend — Global capture processing service
+
+- [x] 2.1 Create `CaptureProcessingTracker` service (singleton/root-provided) with: `track(captureId)` to add a capture to the tracking set, `completions$` observable that emits when tracked captures finish, and internal 5-second polling logic
+- [x] 2.2 Wire `CaptureProcessingTracker.track()` into `QuickCaptureDialogComponent` — call `track(capture.id)` after successful creation
+- [x] 2.3 Wire `CaptureProcessingTracker.track()` into captures list page for file uploads and recorder submissions
+- [x] 2.4 Add PrimeNG `Toast` to the app shell (`app.html`) and subscribe to `CaptureProcessingTracker.completions$` to show success/failure toasts with capture title, extraction summary (commitment count, people count), and View link
+
+## 3. Frontend — Inline processing queue on captures list
+
+- [x] 3.1 Add "Currently Processing" section to `CapturesListComponent` template: conditionally rendered when any captures have `processingStatus` of `Raw` or `Processing`, showing each item with spinner, title, and stage label
+- [x] 3.2 Add 3-second polling logic to `CapturesListComponent`: start when processing items exist, stop after 2 clean polls, restart when new capture created
+- [x] 3.3 Add optimistic queue entry: when a capture is created from this page (file drop, recorder), immediately add it to the processing queue signal from the API response
+- [x] 3.4 Style the inline queue using PrimeNG tokens and Tailwind layout utilities (match mockup Option 5 — indigo-tinted background, spinner icons, stage labels)
+
+## 4. Frontend — Quick capture dialog update
+
+- [x] 4.1 Update `QuickCaptureDialogComponent` to close immediately on successful API response (no longer waits for extraction). The `submitting` signal still gates the button during the HTTP call, but the call now returns in <500ms
+- [x] 4.2 Show a brief "Capture saved — processing in background" info toast immediately after dialog closes
+
+## 5. Testing
+
+- [x] 5.1 Add application-level tests verifying that capture creation endpoints no longer call `AutoExtractCaptureHandler` synchronously
+- [x] 5.2 Add frontend unit tests for `CaptureProcessingTracker` service (tracking, polling, completion emission)
+- [x] 5.3 Add frontend unit tests for the inline processing queue (visibility toggle, item rendering, polling lifecycle)
+- [x] 5.4 Run full backend test suite (`dotnet test src/MentalMetal.slnx`) and frontend tests (`ng test --watch=false`) — verify no regressions

--- a/openspec/specs/async-capture-pipeline/spec.md
+++ b/openspec/specs/async-capture-pipeline/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Inline processing queue on captures list page
+
+The captures list page SHALL display a "Currently Processing" section above the main captures table when one or more captures have `processingStatus` of `Raw` or `Processing`. Each item in the queue SHALL show the capture title (or a truncated preview of raw content if no title), a spinner icon, and the current processing stage label. When no captures are processing, the section SHALL be hidden entirely.
+
+#### Scenario: Processing queue visible with active items
+
+- **WHEN** the user navigates to the captures list page and 2 captures have status `Processing`
+- **THEN** a "Currently Processing" section appears above the captures table showing both items with spinners and stage labels
+
+#### Scenario: Processing queue hidden when empty
+
+- **WHEN** the user navigates to the captures list page and no captures have status `Raw` or `Processing`
+- **THEN** the "Currently Processing" section is not rendered
+
+#### Scenario: Item transitions from queue to table
+
+- **WHEN** a capture in the processing queue transitions to `Processed` status
+- **THEN** the item is removed from the "Currently Processing" section and appears in the main captures table on the next poll cycle
+
+#### Scenario: Failed item in queue
+
+- **WHEN** a capture in the processing queue transitions to `Failed` status
+- **THEN** the item is removed from the processing queue and appears in the main table with a `Failed` status badge
+
+### Requirement: Captures list polls for status updates
+
+The captures list page SHALL poll `GET /api/captures` on a 3-second interval when the "Currently Processing" section is visible. Polling SHALL stop after 2 consecutive responses with no `Raw` or `Processing` captures. Polling SHALL restart when a new capture is created.
+
+#### Scenario: Polling starts on page load with processing items
+
+- **WHEN** the user loads the captures list page and 1 capture has status `Processing`
+- **THEN** the page begins polling every 3 seconds
+
+#### Scenario: Polling stops when queue empties
+
+- **WHEN** all processing captures complete and 2 consecutive polls return no processing items
+- **THEN** polling stops
+
+#### Scenario: Polling restarts on new capture
+
+- **WHEN** polling has stopped and the user creates a new capture
+- **THEN** polling restarts at a 3-second interval
+
+### Requirement: Global capture completion toast
+
+A global service SHALL track capture IDs submitted during the current session. The service SHALL poll `GET /api/captures` every 5 seconds when tracking active captures. When a tracked capture transitions to `Processed`, the service SHALL display a PrimeNG success toast with the capture title and an extraction summary (commitment count, people count). When a tracked capture transitions to `Failed`, the service SHALL display an error toast. The toast SHALL include a "View" link that navigates to the capture detail page.
+
+#### Scenario: Success toast on completion
+
+- **WHEN** the user submits a capture from the quick-capture dialog and navigates to the dashboard
+- **AND** the capture finishes processing in the background
+- **THEN** a success toast appears showing the capture title, extraction summary, and a "View" link
+
+#### Scenario: Failure toast on error
+
+- **WHEN** a tracked capture transitions to `Failed` status
+- **THEN** an error toast appears with the capture title and failure reason
+
+#### Scenario: Toast navigation
+
+- **WHEN** the user clicks the "View" link in a completion toast
+- **THEN** the app navigates to `/capture/{id}` for that capture
+
+#### Scenario: Tracking clears on completion
+
+- **WHEN** a toast is shown for a tracked capture
+- **THEN** the capture ID is removed from the tracking set and no further polls check for it
+
+### Requirement: Optimistic queue entry on capture creation
+
+When a capture is created via any method (text, file import, audio upload), the captures list (if mounted) SHALL optimistically add the new capture to the "Currently Processing" section using the data from the creation API response, without waiting for the next poll.
+
+#### Scenario: Immediate queue entry after text capture
+
+- **WHEN** the user submits a text capture via the quick-capture dialog while on the captures list page
+- **THEN** the capture appears immediately in the "Currently Processing" section with status `Raw`

--- a/openspec/specs/capture-ai-extraction/spec.md
+++ b/openspec/specs/capture-ai-extraction/spec.md
@@ -4,22 +4,37 @@
 
 ### Requirement: Begin processing a capture
 
-The system SHALL allow an authenticated user to trigger AI processing on a Capture with status `Raw` by sending a POST to `/api/captures/{id}/process`. The system SHALL call `BeginProcessing()` on the Capture aggregate (transitioning status to `Processing`) and enqueue an asynchronous processing job. If the capture is not in status `Raw`, the system SHALL return HTTP 409 Conflict.
+The system SHALL automatically trigger AI processing on a Capture after it is created, as a background task outside the HTTP request lifecycle. The extraction SHALL run within a new DI scope using `IServiceScopeFactory`, with the user context set via `IBackgroundUserScope.SetUserId()`. The capture's status SHALL transition from `Raw` to `Processing` at the start of extraction and to `Processed` or `Failed` upon completion. If the background task fails to start or the process terminates during extraction, the capture SHALL remain in its current status (`Raw` or `Processing`) and the user MAY retry via the existing retry mechanism.
 
-#### Scenario: Trigger processing on a raw capture
+#### Scenario: Background extraction triggered after capture creation
 
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/process` for a capture with status Raw
-- **THEN** the system transitions the capture to Processing and returns HTTP 202 Accepted
+- **WHEN** a capture is created via POST /api/captures
+- **THEN** the HTTP response returns immediately with the capture in `Raw` status
+- **AND** a background task begins extraction within the same server process
 
-#### Scenario: Trigger processing on a non-raw capture
+#### Scenario: Background extraction completes successfully
 
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/process` for a capture with status Processing or Processed
-- **THEN** the system returns HTTP 409 Conflict
+- **WHEN** the background extraction task runs on a capture
+- **THEN** the capture transitions from `Raw` to `Processing` to `Processed`
+- **AND** extracted commitments, people mentions, and initiative tags are persisted
 
-#### Scenario: Capture not found
+#### Scenario: Background extraction fails
 
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/process` for a capture that does not exist or belongs to another user
-- **THEN** the system returns HTTP 404
+- **WHEN** the AI provider call fails during background extraction
+- **THEN** the capture transitions to `Failed` with the error message as the failure reason
+- **AND** the capture is available for retry via the existing capture detail page
+
+#### Scenario: Process termination during extraction
+
+- **WHEN** the server process terminates while extraction is in progress
+- **THEN** the capture remains in `Processing` status
+- **AND** the user can retry extraction from the capture detail page
+
+#### Scenario: DI scope isolation
+
+- **WHEN** the background extraction task runs
+- **THEN** it uses its own DI scope independent of the HTTP request scope
+- **AND** the HTTP request scope is not kept alive by the background task
 
 ### Requirement: AI extraction pipeline
 

--- a/openspec/specs/capture-text/spec.md
+++ b/openspec/specs/capture-text/spec.md
@@ -4,22 +4,25 @@
 
 ### Requirement: Create a capture
 
-The system SHALL allow an authenticated user to create a new Capture with raw text content and a capture type (QuickNote, Transcript, or MeetingNotes). RawContent MUST NOT be empty. The system SHALL set ProcessingStatus to `Raw`, set CapturedAt to the current time, and scope the Capture to the authenticated user's UserId. The system SHALL raise a `CaptureCreated` domain event.
+The system SHALL allow an authenticated user to create a new Capture with raw text content and a capture type (QuickNote, Transcript, or MeetingNotes). RawContent MUST NOT be empty. The system SHALL set ProcessingStatus to `Raw`, set CapturedAt to the current time, and scope the Capture to the authenticated user's UserId. The system SHALL raise a `CaptureCreated` domain event. The API SHALL return HTTP 201 immediately with the capture in `Raw` status. The system SHALL trigger AI extraction as a background task after the response is sent — the HTTP response MUST NOT wait for extraction to complete.
 
 #### Scenario: Create a quick note
 
 - **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent "Follow up with Sarah on Q3 roadmap" and type "QuickNote"
 - **THEN** the system creates a Capture with the given content, type QuickNote, status Raw, and returns HTTP 201 with the created capture
+- **AND** AI extraction begins asynchronously in the background
 
 #### Scenario: Create a transcript capture with optional fields
 
 - **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing a pasted transcript, type "Transcript", title "Leadership sync 2026-04-10", and source "leadership sync"
-- **THEN** the system creates a Capture with all provided fields and returns HTTP 201
+- **THEN** the system creates a Capture with all provided fields, returns HTTP 201
+- **AND** the response returns within 500ms (extraction runs in background)
 
 #### Scenario: Create a meeting notes capture
 
 - **WHEN** an authenticated user sends a POST to `/api/captures` with rawContent containing meeting notes and type "MeetingNotes"
-- **THEN** the system creates a Capture with type MeetingNotes and returns HTTP 201
+- **THEN** the system creates a Capture with type MeetingNotes, returns HTTP 201 with status `Raw`
+- **AND** the capture transitions to `Processed` asynchronously after extraction completes
 
 #### Scenario: Empty content rejected
 


### PR DESCRIPTION
## Summary

Archives the completed `async-capture-processing` OpenSpec change and syncs delta specs to main specs.

## Changes

- **Spec sync**: Updated `capture-text` and `capture-ai-extraction` main specs with async behavior requirements
- **New spec**: `async-capture-pipeline` main spec (inline queue, polling, toasts)
- **Archive**: Moved change to `openspec/changes/archive/2026-04-20-async-capture-processing/`

## Test Plan

- [x] No code changes — OpenSpec documentation only
- [x] All artifacts complete, all 19/19 tasks marked done

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document asynchronous capture processing as the default behavior and archive the completed OpenSpec change set.

Enhancements:
- Update capture-text and capture-ai-extraction main specs to describe non-blocking capture creation and background AI extraction.
- Introduce an async-capture-pipeline main spec covering the inline processing queue, polling behavior, and global completion toasts.
- Archive the async capture processing proposal, design, specs, and tasks under a dated OpenSpec change directory.