### PR TITLE
chore: propose auto-detect capture type (closes #172)

### DIFF
--- a/openspec/changes/auto-detect-capture-type/.openspec.yaml
+++ b/openspec/changes/auto-detect-capture-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/auto-detect-capture-type/design.md
+++ b/openspec/changes/auto-detect-capture-type/design.md
@@ -73,6 +73,8 @@ The existing `ExtractionPromptBuilder.SystemPrompt` will be extended to include 
 
 The field is added to the JSON schema at the end of the response object. Fallback: if the AI omits the field or returns an unrecognized value, the handler keeps the original capture type (no reclassification).
 
+**Naming convention:** The JSON field is `detected_type` (snake_case, matching the existing extraction schema). The `ExtractionResponseDto` property is `DetectedType` with `[JsonPropertyName("detected_type")]`. The `AiExtraction` value object property is `DetectedCaptureType` (fully qualified to avoid ambiguity with the aggregate's `CaptureType` property).
+
 ## Risks / Trade-offs
 
 - **[Risk] AI misclassifies content** -- Mitigation: keep original type as fallback if `detected_type` is null or unrecognized; the AI prompt includes clear classification criteria; users can still manually set type via Advanced section before capture

--- a/openspec/changes/auto-detect-capture-type/design.md
+++ b/openspec/changes/auto-detect-capture-type/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The Quick Capture dialog defaults all captures to `CaptureType.QuickNote`. The AI extraction pipeline (`AutoExtractCaptureHandler`) already performs deep content analysis but never classifies or reclassifies the capture type. Users who paste multi-speaker transcripts or structured meeting notes end up with mislabelled captures, making type-based filtering unreliable.
+
+The existing extraction prompt instructs the AI to return a structured JSON response with summary, commitments, people, decisions, risks, and initiative tags. Adding a `detected_type` field to this response is a minimal change that piggybacks on the existing AI call with no additional cost or latency.
+
+## Dependencies
+
+- `capture-text` (Tier 2) -- the Capture aggregate and CaptureType enum
+- `capture-ai-extraction` (Tier 2) -- the extraction pipeline, prompt builder, response DTO, and AiExtraction value object
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect content type (`QuickNote`, `Transcript`, `MeetingNotes`) during AI extraction with zero additional AI calls
+- Reclassify the capture's `CaptureType` when the detected type differs from the original
+- Persist the detected type on the `AiExtraction` value object for audit/display purposes
+- Surface the detected type in the frontend capture detail view
+
+**Non-Goals:**
+- Client-side heuristic detection before submission
+- User override UI for the detected type (manual type selection already exists in Advanced section)
+- Reclassification of `AudioRecording` captures (set by the audio pipeline, must not be overwritten)
+- Retroactive reclassification of already-processed captures
+
+## Decisions
+
+### 1. Classification via existing AI extraction call (not a separate call)
+
+**Decision:** Add `detected_type` to the extraction JSON schema and system prompt. The AI classifies the content as part of its existing analysis pass.
+
+**Alternatives considered:**
+- Separate classification endpoint / AI call -- rejected: adds latency, cost, and complexity for a simple enum classification
+- Client-side regex heuristics (e.g., detect `Speaker:` patterns) -- rejected: fragile, duplicates logic, and cannot handle ambiguous cases
+
+**Rationale:** The AI already reads the full content and understands its structure. Adding one more field to the response schema is the simplest approach with the best accuracy.
+
+### 2. Domain method `Reclassify(CaptureType)` on Capture aggregate
+
+**Decision:** Add a domain method that changes `CaptureType` and raises a `CaptureReclassified` event. The method SHALL only be callable when `ProcessingStatus` is `Processing` (i.e., during the extraction pipeline), and SHALL reject reclassification to `AudioRecording`.
+
+**Alternatives considered:**
+- Direct property setter -- rejected: violates DDD encapsulation; no event, no guard
+- Allow reclassification at any status -- rejected: could cause confusion if a user manually set the type and it gets overwritten on retry
+
+**Rationale:** Restricting to `Processing` status ensures reclassification only happens as part of extraction. The domain event enables future audit/reaction.
+
+### 3. Store `DetectedCaptureType` on `AiExtraction` value object
+
+**Decision:** Add a `CaptureType? DetectedCaptureType` property to `AiExtraction`. This records what the AI detected, independent of whether the capture was actually reclassified.
+
+**Rationale:** Separation of detected vs. applied type allows the UI to show "Detected as: Transcript" even if the type was already correct. Also useful for debugging and future analytics.
+
+### 4. Prompt classification guidance
+
+**Decision:** The system prompt will include explicit classification rules:
+- `Transcript` -- content has speaker labels (`Name:` lines), turn-taking dialogue, or is explicitly identified as a transcript
+- `MeetingNotes` -- structured notes with headings, bullet points, agenda items, or action items without speaker labels
+- `QuickNote` -- short unstructured text, a single thought, reminder, or brief observation
+
+**Rationale:** Clear classification criteria reduce ambiguity for the AI and improve consistency across providers.
+
+## AI Prompting Strategy
+
+The existing `ExtractionPromptBuilder.SystemPrompt` will be extended to include a 7th extraction field:
+
+```
+7. **detected_type**: Classify the content type. One of:
+   - "QuickNote": Short unstructured text, a single thought, reminder, or brief note
+   - "Transcript": Multi-speaker dialogue with speaker labels or turn-taking patterns
+   - "MeetingNotes": Structured notes with headings, bullet points, agenda items, or action items
+```
+
+The field is added to the JSON schema at the end of the response object. Fallback: if the AI omits the field or returns an unrecognized value, the handler keeps the original capture type (no reclassification).
+
+## Risks / Trade-offs
+
+- **[Risk] AI misclassifies content** -- Mitigation: keep original type as fallback if `detected_type` is null or unrecognized; the AI prompt includes clear classification criteria; users can still manually set type via Advanced section before capture
+- **[Risk] EF migration on AiExtraction owned entity** -- Mitigation: this is a simple nullable column addition with no data migration; existing rows get NULL for `DetectedCaptureType`
+- **[Trade-off] No retroactive reclassification** -- Existing captures keep their original type. Acceptable because only newly processed captures benefit, and the backlog of mislabelled captures is small.
+
+## Open Questions
+
+_None -- the approach is straightforward and all decisions are resolved._

--- a/openspec/changes/auto-detect-capture-type/design.md
+++ b/openspec/changes/auto-detect-capture-type/design.md
@@ -19,7 +19,7 @@ The existing extraction prompt instructs the AI to return a structured JSON resp
 
 **Non-Goals:**
 - Client-side heuristic detection before submission
-- User override UI for the detected type (manual type selection already exists in Advanced section)
+- User override UI for the detected type (manual type selection in Quick Capture is a separate UI gap, out of scope)
 - Reclassification of `AudioRecording` captures (set by the audio pipeline, must not be overwritten)
 - Retroactive reclassification of already-processed captures
 
@@ -37,7 +37,7 @@ The existing extraction prompt instructs the AI to return a structured JSON resp
 
 ### 2. Domain method `Reclassify(CaptureType)` on Capture aggregate
 
-**Decision:** Add a domain method that changes `CaptureType` and raises a `CaptureReclassified` event. The method SHALL only be callable when `ProcessingStatus` is `Processing` (i.e., during the extraction pipeline), and SHALL reject reclassification to `AudioRecording`.
+**Decision:** Add a domain method that changes `CaptureType` and raises a `CaptureReclassified` event. The method SHALL only be callable when `ProcessingStatus` is `Processing` (i.e., during the extraction pipeline, before `CompleteProcessing` transitions the capture to `Processed`), and SHALL reject reclassification to `AudioRecording`.
 
 **Alternatives considered:**
 - Direct property setter -- rejected: violates DDD encapsulation; no event, no guard
@@ -78,7 +78,7 @@ The field is added to the JSON schema at the end of the response object. Fallbac
 ## Risks / Trade-offs
 
 - **[Risk] AI misclassifies content** -- Mitigation: keep original type as fallback if `detected_type` is null or unrecognized; the AI prompt includes clear classification criteria; users can still manually set type via Advanced section before capture
-- **[Risk] EF migration on AiExtraction owned entity** -- Mitigation: this is a simple nullable column addition with no data migration; existing rows get NULL for `DetectedCaptureType`
+- **[Risk] EF JSONB serialization of new field** -- Mitigation: `AiExtraction` is persisted as JSONB via `ToJson()`, so adding `DetectedCaptureType` requires no schema migration; existing rows simply lack the field and deserialize as null
 - **[Trade-off] No retroactive reclassification** -- Existing captures keep their original type. Acceptable because only newly processed captures benefit, and the backlog of mislabelled captures is small.
 
 ## Open Questions

--- a/openspec/changes/auto-detect-capture-type/proposal.md
+++ b/openspec/changes/auto-detect-capture-type/proposal.md
@@ -15,7 +15,7 @@ When a user pastes a meeting transcript into Quick Capture, the system always cr
 
 - No client-side heuristic detection (all classification happens server-side during AI extraction)
 - No new AI call or separate classification endpoint -- detection piggybacks on the existing extraction call
-- No user override UI for the detected type in this change (existing Advanced section already allows manual type selection at creation time)
+- No user override UI for the detected type in this change (manual type selection in Quick Capture is a separate UI gap and out of scope for this proposal)
 - `AudioRecording` is excluded from auto-detection -- it is set by the audio capture pipeline and should not be reclassified
 
 ## Capabilities
@@ -36,6 +36,6 @@ _None_ -- this change extends existing capabilities rather than introducing a wh
 - **Application layer** (`ExtractionPromptBuilder`): Updated system prompt to request `detected_type`
 - **Application layer** (`ExtractionResponseDto`): New `DetectedType` field
 - **Application layer** (`AutoExtractCaptureHandler`): Reclassify capture after extraction
-- **Infrastructure layer**: EF migration for `DetectedCaptureType` on `AiExtraction` (owned entity column)
+- **Infrastructure layer**: No EF migration needed -- `AiExtraction` is persisted as JSONB, so `DetectedCaptureType` is a new JSON field
 - **Frontend**: Capture detail view shows detected type badge/indicator
 - **No breaking changes** -- existing captures keep their current type; only newly processed captures get reclassified

--- a/openspec/changes/auto-detect-capture-type/proposal.md
+++ b/openspec/changes/auto-detect-capture-type/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+When a user pastes a meeting transcript into Quick Capture, the system always creates the capture as `QuickNote`. The AI extraction pipeline already analyzes the content deeply enough to determine the content type, but it never reclassifies the capture. This means transcripts and meeting notes are mislabelled, which degrades filtering by type and provides a misleading UX. Since the AI is already processing the content, adding type detection requires no additional AI calls.
+
+## What Changes
+
+- Add a `detected_type` field to the AI extraction JSON schema, instructing the AI to classify the content as `QuickNote`, `Transcript`, or `MeetingNotes` during extraction
+- Add `DetectedType` to the `ExtractionResponseDto` to capture the AI's classification
+- Add a `Reclassify(CaptureType)` domain method on the Capture aggregate that changes the type post-creation (only valid during processing)
+- After successful extraction in `AutoExtractCaptureHandler`, reclassify the capture's type to match the AI's detected type (if different from the original)
+- Store the detected type on `AiExtraction` so the UI can display what was detected
+- Surface the detected (or reclassified) type in the capture detail UI
+
+## Non-goals
+
+- No client-side heuristic detection (all classification happens server-side during AI extraction)
+- No new AI call or separate classification endpoint -- detection piggybacks on the existing extraction call
+- No user override UI for the detected type in this change (existing Advanced section already allows manual type selection at creation time)
+- `AudioRecording` is excluded from auto-detection -- it is set by the audio capture pipeline and should not be reclassified
+
+## Capabilities
+
+### New Capabilities
+
+_None_ -- this change extends existing capabilities rather than introducing a wholly new one.
+
+### Modified Capabilities
+
+- `capture-ai-extraction`: The AI extraction pipeline gains content-type classification. The extraction prompt, response DTO, and handler are extended to detect and apply the capture type. The `AiExtraction` value object gains a `DetectedCaptureType` field.
+- `capture-text`: The Capture aggregate gains a `Reclassify(CaptureType)` domain method for post-creation type changes. The capture detail UI surfaces the detected type.
+
+## Impact
+
+- **Domain layer** (`Capture` aggregate): New `Reclassify` method, new `CaptureReclassified` domain event
+- **Domain layer** (`AiExtraction` value object): New `DetectedCaptureType` property
+- **Application layer** (`ExtractionPromptBuilder`): Updated system prompt to request `detected_type`
+- **Application layer** (`ExtractionResponseDto`): New `DetectedType` field
+- **Application layer** (`AutoExtractCaptureHandler`): Reclassify capture after extraction
+- **Infrastructure layer**: EF migration for `DetectedCaptureType` on `AiExtraction` (owned entity column)
+- **Frontend**: Capture detail view shows detected type badge/indicator
+- **No breaking changes** -- existing captures keep their current type; only newly processed captures get reclassified

--- a/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: AI extraction pipeline
 
-The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load the Capture, (2) call `IAiCompletionService.CompleteAsync` with a system prompt instructing the AI to extract structured data from the raw content, (3) parse the AI response into an `AiExtraction` value object, (4) call `CompleteProcessing(extraction)` on the Capture aggregate, and (5) persist the result. If the AI call fails, the service SHALL call `FailProcessing(reason)` on the Capture. The system prompt SHALL instruct the AI to include `source_start_offset` (0-based character index where the commitment starts in the input text) and `source_end_offset` (exclusive character index where the commitment ends) for each extracted commitment. The system prompt SHALL also instruct the AI to classify the content type as one of `QuickNote`, `Transcript`, or `MeetingNotes` via a `detected_type` field. After successful extraction, the handler SHALL call `Reclassify(detectedType)` on the Capture aggregate if the detected type is a valid `CaptureType` other than `AudioRecording` and differs from the current type.
+The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load the Capture, (2) call `IAiCompletionService.CompleteAsync` with a system prompt instructing the AI to extract structured data from the raw content, (3) parse the AI response into an `AiExtraction` value object, (4) call `CompleteProcessing(extraction)` on the Capture aggregate, and (5) persist the result. If the AI call fails, the service SHALL call `FailProcessing(reason)` on the Capture. The system prompt SHALL instruct the AI to include `source_start_offset` (0-based character index where the commitment starts in the input text) and `source_end_offset` (exclusive character index where the commitment ends) for each extracted commitment. The system prompt SHALL also instruct the AI to classify the content type as one of `QuickNote`, `Transcript`, or `MeetingNotes` via a `detected_type` field. After successful extraction, the handler SHALL call `Reclassify(detectedType)` on the Capture aggregate if the detected type is a valid `CaptureType` other than `AudioRecording`, the current capture type is not `AudioRecording`, and the detected type differs from the current type. The handler SHALL skip reclassification entirely for `AudioRecording` captures.
 
 #### Scenario: Successful extraction from a quick note
 
@@ -38,6 +38,12 @@ The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load
 - **WHEN** the processing pipeline runs on a capture with type `Transcript` and the AI returns `detected_type` of "Transcript"
 - **THEN** the handler does NOT call `Reclassify` on the capture
 - **AND** the capture's `CaptureType` remains `Transcript`
+
+#### Scenario: No reclassification for AudioRecording captures
+
+- **WHEN** the processing pipeline runs on a capture with type `AudioRecording` and the AI returns `detected_type` of "Transcript"
+- **THEN** the handler does NOT call `Reclassify` on the capture
+- **AND** the capture's `CaptureType` remains `AudioRecording`
 
 #### Scenario: No reclassification when detected_type is missing or unrecognized
 

--- a/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: AI extraction pipeline
+
+The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load the Capture, (2) call `IAiCompletionService.CompleteAsync` with a system prompt instructing the AI to extract structured data from the raw content, (3) parse the AI response into an `AiExtraction` value object, (4) call `CompleteProcessing(extraction)` on the Capture aggregate, and (5) persist the result. If the AI call fails, the service SHALL call `FailProcessing(reason)` on the Capture. The system prompt SHALL instruct the AI to include `source_start_offset` (0-based character index where the commitment starts in the input text) and `source_end_offset` (exclusive character index where the commitment ends) for each extracted commitment. The system prompt SHALL also instruct the AI to classify the content type as one of `QuickNote`, `Transcript`, or `MeetingNotes` via a `detected_type` field. After successful extraction, the handler SHALL call `Reclassify(detectedType)` on the Capture aggregate if the detected type is a valid `CaptureType` other than `AudioRecording` and differs from the current type.
+
+#### Scenario: Successful extraction from a quick note
+
+- **WHEN** the processing pipeline runs on a QuickNote capture with content "Follow up with Sarah on Q3 roadmap — she committed to the API spec by Friday"
+- **THEN** the AI extracts a summary, identifies one commitment (TheirsToMe: "Deliver API spec", person: Sarah, due: Friday), and suggests person link to Sarah
+- **AND** the extracted commitment includes `source_start_offset` and `source_end_offset` referencing the position in the input text
+- **AND** the AI returns `detected_type` of "QuickNote"
+- **AND** CompleteProcessing is called with the AiExtraction value object
+
+#### Scenario: Successful extraction from a transcript
+
+- **WHEN** the processing pipeline runs on a Transcript capture containing a multi-topic meeting transcript
+- **THEN** the AI extracts a summary, commitments, delegations, decisions, risks, observations, and suggested person/initiative links
+- **AND** each extracted commitment includes `source_start_offset` and `source_end_offset`
+- **AND** the AI returns `detected_type` of "Transcript"
+
+#### Scenario: Reclassify QuickNote to Transcript after extraction
+
+- **WHEN** the processing pipeline runs on a capture with type `QuickNote` whose content is a multi-speaker transcript with speaker labels
+- **THEN** the AI returns `detected_type` of "Transcript"
+- **AND** the handler calls `Reclassify(CaptureType.Transcript)` on the capture
+- **AND** the capture's `CaptureType` is now `Transcript`
+
+#### Scenario: Reclassify QuickNote to MeetingNotes after extraction
+
+- **WHEN** the processing pipeline runs on a capture with type `QuickNote` whose content contains structured meeting notes with headings and action items
+- **THEN** the AI returns `detected_type` of "MeetingNotes"
+- **AND** the handler calls `Reclassify(CaptureType.MeetingNotes)` on the capture
+- **AND** the capture's `CaptureType` is now `MeetingNotes`
+
+#### Scenario: No reclassification when detected type matches current type
+
+- **WHEN** the processing pipeline runs on a capture with type `Transcript` and the AI returns `detected_type` of "Transcript"
+- **THEN** the handler does NOT call `Reclassify` on the capture
+- **AND** the capture's `CaptureType` remains `Transcript`
+
+#### Scenario: No reclassification when detected_type is missing or unrecognized
+
+- **WHEN** the AI response omits the `detected_type` field or returns an unrecognized value
+- **THEN** the handler does NOT call `Reclassify` on the capture
+- **AND** the capture keeps its original `CaptureType`
+
+#### Scenario: AI provider failure
+
+- **WHEN** the AI completion call throws an AiProviderException
+- **THEN** the service calls FailProcessing with the error message as the reason
+- **AND** the capture status transitions to Failed
+
+#### Scenario: Taste limit exceeded
+
+- **WHEN** the AI completion call throws a TasteLimitExceededException
+- **THEN** the service calls FailProcessing with reason "Daily AI limit reached"
+- **AND** the capture status transitions to Failed
+
+### Requirement: AiExtraction value object
+
+The system SHALL define an `AiExtraction` value object embedded on the Capture aggregate with the following properties: Summary (string, required), Commitments (list of extracted commitments with description, direction, person hint, optional due date, and optional source character offsets: SourceStartOffset and SourceEndOffset), Delegations (list of extracted delegations with description, person hint, and optional due date), Observations (list of extracted observations with description, person hint, and tag), Decisions (list of strings), RisksIdentified (list of strings), SuggestedPersonLinks (list of person name hints), SuggestedInitiativeLinks (list of initiative name hints), ConfidenceScore (decimal, 0.0-1.0), and DetectedCaptureType (nullable CaptureType indicating the AI's content classification).
+
+#### Scenario: AiExtraction with all fields populated
+
+- **WHEN** a transcript yields commitments, delegations, observations, decisions, and risks
+- **THEN** the AiExtraction value object contains all extracted items with their respective properties
+- **AND** each commitment includes SourceStartOffset and SourceEndOffset
+- **AND** DetectedCaptureType is set to the type the AI classified the content as
+
+#### Scenario: AiExtraction with minimal content
+
+- **WHEN** a quick note yields only a summary and one commitment
+- **THEN** the AiExtraction value object contains the summary and one commitment, with empty lists for other properties
+
+#### Scenario: AiExtraction with null DetectedCaptureType
+
+- **WHEN** the AI omits the `detected_type` field from its response
+- **THEN** the AiExtraction value object has DetectedCaptureType as null
+
+#### Scenario: AiExtraction equality
+
+- **WHEN** two AiExtraction instances have identical property values including DetectedCaptureType
+- **THEN** they are considered equal

--- a/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/auto-detect-capture-type/specs/capture-ai-extraction/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: AI extraction pipeline
 
-The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load the Capture, (2) call `IAiCompletionService.CompleteAsync` with a system prompt instructing the AI to extract structured data from the raw content, (3) parse the AI response into an `AiExtraction` value object, (4) call `CompleteProcessing(extraction)` on the Capture aggregate, and (5) persist the result. If the AI call fails, the service SHALL call `FailProcessing(reason)` on the Capture. The system prompt SHALL instruct the AI to include `source_start_offset` (0-based character index where the commitment starts in the input text) and `source_end_offset` (exclusive character index where the commitment ends) for each extracted commitment. The system prompt SHALL also instruct the AI to classify the content type as one of `QuickNote`, `Transcript`, or `MeetingNotes` via a `detected_type` field. After successful extraction, the handler SHALL call `Reclassify(detectedType)` on the Capture aggregate if the detected type is a valid `CaptureType` other than `AudioRecording`, the current capture type is not `AudioRecording`, and the detected type differs from the current type. The handler SHALL skip reclassification entirely for `AudioRecording` captures.
+The `AutoExtractCaptureHandler` SHALL orchestrate the extraction pipeline: (1) load the Capture, (2) call `IAiCompletionService.CompleteAsync` with a system prompt instructing the AI to extract structured data from the raw content, (3) parse the AI response into an `AiExtraction` value object, (4) if the detected type warrants reclassification, call `Reclassify(detectedType)` on the Capture while it is still in `Processing` status, (5) call `CompleteProcessing(extraction)` on the Capture aggregate, and (6) persist the result. If the AI call fails, the handler SHALL call `FailProcessing(reason)` on the Capture. The system prompt SHALL instruct the AI to include `source_start_offset` (0-based character index where the commitment starts in the input text) and `source_end_offset` (exclusive character index where the commitment ends) for each extracted commitment. The system prompt SHALL also instruct the AI to classify the content type as one of `QuickNote`, `Transcript`, or `MeetingNotes` via a `detected_type` field. The handler SHALL call `Reclassify(detectedType)` on the Capture aggregate if the detected type is a valid `CaptureType` other than `AudioRecording`, the current capture type is not `AudioRecording`, and the detected type differs from the current type. The handler SHALL skip reclassification entirely for `AudioRecording` captures.
 
 #### Scenario: Successful extraction from a quick note
 
@@ -54,13 +54,13 @@ The CaptureProcessingService SHALL orchestrate the extraction pipeline: (1) load
 #### Scenario: AI provider failure
 
 - **WHEN** the AI completion call throws an AiProviderException
-- **THEN** the service calls FailProcessing with the error message as the reason
+- **THEN** the handler calls FailProcessing with the error message as the reason
 - **AND** the capture status transitions to Failed
 
 #### Scenario: Taste limit exceeded
 
 - **WHEN** the AI completion call throws a TasteLimitExceededException
-- **THEN** the service calls FailProcessing with reason "Daily AI limit reached"
+- **THEN** the handler calls FailProcessing with reason "Daily AI limit reached"
 - **AND** the capture status transitions to Failed
 
 ### Requirement: AiExtraction value object

--- a/openspec/changes/auto-detect-capture-type/specs/capture-text/spec.md
+++ b/openspec/changes/auto-detect-capture-type/specs/capture-text/spec.md
@@ -41,7 +41,7 @@ The Capture aggregate SHALL expose a `Reclassify(CaptureType newType)` method th
 
 ### Requirement: Capture detail view
 
-The frontend SHALL provide a detail view for a single capture showing the full raw content, metadata (type, status, title, source, timestamps), and linked people and initiatives. The detail view SHALL allow editing the title and source, and linking/unlinking people and initiatives. When the capture has been processed and the `AiExtraction` contains a `DetectedCaptureType` that differs from the capture's original creation type, the detail view SHALL display a "Detected as: {type}" indicator near the type badge.
+The frontend SHALL provide a detail view for a single capture showing the full raw content, metadata (type, status, title, source, timestamps), and linked people and initiatives. The detail view SHALL allow editing the title and source, and linking/unlinking people and initiatives. When the capture has been processed and the `AiExtraction` contains a non-null `DetectedCaptureType`, the detail view SHALL display a "Detected as: {type}" indicator near the type badge. The indicator compares `DetectedCaptureType` against the capture's current persisted `CaptureType` -- if they match (i.e., the capture was reclassified or was already correct), the indicator serves as confirmation; if they differ (which would only happen if reclassification was skipped, e.g., for AudioRecording captures), the indicator highlights the discrepancy.
 
 #### Scenario: View capture detail
 
@@ -58,7 +58,17 @@ The frontend SHALL provide a detail view for a single capture showing the full r
 - **WHEN** a user adds a person link from the detail view
 - **THEN** the person appears in the linked people section
 
-#### Scenario: Display detected type when reclassified
+#### Scenario: Display detected type after reclassification
 
-- **WHEN** a user views a processed capture that was reclassified from QuickNote to Transcript
-- **THEN** the detail view shows the current type as "Transcript" and displays a "Detected as: Transcript" indicator
+- **WHEN** a user views a processed capture whose `CaptureType` is `Transcript` and whose `AiExtraction.DetectedCaptureType` is `Transcript`
+- **THEN** the detail view shows the type badge as "Transcript" and displays a "Detected as: Transcript" indicator
+
+#### Scenario: Display detected type for AudioRecording capture
+
+- **WHEN** a user views a processed `AudioRecording` capture whose `AiExtraction.DetectedCaptureType` is `Transcript`
+- **THEN** the detail view shows the type badge as "AudioRecording" and displays a "Detected as: Transcript" indicator highlighting the discrepancy
+
+#### Scenario: No detected type indicator when DetectedCaptureType is null
+
+- **WHEN** a user views a processed capture whose `AiExtraction.DetectedCaptureType` is null
+- **THEN** the detail view shows the type badge only, with no "Detected as" indicator

--- a/openspec/changes/auto-detect-capture-type/specs/capture-text/spec.md
+++ b/openspec/changes/auto-detect-capture-type/specs/capture-text/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Reclassify capture type
+
+The Capture aggregate SHALL expose a `Reclassify(CaptureType newType)` method that changes the capture's `CaptureType`. The method SHALL only be callable when `ProcessingStatus` is `Processing`. The method SHALL reject reclassification to `AudioRecording` by throwing a domain exception. If the new type is the same as the current type, the method SHALL be a no-op. On successful reclassification, the aggregate SHALL raise a `CaptureReclassified` domain event containing the capture ID, the old type, and the new type.
+
+#### Scenario: Reclassify from QuickNote to Transcript during processing
+
+- **WHEN** `Reclassify(CaptureType.Transcript)` is called on a capture with type `QuickNote` and status `Processing`
+- **THEN** the capture's `CaptureType` changes to `Transcript`
+- **AND** a `CaptureReclassified` domain event is raised with oldType `QuickNote` and newType `Transcript`
+
+#### Scenario: Reclassify from QuickNote to MeetingNotes during processing
+
+- **WHEN** `Reclassify(CaptureType.MeetingNotes)` is called on a capture with type `QuickNote` and status `Processing`
+- **THEN** the capture's `CaptureType` changes to `MeetingNotes`
+- **AND** a `CaptureReclassified` domain event is raised with oldType `QuickNote` and newType `MeetingNotes`
+
+#### Scenario: No-op when new type matches current type
+
+- **WHEN** `Reclassify(CaptureType.QuickNote)` is called on a capture with type `QuickNote`
+- **THEN** the capture's `CaptureType` remains `QuickNote`
+- **AND** no domain event is raised
+
+#### Scenario: Reject reclassification to AudioRecording
+
+- **WHEN** `Reclassify(CaptureType.AudioRecording)` is called on any capture
+- **THEN** the system throws a domain exception indicating that reclassification to AudioRecording is not allowed
+
+#### Scenario: Reject reclassification when not in Processing status
+
+- **WHEN** `Reclassify(CaptureType.Transcript)` is called on a capture with status `Raw`
+- **THEN** the system throws a domain exception indicating reclassification is only allowed during processing
+
+#### Scenario: Reject reclassification when in Processed status
+
+- **WHEN** `Reclassify(CaptureType.Transcript)` is called on a capture with status `Processed`
+- **THEN** the system throws a domain exception indicating reclassification is only allowed during processing
+
+## MODIFIED Requirements
+
+### Requirement: Capture detail view
+
+The frontend SHALL provide a detail view for a single capture showing the full raw content, metadata (type, status, title, source, timestamps), and linked people and initiatives. The detail view SHALL allow editing the title and source, and linking/unlinking people and initiatives. When the capture has been processed and the `AiExtraction` contains a `DetectedCaptureType` that differs from the capture's original creation type, the detail view SHALL display a "Detected as: {type}" indicator near the type badge.
+
+#### Scenario: View capture detail
+
+- **WHEN** a user clicks on a capture in the list
+- **THEN** the system navigates to the detail view showing the full content, metadata, and linked entities
+
+#### Scenario: Edit metadata from detail view
+
+- **WHEN** a user edits the title or source in the detail view and saves
+- **THEN** the metadata is updated and the view reflects the changes
+
+#### Scenario: Link person from detail view
+
+- **WHEN** a user adds a person link from the detail view
+- **THEN** the person appears in the linked people section
+
+#### Scenario: Display detected type when reclassified
+
+- **WHEN** a user views a processed capture that was reclassified from QuickNote to Transcript
+- **THEN** the detail view shows the current type as "Transcript" and displays a "Detected as: Transcript" indicator

--- a/openspec/changes/auto-detect-capture-type/tasks.md
+++ b/openspec/changes/auto-detect-capture-type/tasks.md
@@ -14,11 +14,11 @@
 
 ## 3. Infrastructure Layer
 
-- [ ] 3.1 Add EF Core migration for `DetectedCaptureType` column on the AiExtraction owned entity (nullable enum column)
-- [ ] 3.2 Update EF Core configuration if needed to map `AiExtraction.DetectedCaptureType`
+- [ ] 3.1 Verify no EF Core migration is required -- `AiExtraction` is persisted as JSONB via `ToJson()`, so `DetectedCaptureType` is stored as a new JSON field rather than a separate column
+- [ ] 3.2 Verify EF Core JSON mapping correctly serializes/deserializes `AiExtraction.DetectedCaptureType` (nullable enum in JSONB)
 
 ## 4. Frontend
 
-- [ ] 4.1 Add `detectedCaptureType` field to the capture response model/DTO in the Angular app
-- [ ] 4.2 Update capture detail view to display a "Detected as: {type}" indicator when `detectedCaptureType` is present and differs from the capture's original type
+- [ ] 4.1 Add `detectedCaptureType` field to the nested `AiExtraction` model/interface in the Angular app (under `aiExtraction`, not as a top-level field on `Capture`)
+- [ ] 4.2 Update capture detail view to display a "Detected as: {type}" indicator when `aiExtraction.detectedCaptureType` is present
 - [ ] 4.3 Write frontend unit test for the detected type indicator display logic

--- a/openspec/changes/auto-detect-capture-type/tasks.md
+++ b/openspec/changes/auto-detect-capture-type/tasks.md
@@ -1,0 +1,24 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Add `CaptureReclassified` domain event record to `Capture` events (Id, oldType, newType)
+- [ ] 1.2 Add `Reclassify(CaptureType newType)` method on `Capture` aggregate: guard Processing status, reject AudioRecording, no-op if same type, raise `CaptureReclassified` event
+- [ ] 1.3 Add `DetectedCaptureType` (nullable `CaptureType?`) property to `AiExtraction` value object
+- [ ] 1.4 Write domain unit tests for `Reclassify`: success cases (QuickNote->Transcript, QuickNote->MeetingNotes), no-op same type, reject AudioRecording, reject non-Processing status (Raw, Processed, Failed)
+
+## 2. Application Layer
+
+- [ ] 2.1 Add `detected_type` field to `ExtractionResponseDto` with `[JsonPropertyName("detected_type")]`
+- [ ] 2.2 Update `ExtractionPromptBuilder.SystemPrompt` to instruct the AI to classify content type and include `detected_type` in the JSON schema
+- [ ] 2.3 Update `AutoExtractCaptureHandler` to: parse `detected_type` from the DTO, set `DetectedCaptureType` on the `AiExtraction` object, call `capture.Reclassify(detectedType)` when valid and different from current type
+- [ ] 2.4 Write unit tests for `AutoExtractCaptureHandler`: reclassification when detected type differs, no reclassification when same type, no reclassification when detected_type is null/unrecognized, DetectedCaptureType stored on AiExtraction
+
+## 3. Infrastructure Layer
+
+- [ ] 3.1 Add EF Core migration for `DetectedCaptureType` column on the AiExtraction owned entity (nullable enum column)
+- [ ] 3.2 Update EF Core configuration if needed to map `AiExtraction.DetectedCaptureType`
+
+## 4. Frontend
+
+- [ ] 4.1 Add `detectedCaptureType` field to the capture response model/DTO in the Angular app
+- [ ] 4.2 Update capture detail view to display a "Detected as: {type}" indicator when `detectedCaptureType` is present and differs from the capture's original type
+- [ ] 4.3 Write frontend unit test for the detected type indicator display logic


### PR DESCRIPTION
## Summary

OpenSpec proposal to auto-detect capture content type (QuickNote, Transcript, MeetingNotes) during AI extraction. When AutoExtractCaptureHandler processes a capture, the AI classifies the content type as part of its existing extraction call and the capture is reclassified accordingly. Closes #172.

**Spec**: [capture-ai-extraction](openspec/specs/capture-ai-extraction/spec.md), [capture-text](openspec/specs/capture-text/spec.md)

## Changes

- **proposal.md**: Motivation, scope, and capability mapping for the change
- **design.md**: Technical decisions — classification via existing AI call, domain `Reclassify` method, `DetectedCaptureType` on AiExtraction
- **specs/capture-ai-extraction/spec.md**: Delta spec modifying the extraction pipeline and AiExtraction value object to include content type detection
- **specs/capture-text/spec.md**: Delta spec adding `Reclassify(CaptureType)` domain method and updating capture detail UI
- **tasks.md**: Implementation checklist across domain, application, infrastructure, and frontend layers

## Test Plan

- [ ] `dotnet test src/MentalMetal.slnx` passes (no code changes, verified locally)
- [ ] Review artifacts for completeness and consistency with existing specs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the proposal and specification changes for auto-detecting and reclassifying capture content types during AI extraction.

New Features:
- Define AI-driven detection of capture content type (QuickNote, Transcript, MeetingNotes) as part of the existing extraction pipeline.
- Specify domain-level reclassification of capture type during processing based on AI-detected type and expose the detected type in the capture detail UI.

Enhancements:
- Extend the AiExtraction value object to store the AI-detected capture type for auditing and display.
- Clarify prompt strategy and classification rules for content-type detection within the AI extraction system.
- Add an implementation task list covering domain, application, infrastructure, and frontend changes for the auto-detect capture type feature.

Documentation:
- Add design, proposal, and spec-change documents under openspec/changes/auto-detect-capture-type describing motivations, requirements, and scenarios for auto-detecting capture type.