### PR TITLE
chore: propose surface-unresolved-people change (closes #173)

### DIFF
--- a/openspec/changes/surface-unresolved-people/.openspec.yaml
+++ b/openspec/changes/surface-unresolved-people/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/surface-unresolved-people/design.md
+++ b/openspec/changes/surface-unresolved-people/design.md
@@ -1,0 +1,82 @@
+## Context
+
+When AI extraction processes a capture, `NameResolutionService` attempts to match raw person names against the user's existing people. Unresolved names (no match found) result in `PersonMention` entries with `PersonId = null` and extracted commitments with `PersonId = null` that are **not** spawned as Commitment entities (the handler requires a resolved person).
+
+A `ResolvePersonMentionHandler` already exists that links an existing person to an unresolved mention and adds the raw name as an alias. However, it does not spawn the skipped commitments after resolution, and there is no way to quick-create a new person from the capture context.
+
+The frontend capture detail view shows extraction results but does not highlight unresolved people or provide inline resolution actions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface unresolved person mentions prominently on the capture detail view
+- Allow users to resolve unresolved names by linking to an existing person (already partially implemented) or quick-creating a new person
+- Spawn skipped commitments when an unresolved person is resolved post-extraction
+- Add the raw name as an alias on the person (existing behaviour, extend to quick-create flow)
+
+**Non-Goals:**
+- Making `Commitment.PersonId` nullable
+- Changing the AI extraction prompt or fuzzy matching algorithm
+- Auto-creating people without user confirmation
+- Batch resolution across multiple captures
+
+## Dependencies
+
+- `person-management` (create person API, Person aggregate)
+- `commitment-tracking` (Commitment.Create, commitment repository)
+- `capture-ai-extraction` (AiExtraction value object, extraction pipeline)
+
+## Decisions
+
+### 1. Extend `ResolvePersonMentionHandler` to spawn skipped commitments
+
+**Decision:** After resolving a person mention, iterate the extraction's commitments that reference the same raw name and have no `SpawnedCommitmentId`, then create Commitment entities for High/Medium confidence items.
+
+**Rationale:** The handler already updates the extraction and links the person. Adding commitment spawning here keeps the resolution flow atomic -- one API call resolves the person and creates all associated commitments. The alternative (separate "spawn commitments" endpoint) adds unnecessary round-trips and coordination.
+
+**Alternatives considered:**
+- Separate endpoint for spawning commitments after resolution -- rejected: adds complexity and partial-state risk
+- Domain event on PersonMention resolution -- rejected: over-engineering for a synchronous flow within a single handler
+
+### 2. New `QuickCreateAndResolveHandler` for inline person creation
+
+**Decision:** Create a new handler that creates a Person (name + type, minimal fields), then delegates to the existing `ResolvePersonMentionHandler` logic (resolve mention, add alias, spawn commitments).
+
+**Rationale:** Reuses the existing resolution path. The quick-create flow needs only name and person type (defaulting to Stakeholder) -- full person details can be edited later. This avoids duplicating resolution logic.
+
+**Alternatives considered:**
+- Calling two separate APIs from the frontend (create person, then resolve mention) -- rejected: race conditions, poor UX, two round-trips
+- Adding person creation into `ResolvePersonMentionHandler` -- rejected: violates SRP, the existing handler takes a PersonId
+
+### 3. Frontend: unresolved-people banner on capture detail
+
+**Decision:** Show a prominent banner/card on the capture detail view when there are unresolved person mentions. Each unresolved name shows: the raw name, context snippet, and action buttons for "Link to Existing" (opens person search dropdown) and "Quick Create" (opens inline dialog with name pre-filled).
+
+**Rationale:** Users need to see unresolved names immediately after extraction completes. Inline actions avoid navigation away from the capture. PrimeNG Message component for the banner, Dialog for quick-create.
+
+**Alternatives considered:**
+- Toast notification only -- rejected: transient, easy to miss, no action affordance
+- Separate "unresolved people" page -- rejected: adds navigation, breaks capture-centric workflow
+- Inline expansion in the extraction panel -- acceptable but banner is more visible
+
+### 4. Track unresolved commitment details in extraction metadata
+
+**Decision:** The `ExtractedCommitment` already stores `PersonId` (null for unresolved) and `SpawnedCommitmentId` (null when not spawned). A commitment with a non-null `PersonId` referencing a raw name in the extraction and a null `SpawnedCommitmentId` is the indicator for "needs spawning after resolution." No schema changes needed for tracking.
+
+**Rationale:** The existing data model already captures the necessary state. Adding new fields would be redundant.
+
+### 5. Match extracted commitments to unresolved names via raw name correlation
+
+**Decision:** When resolving a person mention for raw name X, find extracted commitments where the `PersonRawName` from the original AI response matches X. Since `ExtractedCommitment` does not currently store the raw name (only the resolved `PersonId`), add a `PersonRawName` field to `ExtractedCommitment`.
+
+**Rationale:** Without the raw name on the extracted commitment, there is no reliable way to correlate which commitments belong to which unresolved person after the fact. The `PersonId` is null for unresolved names, but multiple unresolved names could exist. Storing the raw name is the simplest correlation mechanism.
+
+## Risks / Trade-offs
+
+- **[Risk] Adding `PersonRawName` to `ExtractedCommitment` requires a migration** -- Mitigation: `AiExtraction` is stored as a JSON column, so this is a non-breaking additive change. No SQL migration needed, just a code change.
+- **[Risk] Quick-create might produce duplicate people** -- Mitigation: Person creation already enforces name uniqueness per user. The quick-create dialog will show a warning if the name matches an existing person and suggest linking instead.
+- **[Risk] Spawning commitments post-resolution could create unexpected items** -- Mitigation: Only High/Medium confidence commitments are spawned (same rules as initial extraction). The UI will show a preview of what will be created.
+
+## Open Questions
+
+None -- the existing data model and handler patterns provide a clear path.

--- a/openspec/changes/surface-unresolved-people/design.md
+++ b/openspec/changes/surface-unresolved-people/design.md
@@ -59,11 +59,11 @@ The frontend capture detail view shows extraction results but does not highlight
 - Separate "unresolved people" page -- rejected: adds navigation, breaks capture-centric workflow
 - Inline expansion in the extraction panel -- acceptable but banner is more visible
 
-### 4. Track unresolved commitment details in extraction metadata
+### 4. Leverage existing extraction state for tracking unresolved commitments
 
-**Decision:** The `ExtractedCommitment` already stores `PersonId` (null for unresolved) and `SpawnedCommitmentId` (null when not spawned). A commitment with a non-null `PersonId` referencing a raw name in the extraction and a null `SpawnedCommitmentId` is the indicator for "needs spawning after resolution." No schema changes needed for tracking.
+**Decision:** The `ExtractedCommitment` already stores `PersonId` (null for unresolved) and `SpawnedCommitmentId` (null when not spawned). These two fields together identify commitments that were skipped during extraction and need spawning after person resolution. The only addition needed is `PersonRawName` (see decision 5) to correlate which commitments belong to which unresolved person.
 
-**Rationale:** The existing data model already captures the necessary state. Adding new fields would be redundant.
+**Rationale:** The existing state fields (`PersonId`, `SpawnedCommitmentId`) already capture whether a commitment was spawned or skipped. The gap is correlation -- knowing which raw name each commitment references -- which is addressed by `PersonRawName` in decision 5.
 
 ### 5. Match extracted commitments to unresolved names via raw name correlation
 

--- a/openspec/changes/surface-unresolved-people/proposal.md
+++ b/openspec/changes/surface-unresolved-people/proposal.md
@@ -8,7 +8,7 @@ When AI extraction identifies people mentioned in a capture, unresolved names ar
 - Add a "quick-create person" inline flow from the capture detail view so users can create people without navigating away
 - Add a "link to existing person" option for unresolved names where the AI match was ambiguous
 - After resolving previously-unresolved people, automatically spawn the commitments that were skipped during initial extraction
-- Include unresolved person count in the capture response DTO so the UI can show a notification badge
+- Frontend derives unresolved person count by filtering `PeopleMentioned` where `PersonId` is null (no separate DTO field needed)
 
 ## Non-goals
 

--- a/openspec/changes/surface-unresolved-people/proposal.md
+++ b/openspec/changes/surface-unresolved-people/proposal.md
@@ -30,7 +30,7 @@ When AI extraction identifies people mentioned in a capture, unresolved names ar
 
 - **Domain:** Capture aggregate gains unresolved-people tracking on AiExtraction value object (already partially there via PersonMention with null PersonId)
 - **Application:** AutoExtractCaptureHandler records skipped commitments for later resolution; new handler for resolving unresolved people post-extraction
-- **API:** New endpoint `POST /api/captures/{id}/resolve-people` to create/link people and spawn skipped commitments; CaptureResponse gains unresolved people count
+- **API:** New endpoint `POST /api/captures/{captureId}/resolve-person-mention/quick-create` to create a person and resolve the mention in one step; existing `POST /api/captures/{captureId}/resolve-person-mention` extended to spawn skipped commitments after resolution
 - **Frontend:** Capture detail view gains an unresolved-people review panel with quick-create and link-existing actions
 - **Aggregates affected:** Capture (extraction metadata), Person (creation), Commitment (deferred spawning)
 - **Dependencies:** person-management (create person API), commitment-tracking (create commitment), capture-ai-extraction (extraction pipeline)

--- a/openspec/changes/surface-unresolved-people/proposal.md
+++ b/openspec/changes/surface-unresolved-people/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+When AI extraction identifies people mentioned in a capture, unresolved names are silently dropped -- no commitment is created for them, and the user has no visibility into what was missed. This means actionable items tied to people not yet in the system are lost without the user knowing. Surfacing unresolved people and providing inline quick-create enables the user to capture all commitments from a single extraction pass. Closes #173.
+
+## What Changes
+
+- Surface unresolved person names to the user after extraction completes, showing which names could not be matched to existing people
+- Add a "quick-create person" inline flow from the capture detail view so users can create people without navigating away
+- Add a "link to existing person" option for unresolved names where the AI match was ambiguous
+- After resolving previously-unresolved people, automatically spawn the commitments that were skipped during initial extraction
+- Include unresolved person count in the capture response DTO so the UI can show a notification badge
+
+## Non-goals
+
+- Fully automated person creation (always require user confirmation)
+- Changing the fuzzy matching algorithm in NameResolutionService
+- Bulk person import or CSV upload
+- Modifying the AI extraction prompt to improve name resolution
+- Making Commitment.PersonId nullable (commitments still require a person)
+
+## Capabilities
+
+### New Capabilities
+- `unresolved-people-review`: Surface unresolved people from AI extraction and allow users to quick-create new people or link to existing ones, then spawn skipped commitments
+
+### Modified Capabilities
+- `capture-ai-extraction`: Add unresolved people data to extraction results and capture response; add endpoint to resolve unresolved people post-extraction
+
+## Impact
+
+- **Domain:** Capture aggregate gains unresolved-people tracking on AiExtraction value object (already partially there via PersonMention with null PersonId)
+- **Application:** AutoExtractCaptureHandler records skipped commitments for later resolution; new handler for resolving unresolved people post-extraction
+- **API:** New endpoint `POST /api/captures/{id}/resolve-people` to create/link people and spawn skipped commitments; CaptureResponse gains unresolved people count
+- **Frontend:** Capture detail view gains an unresolved-people review panel with quick-create and link-existing actions
+- **Aggregates affected:** Capture (extraction metadata), Person (creation), Commitment (deferred spawning)
+- **Dependencies:** person-management (create person API), commitment-tracking (create commitment), capture-ai-extraction (extraction pipeline)

--- a/openspec/changes/surface-unresolved-people/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/surface-unresolved-people/specs/capture-ai-extraction/spec.md
@@ -4,44 +4,29 @@
 
 The system SHALL, after successful extraction, automatically spawn Commitment entities for High/Medium confidence commitments that have a resolved PersonId. Commitments referencing unresolved people (null PersonId) SHALL be recorded in the extraction metadata with their `PersonRawName` but SHALL NOT be spawned as Commitment entities. Each spawned entity SHALL have its SourceCaptureId set to the originating capture's ID. Each spawned Commitment SHALL have its SourceStartOffset and SourceEndOffset set from the extracted commitment's source offsets (if available). The extraction metadata SHALL preserve all extracted commitments (both spawned and skipped) so that skipped commitments can be spawned later when the person is resolved.
 
-#### Scenario: Spawn commitments for resolved people only
+#### Scenario: Auto-spawn commitments for resolved people only
 
 - **WHEN** the extraction pipeline finds two commitments: one for "Sarah" (resolved to PersonId X) and one for "Mike" (unresolved)
-- **THEN** the system creates a Commitment entity for Sarah's commitment with PersonId X
+- **THEN** the system creates a Commitment entity for Sarah's commitment with PersonId X and SourceCaptureId set to the capture
 - **AND** records Mike's commitment in the extraction with PersonRawName "Mike", PersonId null, and SpawnedCommitmentId null
 - **AND** does NOT create a Commitment entity for Mike's commitment
 
-#### Scenario: Confirm and spawn all extracted entities
+#### Scenario: Auto-spawn with source offsets
 
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/confirm-extraction`
-- **THEN** the system creates Commitment entities for each extracted commitment with a resolved PersonId
-- **AND** each spawned entity has SourceCaptureId set to the capture's ID
-- **AND** each spawned Commitment has SourceStartOffset and SourceEndOffset set from the extraction data
-- **AND** the capture raises a `CaptureExtractionConfirmed` domain event
+- **WHEN** the extraction pipeline spawns a commitment with source offsets
+- **THEN** the spawned Commitment has SourceStartOffset and SourceEndOffset set from the extraction data
 
-#### Scenario: Confirm extraction with person matching
+#### Scenario: Name resolution matches existing person
 
 - **WHEN** the extraction contains person hints (e.g., "Sarah") and the user has a Person named "Sarah Chen"
-- **THEN** the system matches the hint to the existing Person by name similarity and sets the PersonId on spawned entities
+- **THEN** the system matches the hint to the existing Person by name similarity and sets the PersonId on the spawned commitment
 
-#### Scenario: Confirm extraction with no person match
+#### Scenario: Name resolution finds no match
 
 - **WHEN** the extraction contains a person hint that does not match any existing Person
 - **THEN** the extracted commitment is recorded with PersonRawName set and PersonId null
 - **AND** no Commitment entity is spawned for that item
 - **AND** the user can resolve the person later via the unresolved people review flow
-
-#### Scenario: Discard extraction
-
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/discard-extraction`
-- **THEN** the system does NOT spawn any entities
-- **AND** the AiExtraction is retained on the capture for reference
-- **AND** the capture raises a `CaptureExtractionDiscarded` domain event
-
-#### Scenario: Confirm on non-processed capture rejected
-
-- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/confirm-extraction` for a capture that is not in Processed status
-- **THEN** the system returns HTTP 409 Conflict
 
 ### Requirement: AiExtraction value object
 

--- a/openspec/changes/surface-unresolved-people/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/surface-unresolved-people/specs/capture-ai-extraction/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: Spawn entities from extraction
+
+The system SHALL, after successful extraction, automatically spawn Commitment entities for High/Medium confidence commitments that have a resolved PersonId. Commitments referencing unresolved people (null PersonId) SHALL be recorded in the extraction metadata with their `PersonRawName` but SHALL NOT be spawned as Commitment entities. Each spawned entity SHALL have its SourceCaptureId set to the originating capture's ID. Each spawned Commitment SHALL have its SourceStartOffset and SourceEndOffset set from the extracted commitment's source offsets (if available). The extraction metadata SHALL preserve all extracted commitments (both spawned and skipped) so that skipped commitments can be spawned later when the person is resolved.
+
+#### Scenario: Spawn commitments for resolved people only
+
+- **WHEN** the extraction pipeline finds two commitments: one for "Sarah" (resolved to PersonId X) and one for "Mike" (unresolved)
+- **THEN** the system creates a Commitment entity for Sarah's commitment with PersonId X
+- **AND** records Mike's commitment in the extraction with PersonRawName "Mike", PersonId null, and SpawnedCommitmentId null
+- **AND** does NOT create a Commitment entity for Mike's commitment
+
+#### Scenario: Confirm and spawn all extracted entities
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/confirm-extraction`
+- **THEN** the system creates Commitment entities for each extracted commitment with a resolved PersonId
+- **AND** each spawned entity has SourceCaptureId set to the capture's ID
+- **AND** each spawned Commitment has SourceStartOffset and SourceEndOffset set from the extraction data
+- **AND** the capture raises a `CaptureExtractionConfirmed` domain event
+
+#### Scenario: Confirm extraction with person matching
+
+- **WHEN** the extraction contains person hints (e.g., "Sarah") and the user has a Person named "Sarah Chen"
+- **THEN** the system matches the hint to the existing Person by name similarity and sets the PersonId on spawned entities
+
+#### Scenario: Confirm extraction with no person match
+
+- **WHEN** the extraction contains a person hint that does not match any existing Person
+- **THEN** the extracted commitment is recorded with PersonRawName set and PersonId null
+- **AND** no Commitment entity is spawned for that item
+- **AND** the user can resolve the person later via the unresolved people review flow
+
+#### Scenario: Discard extraction
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/discard-extraction`
+- **THEN** the system does NOT spawn any entities
+- **AND** the AiExtraction is retained on the capture for reference
+- **AND** the capture raises a `CaptureExtractionDiscarded` domain event
+
+#### Scenario: Confirm on non-processed capture rejected
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{id}/confirm-extraction` for a capture that is not in Processed status
+- **THEN** the system returns HTTP 409 Conflict
+
+### Requirement: AiExtraction value object
+
+The system SHALL define an `AiExtraction` value object embedded on the Capture aggregate with the following properties: Summary (string, required), Commitments (list of extracted commitments with description, direction, person hint, PersonRawName, optional due date, and optional source character offsets: SourceStartOffset and SourceEndOffset, optional SpawnedCommitmentId), Delegations (list of extracted delegations with description, person hint, and optional due date), Observations (list of extracted observations with description, person hint, and tag), Decisions (list of strings), RisksIdentified (list of strings), SuggestedPersonLinks (list of person name hints), SuggestedInitiativeLinks (list of initiative name hints), and ConfidenceScore (decimal, 0.0-1.0).
+
+#### Scenario: AiExtraction with all fields populated
+
+- **WHEN** a transcript yields commitments, delegations, observations, decisions, and risks
+- **THEN** the AiExtraction value object contains all extracted items with their respective properties
+- **AND** each commitment includes SourceStartOffset, SourceEndOffset, and PersonRawName
+
+#### Scenario: AiExtraction with minimal content
+
+- **WHEN** a quick note yields only a summary and one commitment
+- **THEN** the AiExtraction value object contains the summary and one commitment, with empty lists for other properties
+
+#### Scenario: AiExtraction equality
+
+- **WHEN** two AiExtraction instances have identical property values
+- **THEN** they are considered equal
+
+### Requirement: Resolve person mention post-extraction
+
+The system SHALL allow an authenticated user to resolve an unresolved person mention by sending a POST to `/api/captures/{captureId}/resolve-person-mention` with `rawName` and `personId`. The system SHALL update the extraction's PersonMention with the resolved PersonId, add the raw name as an alias on the person (if not already present), link the capture to the person, and spawn any skipped commitments for that person (High/Medium confidence with no existing SpawnedCommitmentId). The raw name used as alias SHALL be validated for uniqueness among the user's people.
+
+#### Scenario: Resolve and spawn skipped commitments
+
+- **WHEN** an authenticated user resolves "Sarah" to PersonId X
+- **AND** the extraction has one High confidence commitment with PersonRawName "Sarah" and SpawnedCommitmentId null
+- **THEN** the system creates a Commitment entity with PersonId X
+- **AND** updates the extraction's commitment with the SpawnedCommitmentId
+- **AND** records the spawned commitment on the capture
+
+#### Scenario: Resolve with no skipped commitments
+
+- **WHEN** an authenticated user resolves "Mike" to PersonId Y
+- **AND** no extracted commitments reference "Mike"
+- **THEN** the mention is resolved and linked, but no commitments are spawned
+
+#### Scenario: Alias conflict rejected
+
+- **WHEN** an authenticated user resolves "Sarah" to PersonId X
+- **AND** another Person already has "Sarah" as an alias
+- **THEN** the system returns HTTP 409 Conflict

--- a/openspec/changes/surface-unresolved-people/specs/unresolved-people-review/spec.md
+++ b/openspec/changes/surface-unresolved-people/specs/unresolved-people-review/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Quick-create person and resolve mention
+
+The system SHALL allow an authenticated user to create a new Person and resolve an unresolved person mention in a single operation by sending a POST to `/api/captures/{captureId}/resolve-person-mention/quick-create` with `rawName`, `personName`, and `personType`. The system SHALL create the Person, add the raw name as an alias (if different from the person name), update the extraction's PersonMention with the new PersonId, link the capture to the new person, and spawn any skipped commitments for that person. The operation SHALL be atomic -- if any step fails, no changes are persisted.
+
+#### Scenario: Quick-create a new person from unresolved mention
+
+- **WHEN** an authenticated user sends a POST to `/api/captures/{captureId}/resolve-person-mention/quick-create` with rawName "Sarah", personName "Sarah Chen", and personType "Stakeholder"
+- **THEN** the system creates a Person named "Sarah Chen" with type Stakeholder
+- **AND** adds "Sarah" as an alias on the new Person
+- **AND** updates the extraction's PersonMention for "Sarah" with the new PersonId
+- **AND** links the capture to the new Person
+- **AND** spawns Commitment entities for any High/Medium confidence extracted commitments referencing "Sarah"
+- **AND** returns HTTP 200 with the updated CaptureResponse
+
+#### Scenario: Quick-create with same name as raw name
+
+- **WHEN** an authenticated user sends a POST with rawName "Sarah Chen" and personName "Sarah Chen"
+- **THEN** the system creates the Person but does NOT add a redundant alias
+- **AND** resolves the mention and spawns commitments as normal
+
+#### Scenario: Quick-create with duplicate person name rejected
+
+- **WHEN** an authenticated user sends a POST with personName "Alice Smith" and a non-archived Person named "Alice Smith" already exists
+- **THEN** the system returns HTTP 409 Conflict with a message suggesting to link to the existing person instead
+
+#### Scenario: Quick-create with no extraction rejected
+
+- **WHEN** an authenticated user sends a POST for a capture that has no AI extraction
+- **THEN** the system returns HTTP 400 with message "Capture has no AI extraction to resolve"
+
+#### Scenario: Quick-create with unknown raw name rejected
+
+- **WHEN** an authenticated user sends a POST with a rawName that does not match any PersonMention in the extraction
+- **THEN** the system returns HTTP 400 with message indicating the raw name was not found in extraction
+
+### Requirement: Spawn skipped commitments on person resolution
+
+The system SHALL, when resolving an unresolved person mention (via either link-to-existing or quick-create), spawn Commitment entities for extracted commitments that reference the resolved raw name, have High or Medium confidence, and have no `SpawnedCommitmentId`. The spawned commitments SHALL follow the same creation rules as initial extraction (direction, due date, source offsets, source capture link). The system SHALL update the extraction's `ExtractedCommitment` entries with the newly spawned `SpawnedCommitmentId` and resolved `PersonId`.
+
+#### Scenario: Spawn commitments after resolving person mention
+
+- **WHEN** an unresolved person mention for "Sarah" is resolved to PersonId X
+- **AND** the extraction contains two commitments referencing "Sarah": one High confidence and one Low confidence
+- **THEN** the system creates one Commitment entity (High confidence) with PersonId X and SourceCaptureId set to the capture
+- **AND** updates the extraction's High confidence commitment with the SpawnedCommitmentId
+- **AND** does NOT spawn a commitment for the Low confidence item
+
+#### Scenario: No commitments to spawn
+
+- **WHEN** an unresolved person mention is resolved but no extracted commitments reference that raw name
+- **THEN** no commitments are spawned and the resolution completes successfully
+
+#### Scenario: Commitments already spawned are not duplicated
+
+- **WHEN** an extracted commitment already has a non-null SpawnedCommitmentId
+- **THEN** the system does NOT create a duplicate commitment for that entry
+
+### Requirement: Store raw person name on extracted commitments
+
+The system SHALL store the `PersonRawName` on each `ExtractedCommitment` in the `AiExtraction` value object. This field records the original raw name string from the AI response, enabling correlation between unresolved person mentions and their associated commitments after extraction. The field SHALL be populated during the extraction pipeline for all commitments that reference a person.
+
+#### Scenario: Extracted commitment stores raw person name
+
+- **WHEN** the AI extraction pipeline processes a capture and extracts a commitment referencing "Sarah"
+- **THEN** the `ExtractedCommitment` has `PersonRawName` set to "Sarah"
+
+#### Scenario: Extracted commitment with no person reference
+
+- **WHEN** the AI extraction pipeline extracts a commitment with no person reference
+- **THEN** the `ExtractedCommitment` has `PersonRawName` set to null
+
+### Requirement: Unresolved people banner on capture detail
+
+The frontend capture detail view SHALL display a prominent banner when the extraction contains unresolved person mentions (PersonMention entries with null PersonId). The banner SHALL show the count of unresolved people and list each unresolved name with its context snippet. Each unresolved name SHALL have two action buttons: "Link to Existing" (opens a person search/select dropdown) and "Quick Create" (opens a dialog with name pre-filled). The banner SHALL disappear when all person mentions are resolved.
+
+#### Scenario: Banner shown with unresolved people
+
+- **WHEN** a user views a processed capture that has two unresolved person mentions ("Sarah" and "Mike")
+- **THEN** the capture detail view shows a banner stating "2 unresolved people"
+- **AND** each name is listed with "Link to Existing" and "Quick Create" buttons
+
+#### Scenario: Banner hidden when all people resolved
+
+- **WHEN** a user views a processed capture where all person mentions have a non-null PersonId
+- **THEN** no unresolved people banner is displayed
+
+#### Scenario: Banner updates after resolution
+
+- **WHEN** a user resolves "Sarah" via quick-create or link-to-existing
+- **THEN** the banner updates to show the remaining unresolved count
+- **AND** "Sarah" is removed from the unresolved list
+
+### Requirement: Link-to-existing person flow
+
+The frontend SHALL provide a person search/select flow for the "Link to Existing" action on unresolved person mentions. The flow SHALL show a searchable dropdown of the user's existing people. Selecting a person SHALL call the existing `POST /api/captures/{captureId}/resolve-person-mention` endpoint with the raw name and selected PersonId.
+
+#### Scenario: Link unresolved mention to existing person
+
+- **WHEN** a user clicks "Link to Existing" on unresolved name "Sarah"
+- **AND** selects "Sarah Chen" from the person dropdown
+- **THEN** the system calls the resolve endpoint with rawName "Sarah" and the PersonId for "Sarah Chen"
+- **AND** the UI updates to show "Sarah" as resolved
+
+#### Scenario: Search filters people list
+
+- **WHEN** a user types "Sar" in the person search dropdown
+- **THEN** the dropdown shows only people whose name contains "Sar"
+
+### Requirement: Quick-create person dialog
+
+The frontend SHALL provide a quick-create dialog for the "Quick Create" action on unresolved person mentions. The dialog SHALL pre-fill the person name with the raw name from the extraction and default the person type to Stakeholder. The user SHALL be able to edit the name and select a different person type before confirming. Confirming SHALL call the `POST /api/captures/{captureId}/resolve-person-mention/quick-create` endpoint.
+
+#### Scenario: Quick-create dialog pre-filled
+
+- **WHEN** a user clicks "Quick Create" on unresolved name "Sarah"
+- **THEN** a dialog opens with the name field pre-filled as "Sarah" and type defaulted to "Stakeholder"
+
+#### Scenario: User edits name before creating
+
+- **WHEN** a user changes the pre-filled name from "Sarah" to "Sarah Chen" and confirms
+- **THEN** the system creates a Person named "Sarah Chen" and resolves the mention
+
+#### Scenario: User changes person type
+
+- **WHEN** a user selects "DirectReport" instead of the default "Stakeholder" and confirms
+- **THEN** the system creates a Person with type DirectReport

--- a/openspec/changes/surface-unresolved-people/tasks.md
+++ b/openspec/changes/surface-unresolved-people/tasks.md
@@ -1,0 +1,57 @@
+## 1. Domain: Add PersonRawName to ExtractedCommitment
+
+- [ ] 1.1 Add `PersonRawName` (string?) property to `ExtractedCommitment` record in `AiExtraction.cs`
+- [ ] 1.2 Add unit tests verifying `ExtractedCommitment` stores and exposes `PersonRawName`
+
+## 2. Application: Populate PersonRawName during extraction
+
+- [ ] 2.1 Update `AutoExtractCaptureHandler` to set `PersonRawName` on each `ExtractedCommitment` from the AI response's `PersonRawName` field
+- [ ] 2.2 Update `ExtractedCommitmentResponse` DTO in `CaptureDtos.cs` to include `PersonRawName`
+- [ ] 2.3 Add/update unit tests for `AutoExtractCaptureHandler` verifying `PersonRawName` is populated on extracted commitments
+
+## 3. Application: Extend ResolvePersonMentionHandler to spawn skipped commitments
+
+- [ ] 3.1 Update `ResolvePersonMentionHandler` to find extracted commitments matching the resolved raw name (via `PersonRawName`) with High/Medium confidence and null `SpawnedCommitmentId`
+- [ ] 3.2 Spawn Commitment entities for matching extracted commitments and update extraction with `SpawnedCommitmentId` and `PersonId`
+- [ ] 3.3 Record spawned commitments on the capture via `RecordSpawnedCommitment`
+- [ ] 3.4 Add unit tests for commitment spawning on person resolution (resolved with commitments, resolved without commitments, already-spawned not duplicated, Low confidence not spawned)
+
+## 4. Application: QuickCreateAndResolveHandler
+
+- [ ] 4.1 Create `QuickCreateAndResolveHandler` with request record (`RawName`, `PersonName`, `PersonType`) in `Captures/AutoExtract/`
+- [ ] 4.2 Implement: create Person, add raw name as alias (if different from person name), delegate to resolve-mention logic (update extraction, link capture, spawn commitments)
+- [ ] 4.3 Handle duplicate person name by returning conflict error
+- [ ] 4.4 Add unit tests for quick-create flow (happy path, duplicate name conflict, same name as raw name skips alias, no extraction error)
+
+## 5. Web: Register API endpoint
+
+- [ ] 5.1 Add minimal API endpoint `POST /api/captures/{captureId}/resolve-person-mention/quick-create` mapped to `QuickCreateAndResolveHandler`
+- [ ] 5.2 Add unit/integration test for the new endpoint (201 on success, 409 on duplicate, 400 on missing extraction)
+
+## 6. Frontend: Unresolved people banner component
+
+- [ ] 6.1 Create `UnresolvedPeopleBannerComponent` (standalone, signals) in `src/app/pages/captures/capture-detail/`
+- [ ] 6.2 Implement banner displaying count and list of unresolved person mentions (filter `PeopleMentioned` where `PersonId` is null)
+- [ ] 6.3 Add "Link to Existing" button per unresolved name with PrimeNG AutoComplete/Dropdown for person search
+- [ ] 6.4 Add "Quick Create" button per unresolved name that opens quick-create dialog
+
+## 7. Frontend: Quick-create person dialog
+
+- [ ] 7.1 Create `QuickCreatePersonDialogComponent` (standalone, signals) using PrimeNG Dialog
+- [ ] 7.2 Implement form with pre-filled name input and person type dropdown (defaulting to Stakeholder)
+- [ ] 7.3 Wire dialog confirmation to call the quick-create-and-resolve API endpoint
+- [ ] 7.4 Handle success (refresh capture data, close dialog) and error (show conflict message suggesting link-to-existing)
+
+## 8. Frontend: Wire into capture detail view
+
+- [ ] 8.1 Add `UnresolvedPeopleBannerComponent` to capture detail view template, shown when extraction has unresolved mentions
+- [ ] 8.2 Wire "Link to Existing" flow to call existing resolve-person-mention API and refresh capture data
+- [ ] 8.3 Add capture service method for the quick-create-and-resolve endpoint
+- [ ] 8.4 Verify banner disappears when all mentions are resolved
+
+## 9. Testing
+
+- [ ] 9.1 Add backend integration tests for the full resolve-and-spawn flow (link-to-existing path)
+- [ ] 9.2 Add backend integration tests for the full quick-create-and-resolve flow
+- [ ] 9.3 Add frontend component tests for `UnresolvedPeopleBannerComponent` (shows/hides, button actions)
+- [ ] 9.4 Add frontend component tests for `QuickCreatePersonDialogComponent` (pre-fill, submit, error handling)

--- a/openspec/changes/surface-unresolved-people/tasks.md
+++ b/openspec/changes/surface-unresolved-people/tasks.md
@@ -26,7 +26,7 @@
 ## 5. Web: Register API endpoint
 
 - [ ] 5.1 Add minimal API endpoint `POST /api/captures/{captureId}/resolve-person-mention/quick-create` mapped to `QuickCreateAndResolveHandler`
-- [ ] 5.2 Add unit/integration test for the new endpoint (201 on success, 409 on duplicate, 400 on missing extraction)
+- [ ] 5.2 Add unit/integration test for the new endpoint (200 on success, 409 on duplicate, 400 on missing extraction)
 
 ## 6. Frontend: Unresolved people banner component
 


### PR DESCRIPTION
## Summary

OpenSpec proposal to surface unresolved people from AI extraction and allow quick-create or linking. When AutoExtractCaptureHandler finds person names that don't match existing people, this change will surface them to the user with options to create new people or link to existing ones, and spawn skipped commitments after resolution.

**Spec**: [capture-ai-extraction](openspec/specs/capture-ai-extraction/spec.md), [unresolved-people-review](openspec/changes/surface-unresolved-people/specs/unresolved-people-review/spec.md)

## Changes

- **proposal.md**: Problem statement, scope, capabilities (new: `unresolved-people-review`, modified: `capture-ai-extraction`)
- **design.md**: Technical decisions — extend ResolvePersonMentionHandler for commitment spawning, new QuickCreateAndResolveHandler, unresolved-people banner component, PersonRawName on ExtractedCommitment
- **specs/unresolved-people-review/spec.md**: New capability spec — quick-create person + resolve, spawn skipped commitments, unresolved banner UI, link-to-existing flow, quick-create dialog
- **specs/capture-ai-extraction/spec.md**: Delta spec — modified AiExtraction value object (PersonRawName), modified spawn-from-extraction to skip unresolved, new resolve-post-extraction requirement
- **tasks.md**: 9 task groups (domain, application, web, frontend, testing) with 27 implementation tasks

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (375 tests)
- [x] `ng test --watch=false` passes (49 tests)
- [ ] Review artifacts for completeness and consistency

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an OpenSpec proposal for surfacing unresolved people from AI capture extraction, enabling post-extraction resolution flows and spawning of previously skipped commitments.

New Features:
- Introduce an unresolved-people review capability that surfaces unresolved person mentions and supports quick-create or link-to-existing flows from capture detail.
- Define a quick-create-and-resolve API flow to create a new person, resolve an unresolved mention, and spawn any related skipped commitments in one atomic operation.
- Specify frontend UX for an unresolved people banner, quick-create dialog, and person search/select flow on capture detail views.

Enhancements:
- Extend the capture AI extraction capability specification to retain unresolved commitments with raw person names for later resolution and spawning.
- Clarify domain and application behaviors around storing PersonRawName on extracted commitments, commitment spawning rules, and post-extraction person resolution flows.
- Add a task breakdown covering domain, application, web API, frontend, and testing work required to implement the unresolved-people review experience.

Documentation:
- Add proposal, design, and detailed spec documents describing the unresolved-people-review capability, including goals, decisions, scenarios, and implementation tasks.