### PR TITLE
fix: resolve weekly brief data population bugs (closes #170)

### DIFF
--- a/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
+++ b/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
@@ -13,6 +13,8 @@ public sealed class GenerateWeeklyBriefHandler(
     IAiCompletionService aiCompletionService,
     ICurrentUserService currentUserService)
 {
+    public const string NoDataNarrative =
+        "No captures or commitment activity were recorded this week.";
     public async Task<WeeklyBriefResponse> HandleAsync(
         DateOnly? weekOf,
         CancellationToken cancellationToken)
@@ -76,6 +78,9 @@ public sealed class GenerateWeeklyBriefHandler(
 
             if (linkedCaptureCount > 0 || linkedCommitmentCount > 0)
             {
+                // DTO intentionally reports capture count only — commitment count is used
+                // solely as an inclusion criterion so initiatives with commitment-only activity
+                // appear in the brief rather than being silently excluded.
                 initiativeActivity.Add(new InitiativeActivityDto(
                     initiative.Id,
                     initiative.Title,
@@ -102,7 +107,7 @@ public sealed class GenerateWeeklyBriefHandler(
         if (weekCaptures.Count == 0 && newThisWeek == 0 && completedThisWeek == 0 && overdueCount == 0)
         {
             return new WeeklyBriefResponse(
-                "No captures or commitment activity were recorded this week.",
+                NoDataNarrative,
                 [],
                 [],
                 new CommitmentStatusSummary(newThisWeek, completedThisWeek, overdueCount, totalOpen),

--- a/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
+++ b/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
@@ -66,15 +66,20 @@ public sealed class GenerateWeeklyBriefHandler(
         var initiativeActivity = new List<InitiativeActivityDto>();
         foreach (var initiative in initiatives)
         {
-            var linkedCount = weekCaptures
+            var linkedCaptureCount = weekCaptures
                 .Count(c => c.LinkedInitiativeIds.Contains(initiative.Id));
 
-            if (linkedCount > 0)
+            var linkedCommitmentCount = allCommitments
+                .Count(c => c.InitiativeId == initiative.Id
+                         && c.CreatedAt >= weekStartOffset
+                         && c.CreatedAt < weekEndOffset);
+
+            if (linkedCaptureCount > 0 || linkedCommitmentCount > 0)
             {
                 initiativeActivity.Add(new InitiativeActivityDto(
                     initiative.Id,
                     initiative.Title,
-                    linkedCount,
+                    linkedCaptureCount,
                     initiative.AutoSummary));
             }
         }
@@ -91,6 +96,21 @@ public sealed class GenerateWeeklyBriefHandler(
             i.Title,
             i.CaptureCount,
             i.AutoSummary)).ToList();
+
+        // When there are no captures and no commitment activity, skip AI and return a clean
+        // "no data" response to avoid generating misleading narrative from empty context.
+        if (weekCaptures.Count == 0 && newThisWeek == 0 && completedThisWeek == 0 && overdueCount == 0)
+        {
+            return new WeeklyBriefResponse(
+                "No captures or commitment activity were recorded this week.",
+                [],
+                [],
+                new CommitmentStatusSummary(newThisWeek, completedThisWeek, overdueCount, totalOpen),
+                [],
+                initiativeActivity,
+                new DateRange(weekStartOffset, weekEndOffset),
+                DateTimeOffset.UtcNow);
+        }
 
         var userPrompt = WeeklyBriefPromptBuilder.BuildUserPrompt(
             captureContexts,
@@ -163,12 +183,12 @@ public sealed class GenerateWeeklyBriefHandler(
 
         foreach (var kv in multiCapturePeople)
         {
-            // Find the person's name from extraction data
+            // Find the person's name from extraction data — skip if unresolvable
             var name = captures
                 .SelectMany(c => c.AiExtraction?.PeopleMentioned ?? [])
                 .FirstOrDefault(p => p.PersonId == kv.Key)?.RawName;
 
-            if (name is not null)
+            if (!string.IsNullOrWhiteSpace(name))
                 insights.Add($"{name} appeared in {kv.Value} conversations this week");
         }
 

--- a/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
+++ b/src/MentalMetal.Application/Briefings/GenerateWeeklyBriefHandler.cs
@@ -61,9 +61,33 @@ public sealed class GenerateWeeklyBriefHandler(
         var totalOpen = allCommitments
             .Count(c => c.Status == CommitmentStatus.Open);
 
-        // Get initiatives with linked captures from this period
+        // When there are no captures and no commitment activity, skip AI and return a clean
+        // "no data" response to avoid generating misleading narrative from empty context.
+        // Check early to avoid unnecessary initiative DB call and iteration.
+        if (weekCaptures.Count == 0 && newThisWeek == 0 && completedThisWeek == 0 && overdueCount == 0)
+        {
+            return new WeeklyBriefResponse(
+                NoDataNarrative,
+                [],
+                [],
+                new CommitmentStatusSummary(newThisWeek, completedThisWeek, overdueCount, totalOpen),
+                [],
+                [],
+                new DateRange(weekStartOffset, weekEndOffset),
+                DateTimeOffset.UtcNow);
+        }
+
+        // Get initiatives with linked captures or commitments from this period
         var initiatives = await initiativeRepository.GetAllAsync(
             userId, InitiativeStatus.Active, cancellationToken);
+
+        // Pre-compute commitment counts per initiative for O(1) lookup
+        var weekCommitmentsByInitiative = allCommitments
+            .Where(c => c.InitiativeId.HasValue
+                     && c.CreatedAt >= weekStartOffset
+                     && c.CreatedAt < weekEndOffset)
+            .GroupBy(c => c.InitiativeId!.Value)
+            .ToDictionary(g => g.Key, g => g.Count());
 
         var initiativeActivity = new List<InitiativeActivityDto>();
         foreach (var initiative in initiatives)
@@ -71,10 +95,7 @@ public sealed class GenerateWeeklyBriefHandler(
             var linkedCaptureCount = weekCaptures
                 .Count(c => c.LinkedInitiativeIds.Contains(initiative.Id));
 
-            var linkedCommitmentCount = allCommitments
-                .Count(c => c.InitiativeId == initiative.Id
-                         && c.CreatedAt >= weekStartOffset
-                         && c.CreatedAt < weekEndOffset);
+            weekCommitmentsByInitiative.TryGetValue(initiative.Id, out var linkedCommitmentCount);
 
             if (linkedCaptureCount > 0 || linkedCommitmentCount > 0)
             {
@@ -101,21 +122,6 @@ public sealed class GenerateWeeklyBriefHandler(
             i.Title,
             i.CaptureCount,
             i.AutoSummary)).ToList();
-
-        // When there are no captures and no commitment activity, skip AI and return a clean
-        // "no data" response to avoid generating misleading narrative from empty context.
-        if (weekCaptures.Count == 0 && newThisWeek == 0 && completedThisWeek == 0 && overdueCount == 0)
-        {
-            return new WeeklyBriefResponse(
-                NoDataNarrative,
-                [],
-                [],
-                new CommitmentStatusSummary(newThisWeek, completedThisWeek, overdueCount, totalOpen),
-                [],
-                initiativeActivity,
-                new DateRange(weekStartOffset, weekEndOffset),
-                DateTimeOffset.UtcNow);
-        }
 
         var userPrompt = WeeklyBriefPromptBuilder.BuildUserPrompt(
             captureContexts,
@@ -188,12 +194,14 @@ public sealed class GenerateWeeklyBriefHandler(
 
         foreach (var kv in multiCapturePeople)
         {
-            // Find the person's name from extraction data — skip if unresolvable
+            // Find the first non-whitespace name for this person across all captures
             var name = captures
                 .SelectMany(c => c.AiExtraction?.PeopleMentioned ?? [])
-                .FirstOrDefault(p => p.PersonId == kv.Key)?.RawName;
+                .Where(p => p.PersonId == kv.Key)
+                .Select(p => p.RawName)
+                .FirstOrDefault(rawName => !string.IsNullOrWhiteSpace(rawName));
 
-            if (!string.IsNullOrWhiteSpace(name))
+            if (name is not null)
                 insights.Add($"{name} appeared in {kv.Value} conversations this week");
         }
 

--- a/tests/MentalMetal.Application.Tests/Briefings/GenerateWeeklyBriefHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Briefings/GenerateWeeklyBriefHandlerTests.cs
@@ -27,8 +27,9 @@ public class GenerateWeeklyBriefHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_NoCapturesThisWeek_ReturnsEmptyBrief()
+    public async Task HandleAsync_NoDataThisWeek_SkipsAiAndReturnsCannedNarrative()
     {
+        // Regression: bug #4 — AI was invoked with empty context, producing misleading narrative.
         _captureRepo.GetAllAsync(_userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>())
             .Returns(new List<Capture>());
         _commitmentRepo.GetAllAsync(_userId, null, null, null, null, null, Arg.Any<CancellationToken>())
@@ -36,22 +37,29 @@ public class GenerateWeeklyBriefHandlerTests
         _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
             .Returns(new List<Initiative>());
 
-        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
-            .Returns(new AiCompletionResult("Quiet week.", 20, 50, "test-model", AiProvider.Anthropic));
-
         var result = await _sut.HandleAsync(null, CancellationToken.None);
 
-        Assert.Equal("Quiet week.", result.Narrative);
+        Assert.Contains("No captures or commitment activity", result.Narrative);
         Assert.Empty(result.InitiativeActivity);
         Assert.Empty(result.CrossConversationInsights);
         Assert.Equal(0, result.CommitmentStatus.NewCount);
+        await _aiService.DidNotReceive().CompleteAsync(
+            Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task HandleAsync_CallsAiWithWeeklyPrompt()
+    public async Task HandleAsync_WithCaptures_CallsAiWithWeeklyPrompt()
     {
+        var capture = Capture.Create(_userId, "Status sync.", CaptureType.MeetingNotes);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(new AiExtraction
+        {
+            Summary = "Sync meeting.",
+            ExtractedAt = DateTimeOffset.UtcNow
+        });
+
         _captureRepo.GetAllAsync(_userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>())
-            .Returns(new List<Capture>());
+            .Returns(new List<Capture> { capture });
         _commitmentRepo.GetAllAsync(_userId, null, null, null, null, null, Arg.Any<CancellationToken>())
             .Returns(new List<Commitment>());
         _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
@@ -77,9 +85,6 @@ public class GenerateWeeklyBriefHandlerTests
             .Returns(new List<Commitment>());
         _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
             .Returns(new List<Initiative>());
-
-        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
-            .Returns(new AiCompletionResult("Week of April 13.", 20, 50, "test-model", AiProvider.Anthropic));
 
         var result = await _sut.HandleAsync(weekOf, CancellationToken.None);
 
@@ -121,8 +126,8 @@ public class GenerateWeeklyBriefHandlerTests
     [Fact]
     public async Task HandleAsync_CaptureWithNullExtractionCollections_DoesNotThrow()
     {
-        // Regression: EF Core JSON deserialization can produce null for Decisions/Risks
-        // even when C# defaults are set. The handler must tolerate this.
+        // Regression: bug #2 — EF Core JSON deserialization can produce null for Decisions/Risks
+        // even when C# defaults are set. The handler must tolerate this via null-coalescing.
         var capture = Capture.Create(_userId, "Meeting notes.", CaptureType.MeetingNotes);
         capture.BeginProcessing();
         capture.CompleteProcessing(new AiExtraction
@@ -146,7 +151,103 @@ public class GenerateWeeklyBriefHandlerTests
         var result = await _sut.HandleAsync(null, CancellationToken.None);
 
         Assert.NotNull(result.Narrative);
-        await _aiService.Received(1).CompleteAsync(
-            Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_InitiativeWithCommitmentsButNoCaptures_IncludedInActivity()
+    {
+        // Regression: bug #3 — initiatives were excluded if they had no linked captures in the
+        // date range, even when they had commitments created that week.
+        // Use null weekOf so the handler defaults to the current week, which will include
+        // the commitment we just created (CreatedAt = UtcNow).
+        var initiative = Initiative.Create(_userId, "Project Alpha");
+        var personId = Guid.NewGuid();
+
+        var commitment = Commitment.Create(
+            _userId, "Deliver spec", CommitmentDirection.MineToThem, personId,
+            initiativeId: initiative.Id);
+
+        _captureRepo.GetAllAsync(_userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>())
+            .Returns(new List<Capture>());
+        _commitmentRepo.GetAllAsync(_userId, null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(new List<Commitment> { commitment });
+        _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
+            .Returns(new List<Initiative> { initiative });
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult("Active week.", 20, 50, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(null, CancellationToken.None);
+
+        Assert.Single(result.InitiativeActivity);
+        Assert.Equal("Project Alpha", result.InitiativeActivity[0].Title);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OnlyProcessedCapturesUsed()
+    {
+        // Regression: bug #1 — weekly brief must only use processed captures (matching daily brief).
+        // The repo is called with ProcessingStatus.Processed filter.
+        _captureRepo.GetAllAsync(_userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>())
+            .Returns(new List<Capture>());
+        _commitmentRepo.GetAllAsync(_userId, null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(new List<Commitment>());
+        _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
+            .Returns(new List<Initiative>());
+
+        await _sut.HandleAsync(null, CancellationToken.None);
+
+        // Verify the capture repo was called with the Processed filter
+        await _captureRepo.Received(1).GetAllAsync(
+            _userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PersonWithWhitespaceRawName_SkippedInCrossInsights()
+    {
+        // Regression: bug #5 — person name lookup returning empty/whitespace names should
+        // be skipped, not rendered with blank or "unknown" labels.
+        var personId = Guid.NewGuid();
+
+        var capture1 = Capture.Create(_userId, "Meeting 1.", CaptureType.MeetingNotes);
+        capture1.BeginProcessing();
+        capture1.LinkToPerson(personId);
+        capture1.CompleteProcessing(new AiExtraction
+        {
+            Summary = "Meeting one.",
+            PeopleMentioned = new List<PersonMention>
+            {
+                new() { PersonId = personId, RawName = "  " }
+            },
+            ExtractedAt = DateTimeOffset.UtcNow
+        });
+
+        var capture2 = Capture.Create(_userId, "Meeting 2.", CaptureType.MeetingNotes);
+        capture2.BeginProcessing();
+        capture2.LinkToPerson(personId);
+        capture2.CompleteProcessing(new AiExtraction
+        {
+            Summary = "Meeting two.",
+            PeopleMentioned = new List<PersonMention>
+            {
+                new() { PersonId = personId, RawName = "  " }
+            },
+            ExtractedAt = DateTimeOffset.UtcNow
+        });
+
+        _captureRepo.GetAllAsync(_userId, null, ProcessingStatus.Processed, Arg.Any<CancellationToken>())
+            .Returns(new List<Capture> { capture1, capture2 });
+        _commitmentRepo.GetAllAsync(_userId, null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(new List<Commitment>());
+        _initiativeRepo.GetAllAsync(_userId, InitiativeStatus.Active, Arg.Any<CancellationToken>())
+            .Returns(new List<Initiative>());
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult("Brief.", 20, 50, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(null, CancellationToken.None);
+
+        // Person with whitespace-only name should not appear in cross-conversation insights
+        Assert.Empty(result.CrossConversationInsights);
     }
 }

--- a/tests/MentalMetal.Application.Tests/Briefings/GenerateWeeklyBriefHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Briefings/GenerateWeeklyBriefHandlerTests.cs
@@ -39,10 +39,18 @@ public class GenerateWeeklyBriefHandlerTests
 
         var result = await _sut.HandleAsync(null, CancellationToken.None);
 
-        Assert.Contains("No captures or commitment activity", result.Narrative);
+        Assert.Equal(GenerateWeeklyBriefHandler.NoDataNarrative, result.Narrative);
         Assert.Empty(result.InitiativeActivity);
         Assert.Empty(result.CrossConversationInsights);
         Assert.Equal(0, result.CommitmentStatus.NewCount);
+        Assert.Equal(0, result.CommitmentStatus.CompletedCount);
+        Assert.Equal(0, result.CommitmentStatus.OverdueCount);
+
+        Assert.NotNull(result.DateRange);
+        Assert.Equal(DayOfWeek.Monday, result.DateRange.Start.DayOfWeek);
+        Assert.Equal(DayOfWeek.Monday, result.DateRange.End.DayOfWeek);
+        Assert.Equal(result.DateRange.Start.AddDays(7), result.DateRange.End);
+
         await _aiService.DidNotReceive().CompleteAsync(
             Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Summary

Fixes three active bugs in `GenerateWeeklyBriefHandler` that caused initiative briefs to appear empty or show misleading content. The ProcessingStatus filter and null-coalescing for Decisions/Risks were already fixed in a prior PR, so this addresses the remaining three issues from #170.

Closes #170

## Changes

- **Initiative activity gate**: Include initiatives with commitments created during the week, not only those with linked captures — an initiative with commitment activity but no captures in the date range was previously excluded
- **Skip AI on empty data**: Return a clean "no data" narrative when there are zero captures and no commitment activity, instead of invoking AI with empty context that produces generic/misleading output
- **Person name validation**: Use `string.IsNullOrWhiteSpace` instead of null-check for person names in cross-conversation insights, so whitespace-only names are properly skipped

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (367 tests)
- [x] `ng test --watch=false` passes (45 tests)
- [x] New regression test: `HandleAsync_InitiativeWithCommitmentsButNoCaptures_IncludedInActivity`
- [x] New regression test: `HandleAsync_NoDataThisWeek_SkipsAiAndReturnsCannedNarrative`
- [x] New regression test: `HandleAsync_OnlyProcessedCapturesUsed`
- [x] New regression test: `HandleAsync_PersonWithWhitespaceRawName_SkippedInCrossInsights`
- [x] Existing test updated to reflect no-AI-call behavior on empty data

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix weekly brief generation to base initiative activity and AI narratives on meaningful capture and commitment data while skipping empty or invalid inputs.

Bug Fixes:
- Ensure initiatives with commitments created during the week are included in initiative activity even if they have no linked captures in the date range.
- Avoid invoking the AI service when there are no captures and no commitment activity, returning a clear no-data narrative instead.
- Ignore people with empty or whitespace-only names when generating cross-conversation insights so blank labels are not emitted.
- Guarantee weekly briefs only use captures in the processed state, matching daily brief behavior.
- Handle null Decisions/Risks collections from EF Core JSON deserialization without throwing.

Tests:
- Add and update unit tests to cover initiative inclusion via commitments, no-data AI skipping behavior, processed-capture filtering, whitespace-only person names, and capture processing edge cases in weekly brief generation.