### PR TITLE
fix: queue concurrent 401s behind single token refresh

### DIFF
--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClient,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { authInterceptor } from './auth.interceptor';
+import { AuthService } from './auth.service';
+import { firstValueFrom } from 'rxjs';
+
+/**
+ * Regression tests for the auth interceptor — specifically the 401 race
+ * condition on first load (GitHub #168). When multiple requests receive 401s
+ * concurrently, the interceptor must queue them behind a single token refresh
+ * rather than dropping all but the first.
+ */
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpTesting: HttpTestingController;
+  let authService: AuthService;
+
+  beforeEach(() => {
+    // Clear any module-level state from previous tests
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+  });
+
+  it('attaches bearer token to authenticated requests', () => {
+    authService.accessToken.set('test-token');
+
+    http.get('/api/data').subscribe();
+
+    const req = httpTesting.expectOne('/api/data');
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer test-token',
+    );
+    req.flush({});
+  });
+
+  it('does not attach token to unauthenticated auth endpoints', () => {
+    authService.accessToken.set('test-token');
+
+    http.post('/api/auth/login', {}).subscribe();
+
+    const req = httpTesting.expectOne('/api/auth/login');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+
+  it('retries with new token after a 401 triggers refresh', async () => {
+    authService.accessToken.set('expired-token');
+
+    const data$ = firstValueFrom(http.get<{ ok: boolean }>('/api/data'));
+
+    // First request goes out with expired token
+    const firstReq = httpTesting.expectOne('/api/data');
+    expect(firstReq.request.headers.get('Authorization')).toBe(
+      'Bearer expired-token',
+    );
+
+    // Simulate refreshToken succeeding (async to mirror real behavior)
+    vi.spyOn(authService, 'refreshToken').mockImplementation(async () => {
+      authService.accessToken.set('fresh-token');
+      authService.refreshResult$.next('fresh-token');
+      return true;
+    });
+
+    // Respond with 401
+    firstReq.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    // Wait for the async refreshToken mock to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The interceptor should retry with the fresh token
+    const retryReq = httpTesting.expectOne('/api/data');
+    expect(retryReq.request.headers.get('Authorization')).toBe(
+      'Bearer fresh-token',
+    );
+    retryReq.flush({ ok: true });
+
+    const result = await data$;
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('queues concurrent 401s behind a single refresh (regression #168)', async () => {
+    authService.accessToken.set('expired-token');
+
+    // Fire two requests concurrently
+    const data1$ = firstValueFrom(http.get<{ id: 1 }>('/api/one'));
+    const data2$ = firstValueFrom(http.get<{ id: 2 }>('/api/two'));
+
+    const req1 = httpTesting.expectOne('/api/one');
+    const req2 = httpTesting.expectOne('/api/two');
+
+    // Mock refreshToken to simulate a real async refresh
+    let resolveRefresh!: (value: boolean) => void;
+    const refreshPromise = new Promise<boolean>((r) => (resolveRefresh = r));
+    vi.spyOn(authService, 'refreshToken').mockImplementation(() => {
+      authService.refreshResult$.next(null); // reset before refresh
+      return refreshPromise.then((success) => {
+        if (success) {
+          authService.accessToken.set('fresh-token');
+          authService.refreshResult$.next('fresh-token');
+        } else {
+          authService.refreshResult$.next('');
+        }
+        return success;
+      });
+    });
+
+    // Both get 401
+    req1.flush(null, { status: 401, statusText: 'Unauthorized' });
+    req2.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    // refreshToken should only be called once
+    expect(authService.refreshToken).toHaveBeenCalledTimes(1);
+
+    // Complete the refresh
+    resolveRefresh(true);
+    await refreshPromise;
+
+    // Wait a tick for RxJS to process
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Both requests should be retried with the fresh token
+    const retries = httpTesting.match(
+      (r) => r.url === '/api/one' || r.url === '/api/two',
+    );
+    expect(retries.length).toBe(2);
+
+    const retryOne = retries.find((r) => r.request.url === '/api/one')!;
+    const retryTwo = retries.find((r) => r.request.url === '/api/two')!;
+
+    expect(retryOne.request.headers.get('Authorization')).toBe(
+      'Bearer fresh-token',
+    );
+    expect(retryTwo.request.headers.get('Authorization')).toBe(
+      'Bearer fresh-token',
+    );
+
+    retryOne.flush({ id: 1 });
+    retryTwo.flush({ id: 2 });
+
+    expect(await data1$).toEqual({ id: 1 });
+    expect(await data2$).toEqual({ id: 2 });
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import {
   HttpClient,
@@ -26,7 +26,8 @@ describe('authInterceptor', () => {
   let authService: AuthService;
 
   beforeEach(() => {
-    // Clear any module-level state from previous tests
+    // Stub localStorage so AuthService doesn't read stale tokens from
+    // the test runner's environment.
     vi.stubGlobal('localStorage', {
       getItem: vi.fn().mockReturnValue(null),
       setItem: vi.fn(),
@@ -44,6 +45,12 @@ describe('authInterceptor', () => {
     http = TestBed.inject(HttpClient);
     httpTesting = TestBed.inject(HttpTestingController);
     authService = TestBed.inject(AuthService);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('attaches bearer token to authenticated requests', () => {
@@ -79,17 +86,14 @@ describe('authInterceptor', () => {
       'Bearer expired-token',
     );
 
-    // Simulate refreshToken succeeding (async to mirror real behavior)
-    vi.spyOn(authService, 'refreshToken').mockImplementation(async () => {
-      authService.accessToken.set('fresh-token');
-      authService.refreshResult$.next('fresh-token');
-      return true;
-    });
-
-    // Respond with 401
+    // Respond with 401 — triggers refreshToken() which calls /api/auth/refresh
     firstReq.flush(null, { status: 401, statusText: 'Unauthorized' });
 
-    // Wait for the async refreshToken mock to resolve
+    // The real refreshToken() POSTs to /api/auth/refresh — respond with a fresh token
+    const refreshReq = httpTesting.expectOne('/api/auth/refresh');
+    refreshReq.flush({ accessToken: 'fresh-token' });
+
+    // Wait for async processing
     await new Promise((r) => setTimeout(r, 0));
 
     // The interceptor should retry with the fresh token
@@ -113,34 +117,18 @@ describe('authInterceptor', () => {
     const req1 = httpTesting.expectOne('/api/one');
     const req2 = httpTesting.expectOne('/api/two');
 
-    // Mock refreshToken to simulate a real async refresh
-    let resolveRefresh!: (value: boolean) => void;
-    const refreshPromise = new Promise<boolean>((r) => (resolveRefresh = r));
-    vi.spyOn(authService, 'refreshToken').mockImplementation(() => {
-      authService.refreshResult$.next(null); // reset before refresh
-      return refreshPromise.then((success) => {
-        if (success) {
-          authService.accessToken.set('fresh-token');
-          authService.refreshResult$.next('fresh-token');
-        } else {
-          authService.refreshResult$.next('');
-        }
-        return success;
-      });
-    });
-
-    // Both get 401
+    // Both get 401 — only the first should trigger a refresh
     req1.flush(null, { status: 401, statusText: 'Unauthorized' });
     req2.flush(null, { status: 401, statusText: 'Unauthorized' });
 
-    // refreshToken should only be called once
-    expect(authService.refreshToken).toHaveBeenCalledTimes(1);
+    // Only one /api/auth/refresh call should be made
+    const refreshReqs = httpTesting.match('/api/auth/refresh');
+    expect(refreshReqs.length).toBe(1);
 
-    // Complete the refresh
-    resolveRefresh(true);
-    await refreshPromise;
+    // Respond with a fresh token
+    refreshReqs[0].flush({ accessToken: 'fresh-token' });
 
-    // Wait a tick for RxJS to process
+    // Wait for async processing
     await new Promise((r) => setTimeout(r, 0));
 
     // Both requests should be retried with the fresh token

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
@@ -1,6 +1,13 @@
 import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { catchError, filter, first, switchMap, throwError } from 'rxjs';
+import {
+  catchError,
+  filter,
+  finalize,
+  first,
+  switchMap,
+  throwError,
+} from 'rxjs';
 import { from } from 'rxjs';
 import { AuthService } from './auth.service';
 
@@ -83,21 +90,18 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
       // First 401 — initiate the refresh.
       isRefreshing = true;
-      authService.refreshResult$.next(null);
+      authService.beginRefresh();
 
       return from(authService.refreshToken()).pipe(
         switchMap((success) => {
-          isRefreshing = false;
           if (success) {
             return retryWithToken(req, next, authService, error);
           }
           return throwError(() => error);
         }),
-        catchError((refreshError) => {
+        catchError((refreshError) => throwError(() => refreshError)),
+        finalize(() => {
           isRefreshing = false;
-          // Notify queued requests so they don't hang forever.
-          authService.refreshResult$.next('');
-          return throwError(() => refreshError);
         }),
       );
     }),

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
@@ -95,6 +95,8 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
         }),
         catchError((refreshError) => {
           isRefreshing = false;
+          // Notify queued requests so they don't hang forever.
+          authService.refreshResult$.next('');
           return throwError(() => refreshError);
         }),
       );

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.interceptor.ts
@@ -1,6 +1,6 @@
 import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { catchError, switchMap, throwError } from 'rxjs';
+import { catchError, filter, first, switchMap, throwError } from 'rxjs';
 import { from } from 'rxjs';
 import { AuthService } from './auth.service';
 
@@ -30,6 +30,27 @@ function isUnauthenticatedAuthRequest(url: string): boolean {
   }
 }
 
+/**
+ * Retry the original request with the current access token.
+ * Extracted to avoid duplication between the "first 401" and
+ * "queued while refresh in-flight" code paths.
+ */
+function retryWithToken(
+  req: Parameters<HttpInterceptorFn>[0],
+  next: Parameters<HttpInterceptorFn>[1],
+  authService: AuthService,
+  originalError: HttpErrorResponse,
+) {
+  const freshToken = authService.accessToken();
+  if (freshToken) {
+    const retryReq = req.clone({
+      setHeaders: { Authorization: `Bearer ${freshToken}` },
+    });
+    return next(retryReq);
+  }
+  return throwError(() => originalError);
+}
+
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
 
@@ -44,30 +65,39 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(authReq).pipe(
     catchError((error: HttpErrorResponse) => {
-      if (error.status === 401 && !isRefreshing) {
-        isRefreshing = true;
+      if (error.status !== 401) {
+        return throwError(() => error);
+      }
 
-        return from(authService.refreshToken()).pipe(
-          switchMap((success) => {
-            isRefreshing = false;
-            if (success) {
-              const retryReq = req.clone({
-                setHeaders: {
-                  Authorization: `Bearer ${authService.accessToken()}`,
-                },
-              });
-              return next(retryReq);
-            }
-            return throwError(() => error);
-          }),
-          catchError((refreshError) => {
-            isRefreshing = false;
-            return throwError(() => refreshError);
-          }),
+      // A refresh is already in flight — wait for it to complete, then retry.
+      if (isRefreshing) {
+        return authService.refreshResult$.pipe(
+          // refreshResult$ is a BehaviorSubject seeded with null.
+          // Skip the current (null | stale) value and wait for the
+          // next emission, which signals the in-flight refresh completed.
+          filter((result) => result !== null),
+          first(),
+          switchMap(() => retryWithToken(req, next, authService, error)),
         );
       }
 
-      return throwError(() => error);
+      // First 401 — initiate the refresh.
+      isRefreshing = true;
+      authService.refreshResult$.next(null);
+
+      return from(authService.refreshToken()).pipe(
+        switchMap((success) => {
+          isRefreshing = false;
+          if (success) {
+            return retryWithToken(req, next, authService, error);
+          }
+          return throwError(() => error);
+        }),
+        catchError((refreshError) => {
+          isRefreshing = false;
+          return throwError(() => refreshError);
+        }),
+      );
     }),
   );
 };

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import {
   AuthTokenResponse,
   LoginWithPasswordRequest,
@@ -19,6 +19,11 @@ export class AuthService {
   readonly accessToken = signal<string | null>(this.readStoredToken());
   readonly currentUser = signal<UserProfile | null>(null);
   readonly isAuthenticated = computed(() => this.accessToken() !== null);
+
+  /** Emits the new token (or empty string on failure) after a token refresh
+   *  completes. The interceptor uses this to queue concurrent 401 retries so
+   *  they all wait for a single refresh instead of failing independently. */
+  readonly refreshResult$ = new BehaviorSubject<string | null>(null);
 
   constructor() {
     this.extractTokenFromHash();
@@ -94,6 +99,7 @@ export class AuthService {
       if (result?.accessToken) {
         this.accessToken.set(result.accessToken);
         this.storeToken(result.accessToken);
+        this.refreshResult$.next(result.accessToken);
         return true;
       }
     } catch {
@@ -103,6 +109,7 @@ export class AuthService {
     this.accessToken.set(null);
     this.currentUser.set(null);
     this.removeStoredToken();
+    this.refreshResult$.next('');
     return false;
   }
 

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import {
   AuthTokenResponse,
   LoginWithPasswordRequest,
@@ -20,10 +20,21 @@ export class AuthService {
   readonly currentUser = signal<UserProfile | null>(null);
   readonly isAuthenticated = computed(() => this.accessToken() !== null);
 
-  /** Emits the new token (or empty string on failure) after a token refresh
-   *  completes. The interceptor uses this to queue concurrent 401 retries so
-   *  they all wait for a single refresh instead of failing independently. */
-  readonly refreshResult$ = new BehaviorSubject<string | null>(null);
+  /** Private subject that drives refresh coordination. Only AuthService
+   *  should emit on this — the interceptor subscribes via the readonly
+   *  `refreshResult$` observable. */
+  private readonly _refreshResult = new BehaviorSubject<string | null>(null);
+
+  /** Read-only projection the interceptor subscribes to. Emits the new token
+   *  (or empty string on failure) after a token refresh completes so that
+   *  concurrent 401 retries wait for a single refresh. */
+  readonly refreshResult$: Observable<string | null> =
+    this._refreshResult.asObservable();
+
+  /** Reset the refresh result before starting a new refresh cycle. */
+  beginRefresh(): void {
+    this._refreshResult.next(null);
+  }
 
   constructor() {
     this.extractTokenFromHash();
@@ -99,7 +110,7 @@ export class AuthService {
       if (result?.accessToken) {
         this.accessToken.set(result.accessToken);
         this.storeToken(result.accessToken);
-        this.refreshResult$.next(result.accessToken);
+        this._refreshResult.next(result.accessToken);
         return true;
       }
     } catch {
@@ -109,7 +120,7 @@ export class AuthService {
     this.accessToken.set(null);
     this.currentUser.set(null);
     this.removeStoredToken();
-    this.refreshResult$.next('');
+    this._refreshResult.next('');
     return false;
   }
 


### PR DESCRIPTION
## Summary

Fixes the race condition where multiple API requests fire with an expired token on first load, all receive 401s, but only the first triggers a token refresh — the rest are dropped as errors, producing visible 401 errors to users. Closes #168.

## Changes

- Added `refreshResult$` BehaviorSubject to `AuthService` that emits when a token refresh completes (new token on success, empty string on failure)
- Rewired the auth interceptor so concurrent 401s wait on `refreshResult$` instead of being dropped when `isRefreshing` is true
- Extracted `retryWithToken()` helper to deduplicate retry logic between the two code paths
- Added regression tests covering: token attachment, unauthenticated endpoint bypass, single 401 retry, and concurrent 401 queuing

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (364 tests)
- [x] `ng test --watch=false` passes (45 tests)
- [ ] Manual: open app with expired token in localStorage, verify no 401 errors on first load

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Queue concurrent 401 responses behind a single token refresh and ensure all affected requests are retried consistently.

Bug Fixes:
- Prevent concurrent requests with expired tokens from failing with visible 401 errors by coordinating them around a single refresh cycle.

Enhancements:
- Introduce a shared refreshResult$ stream and a retryWithToken helper to centralize and simplify token refresh and retry handling in the auth interceptor.

Tests:
- Add unit tests for the auth interceptor covering token attachment, unauthenticated endpoint bypass, single 401 retry, and concurrent 401 queuing behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token refresh handling for expired tokens (401 responses).
  * Implemented request queuing during token refresh to prevent duplicate refresh calls.

* **Tests**
  * Added comprehensive test coverage for authentication interceptor including token refresh scenarios and concurrent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->