### PR TITLE
fix: accept video/webm and audio/ogg MIME types for audio capture

### DIFF
--- a/src/MentalMetal.Infrastructure/Storage/FileSystemAudioBlobStore.cs
+++ b/src/MentalMetal.Infrastructure/Storage/FileSystemAudioBlobStore.cs
@@ -50,7 +50,7 @@ public sealed class FileSystemAudioBlobStore(IOptions<AudioBlobStoreOptions> opt
 
     private static string MimeToExtension(string? mimeType) => mimeType switch
     {
-        "audio/webm" => ".webm",
+        "audio/webm" or "video/webm" => ".webm",
         "audio/mp4" or "audio/x-m4a" => ".m4a",
         "audio/mpeg" => ".mp3",
         "audio/wav" or "audio/x-wav" => ".wav",

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/deepgram-transcription.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/deepgram-transcription.service.ts
@@ -209,7 +209,7 @@ export class DeepgramTranscriptionService implements OnDestroy {
       this.pendingAudioChunks = [];
       const reason = closeReason
         ? `Transcription service unavailable: ${closeReason}`
-        : 'Could not connect to transcription service. Please try again.';
+        : 'Could not connect to transcription service. Check your Deepgram API key in Settings, or try again.';
       this.error.set(reason);
       return;
     }

--- a/src/MentalMetal.Web/Features/Captures/AudioUploadOptions.cs
+++ b/src/MentalMetal.Web/Features/Captures/AudioUploadOptions.cs
@@ -21,5 +21,7 @@ public sealed class AudioUploadOptions
         "audio/mp4",
         "audio/mpeg",
         "audio/wav",
+        "audio/ogg",
+        "video/webm",  // getDisplayMedia (tab capture) produces video/webm even for audio-only
     };
 }

--- a/src/MentalMetal.Web/appsettings.json
+++ b/src/MentalMetal.Web/appsettings.json
@@ -28,7 +28,7 @@
   },
   "AudioUpload": {
     "MaxSizeBytes": 52428800,
-    "AllowedMimeTypes": [ "audio/webm", "audio/mp4", "audio/mpeg", "audio/wav" ]
+    "AllowedMimeTypes": [ "audio/webm", "audio/mp4", "audio/mpeg", "audio/wav", "audio/ogg", "video/webm" ]
   },
   "Briefing": {
     "MorningBriefingHour": 5,

--- a/tests/MentalMetal.Web.IntegrationTests/AudioUploadOptionsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/AudioUploadOptionsTests.cs
@@ -1,0 +1,26 @@
+using MentalMetal.Web.Features.Captures;
+
+namespace MentalMetal.Web.IntegrationTests;
+
+/// <summary>
+/// Regression tests for AudioUploadOptions to prevent browser MIME type
+/// rejections. Browsers produce different MIME types depending on
+/// MediaRecorder implementation (Chrome vs Firefox vs Safari) and
+/// whether getDisplayMedia (tab capture) is used.
+/// </summary>
+public class AudioUploadOptionsTests
+{
+    [Theory]
+    [InlineData("audio/webm")]          // Chrome/Edge microphone
+    [InlineData("audio/mp4")]           // Safari
+    [InlineData("audio/mpeg")]          // MP3 uploads
+    [InlineData("audio/wav")]           // WAV uploads
+    [InlineData("audio/ogg")]           // Firefox
+    [InlineData("video/webm")]          // Chrome getDisplayMedia (tab capture with video: true)
+    public void DefaultAllowedMimeTypes_IncludesBrowserVariant(string mimeType)
+    {
+        var options = new AudioUploadOptions();
+
+        Assert.Contains(mimeType, options.AllowedMimeTypes, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/tests/MentalMetal.Web.IntegrationTests/AudioUploadOptionsTests.cs
+++ b/tests/MentalMetal.Web.IntegrationTests/AudioUploadOptionsTests.cs
@@ -23,4 +23,17 @@ public class AudioUploadOptionsTests
 
         Assert.Contains(mimeType, options.AllowedMimeTypes, StringComparer.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void DefaultAllowedMimeTypes_ExactSet()
+    {
+        var options = new AudioUploadOptions();
+        var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "audio/webm", "audio/mp4", "audio/mpeg", "audio/wav", "audio/ogg", "video/webm"
+        };
+
+        Assert.Equal(expected.Count, options.AllowedMimeTypes.Count);
+        Assert.All(options.AllowedMimeTypes, mime => Assert.Contains(mime, expected));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two audio capture bugs:

1. **audio.invalidFormat on Record Meeting**: `getDisplayMedia` (tab capture) produces `video/webm` because Chrome requires `video: true` for the tab picker. The server's allowed MIME type list only included `audio/*` types, rejecting the upload.
2. **WebSocket transcription connection failure**: Improved error message to suggest checking the Deepgram API key in Settings when the WebSocket connection fails, instead of the generic "Could not connect" message.

## Changes

- Add `video/webm` and `audio/ogg` (Firefox) to `AudioUploadOptions.AllowedMimeTypes` defaults and `appsettings.json`
- Improve WebSocket failure error message in `DeepgramTranscriptionService`
- 6 new regression tests verifying all browser MIME type variants are accepted

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (363 tests)
- [x] `ng test --watch=false` passes (41 tests)
- [x] New `AudioUploadOptionsTests` with 6 `[InlineData]` cases covering Chrome, Firefox, Safari, and tab capture variants

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow additional browser audio capture MIME types and improve transcription connection error messaging.

Bug Fixes:
- Accept Firefox audio/ogg and Chrome tab-capture video/webm MIME types for audio uploads to prevent valid recordings from being rejected.

Enhancements:
- Improve Deepgram transcription WebSocket failure message to guide users to verify their API key in Settings.

Tests:
- Add regression tests ensuring all supported browser audio and tab-capture MIME types are included in the default allowed list.