### PR TITLE
feat: auto-detect capture type during AI extraction

### DIFF
--- a/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
@@ -183,7 +183,18 @@ public sealed class AutoExtractCaptureHandler(
                     capture.LinkToInitiative(initiativeId.Value);
             }
 
-            // 10. Complete processing
+            // 10. Reclassify capture type if the AI detected a different type
+            CaptureType? detectedCaptureType = TryParseCaptureType(dto.DetectedType);
+
+            if (detectedCaptureType.HasValue
+                && detectedCaptureType.Value != CaptureType.AudioRecording
+                && capture.CaptureType != CaptureType.AudioRecording
+                && detectedCaptureType.Value != capture.CaptureType)
+            {
+                capture.Reclassify(detectedCaptureType.Value);
+            }
+
+            // 11. Complete processing
             var extraction = new AiExtraction
             {
                 Summary = dto.Summary,
@@ -192,7 +203,8 @@ public sealed class AutoExtractCaptureHandler(
                 Decisions = dto.Decisions,
                 Risks = dto.Risks,
                 InitiativeTags = initiativeTags,
-                ExtractedAt = DateTimeOffset.UtcNow
+                ExtractedAt = DateTimeOffset.UtcNow,
+                DetectedCaptureType = detectedCaptureType
             };
 
             capture.CompleteProcessing(extraction);
@@ -263,4 +275,12 @@ public sealed class AutoExtractCaptureHandler(
             ? result
             : null;
     }
+
+    private static CaptureType? TryParseCaptureType(string? value) => value switch
+    {
+        "QuickNote" => CaptureType.QuickNote,
+        "Transcript" => CaptureType.Transcript,
+        "MeetingNotes" => CaptureType.MeetingNotes,
+        _ => null
+    };
 }

--- a/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
@@ -276,11 +276,17 @@ public sealed class AutoExtractCaptureHandler(
             : null;
     }
 
-    private static CaptureType? TryParseCaptureType(string? value) => value switch
+    private static CaptureType? TryParseCaptureType(string? value)
     {
-        "QuickNote" => CaptureType.QuickNote,
-        "Transcript" => CaptureType.Transcript,
-        "MeetingNotes" => CaptureType.MeetingNotes,
-        _ => null
-    };
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return value.Trim() switch
+        {
+            var v when v.Equals("QuickNote", StringComparison.OrdinalIgnoreCase) => CaptureType.QuickNote,
+            var v when v.Equals("Transcript", StringComparison.OrdinalIgnoreCase) => CaptureType.Transcript,
+            var v when v.Equals("MeetingNotes", StringComparison.OrdinalIgnoreCase) => CaptureType.MeetingNotes,
+            _ => null
+        };
+    }
 }

--- a/src/MentalMetal.Application/Captures/AutoExtract/ExtractionPromptBuilder.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/ExtractionPromptBuilder.cs
@@ -37,6 +37,11 @@ public static class ExtractionPromptBuilder
 
         6. **summary**: A 2-3 sentence summary of the key discussion points and outcomes.
 
+        7. **detected_type**: Classify the content type. One of:
+           - "QuickNote": Short unstructured text, a single thought, reminder, or brief note
+           - "Transcript": Multi-speaker dialogue with speaker labels or turn-taking patterns
+           - "MeetingNotes": Structured notes with headings, bullet points, agenda items, or action items
+
         Rules:
         - Only extract what is EXPLICITLY stated in the text. Do NOT infer or hallucinate.
         - If the text is a quick note with no clear commitments, return empty arrays.
@@ -49,7 +54,8 @@ public static class ExtractionPromptBuilder
           "commitments": [{"description": "string", "direction": "MineToThem|TheirsToMe", "person_raw_name": "string|null", "due_date": "string|null", "confidence": "High|Medium|Low", "source_start_offset": 0, "source_end_offset": 0}],
           "decisions": ["string"],
           "risks": ["string"],
-          "initiative_tags": [{"raw_name": "string", "context": "string|null"}]
+          "initiative_tags": [{"raw_name": "string", "context": "string|null"}],
+          "detected_type": "QuickNote|Transcript|MeetingNotes"
         }
         """;
 

--- a/src/MentalMetal.Application/Captures/AutoExtract/ExtractionResponseDto.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/ExtractionResponseDto.cs
@@ -24,6 +24,9 @@ internal sealed record ExtractionResponseDto
 
     [JsonPropertyName("initiative_tags")]
     public List<InitiativeTagDto> InitiativeTags { get; init; } = [];
+
+    [JsonPropertyName("detected_type")]
+    public string? DetectedType { get; init; }
 }
 
 internal sealed record PersonMentionDto

--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -14,7 +14,8 @@ public sealed record AiExtractionResponse(
     List<string> Decisions,
     List<string> Risks,
     List<InitiativeTagResponse> InitiativeTags,
-    DateTimeOffset ExtractedAt)
+    DateTimeOffset ExtractedAt,
+    CaptureType? DetectedCaptureType)
 {
     public static AiExtractionResponse? From(AiExtraction? extraction) =>
         extraction is null ? null : new(
@@ -25,7 +26,8 @@ public sealed record AiExtractionResponse(
             (extraction.Decisions ?? []).ToList(),
             (extraction.Risks ?? []).ToList(),
             (extraction.InitiativeTags ?? []).Select(t => new InitiativeTagResponse(t.RawName, t.InitiativeId, t.Context)).ToList(),
-            extraction.ExtractedAt);
+            extraction.ExtractedAt,
+            extraction.DetectedCaptureType);
 }
 
 public sealed record PersonMentionResponse(string RawName, Guid? PersonId, string? Context);

--- a/src/MentalMetal.Domain/Captures/AiExtraction.cs
+++ b/src/MentalMetal.Domain/Captures/AiExtraction.cs
@@ -14,6 +14,7 @@ public sealed record AiExtraction
     public IReadOnlyList<string> Risks { get; init; } = new List<string>();
     public IReadOnlyList<InitiativeTag> InitiativeTags { get; init; } = new List<InitiativeTag>();
     public required DateTimeOffset ExtractedAt { get; init; }
+    public CaptureType? DetectedCaptureType { get; init; }
 }
 
 public sealed record PersonMention

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -161,6 +161,26 @@ public sealed class Capture : AggregateRoot, IUserScoped
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 
+    public void Reclassify(CaptureType newType)
+    {
+        if (ProcessingStatus != ProcessingStatus.Processing)
+            throw new InvalidOperationException(
+                $"Cannot reclassify from '{ProcessingStatus}' status. Reclassification is only allowed during processing.");
+
+        if (newType == CaptureType.AudioRecording)
+            throw new InvalidOperationException(
+                "Cannot reclassify to AudioRecording. AudioRecording is set by the audio capture pipeline.");
+
+        if (CaptureType == newType)
+            return;
+
+        var oldType = CaptureType;
+        CaptureType = newType;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        RaiseDomainEvent(new CaptureReclassified(Id, oldType, newType));
+    }
+
     public void UpdateMetadata(string? title)
     {
         Title = title?.Trim();

--- a/src/MentalMetal.Domain/Captures/Capture.cs
+++ b/src/MentalMetal.Domain/Captures/Capture.cs
@@ -171,6 +171,10 @@ public sealed class Capture : AggregateRoot, IUserScoped
             throw new InvalidOperationException(
                 "Cannot reclassify to AudioRecording. AudioRecording is set by the audio capture pipeline.");
 
+        if (CaptureType == CaptureType.AudioRecording)
+            throw new InvalidOperationException(
+                "Cannot reclassify from AudioRecording. AudioRecording captures are managed by the audio pipeline.");
+
         if (CaptureType == newType)
             return;
 

--- a/src/MentalMetal.Domain/Captures/CaptureEvents.cs
+++ b/src/MentalMetal.Domain/Captures/CaptureEvents.cs
@@ -70,3 +70,8 @@ public sealed record CaptureSpeakerIdentified(Guid CaptureId, string SpeakerLabe
 {
     public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
 }
+
+public sealed record CaptureReclassified(Guid CaptureId, CaptureType OldType, CaptureType NewType) : IDomainEvent
+{
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.Designer.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MentalMetal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MentalMetal.Infrastructure.Migrations
 {
     [DbContext(typeof(MentalMetalDbContext))]
-    partial class MentalMetalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421202108_DetectedCaptureTypeOnAiExtraction")]
+    partial class DetectedCaptureTypeOnAiExtraction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MentalMetal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DetectedCaptureTypeOnAiExtraction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.cs
+++ b/src/MentalMetal.Infrastructure/Migrations/20260421202108_DetectedCaptureTypeOnAiExtraction.cs
@@ -4,19 +4,23 @@
 
 namespace MentalMetal.Infrastructure.Migrations
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Intentionally empty — DetectedCaptureType is a new property on the AiExtraction
+    /// value object, which is persisted as JSONB via ToJson(). No schema change is needed;
+    /// this migration exists only to update the EF Core model snapshot.
+    /// </summary>
     public partial class DetectedCaptureTypeOnAiExtraction : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-
+            // No schema change — AiExtraction is stored as JSONB; new fields appear automatically.
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-
+            // No schema change to revert.
         }
     }
 }

--- a/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
+++ b/src/MentalMetal.Infrastructure/Persistence/Configurations/CaptureConfiguration.cs
@@ -35,6 +35,8 @@ public sealed class CaptureConfiguration : IEntityTypeConfiguration<Capture>
             extraction.OwnsMany(e => e.PeopleMentioned);
             extraction.OwnsMany(e => e.Commitments);
             extraction.OwnsMany(e => e.InitiativeTags);
+            extraction.Property(e => e.DetectedCaptureType)
+                .HasConversion<string?>();
         });
 
         builder.Property(c => c.FailureReason)

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.spec.ts
@@ -1,0 +1,130 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { provideRouter } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { CaptureDetailComponent } from './capture-detail.component';
+import { CapturesService } from '../../../shared/services/captures.service';
+import { PeopleService } from '../../../shared/services/people.service';
+import { InitiativesService } from '../../../shared/services/initiatives.service';
+import { Capture, AiExtraction } from '../../../shared/models/capture.model';
+
+function buildCapture(overrides: Partial<Capture> = {}): Capture {
+  return {
+    id: 'cap-1',
+    userId: 'user-1',
+    rawContent: 'Test content',
+    captureType: 'QuickNote',
+    captureSource: null,
+    processingStatus: 'Processed',
+    aiExtraction: null,
+    failureReason: null,
+    linkedPersonIds: [],
+    linkedInitiativeIds: [],
+    spawnedCommitmentIds: [],
+    title: 'Test',
+    capturedAt: '2026-04-21T00:00:00Z',
+    processedAt: '2026-04-21T00:01:00Z',
+    updatedAt: '2026-04-21T00:01:00Z',
+    ...overrides,
+  };
+}
+
+function buildExtraction(overrides: Partial<AiExtraction> = {}): AiExtraction {
+  return {
+    summary: 'Test summary',
+    peopleMentioned: [],
+    commitments: [],
+    decisions: [],
+    risks: [],
+    initiativeTags: [],
+    extractedAt: '2026-04-21T00:01:00Z',
+    detectedCaptureType: null,
+    ...overrides,
+  };
+}
+
+describe('CaptureDetailComponent', () => {
+  let fixture: ComponentFixture<CaptureDetailComponent>;
+  let component: CaptureDetailComponent;
+
+  const mockCapturesService = {
+    get: vi.fn().mockReturnValue(of(buildCapture())),
+    retry: vi.fn(),
+    updateMetadata: vi.fn(),
+    resolvePersonMention: vi.fn(),
+    resolveInitiativeTag: vi.fn(),
+    getTranscript: vi.fn().mockReturnValue(of(null)),
+    updateSpeakers: vi.fn(),
+  };
+
+  const mockPeopleService = { list: vi.fn().mockReturnValue(of([])) };
+  const mockInitiativesService = { list: vi.fn().mockReturnValue(of([])) };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CaptureDetailComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: { get: () => 'cap-1' },
+              queryParamMap: { get: () => null },
+            },
+          },
+        },
+        { provide: CapturesService, useValue: mockCapturesService },
+        { provide: PeopleService, useValue: mockPeopleService },
+        { provide: InitiativesService, useValue: mockInitiativesService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CaptureDetailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('detectedCaptureType returns null when extraction has no detected type', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        aiExtraction: buildExtraction({ detectedCaptureType: null }),
+      }),
+    );
+
+    expect((component as any).detectedCaptureType()).toBeNull();
+  });
+
+  it('detectedCaptureType returns null when no extraction exists', () => {
+    (component as any).capture.set(
+      buildCapture({ processingStatus: 'Raw', aiExtraction: null }),
+    );
+
+    expect((component as any).detectedCaptureType()).toBeNull();
+  });
+
+  it('detectedCaptureType returns the type when extraction has detectedCaptureType', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        captureType: 'Transcript',
+        aiExtraction: buildExtraction({ detectedCaptureType: 'Transcript' }),
+      }),
+    );
+
+    expect((component as any).detectedCaptureType()).toBe('Transcript');
+  });
+
+  it('detectedCaptureType returns MeetingNotes when extraction detected MeetingNotes', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        captureType: 'MeetingNotes',
+        aiExtraction: buildExtraction({ detectedCaptureType: 'MeetingNotes' }),
+      }),
+    );
+
+    expect((component as any).detectedCaptureType()).toBe('MeetingNotes');
+  });
+});

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -70,6 +70,12 @@ import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.compone
           <p-button icon="pi pi-arrow-left" [text]="true" (onClick)="goBack()" />
           <h1 class="text-2xl font-bold flex-1">{{ capture()!.title || 'Untitled Capture' }}</h1>
           <p-tag [value]="formatType(capture()!.captureType)" [severity]="typeSeverity(capture()!.captureType)" />
+          @if (detectedCaptureType(); as detected) {
+            <p-tag
+              [value]="'Detected as: ' + formatType(detected)"
+              [severity]="detected === capture()!.captureType ? 'success' : 'warn'"
+            />
+          }
           @if (capture()!.processingStatus === 'Processing') {
             <p-tag severity="warn">
               <i class="pi pi-spinner pi-spin mr-1"></i> Processing
@@ -355,6 +361,11 @@ export class CaptureDetailComponent implements OnInit {
       }
     });
   }
+
+  readonly detectedCaptureType = computed(() => {
+    const c = this.capture();
+    return c?.aiExtraction?.detectedCaptureType ?? null;
+  });
 
   readonly hasUnresolvedMentions = computed(() => {
     const c = this.capture();

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -67,6 +67,7 @@ export interface AiExtraction {
   risks: string[];
   initiativeTags: InitiativeTag[];
   extractedAt: string;
+  detectedCaptureType: CaptureType | null;
 }
 
 export interface Capture {

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
@@ -355,6 +355,144 @@ public class AutoExtractCaptureHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_DetectedTypeTranscript_ReclassifiesFromQuickNote()
+    {
+        var capture = Capture.Create(_userId, "Alice: Hi\nBob: Hello", CaptureType.QuickNote);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "A brief conversation.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": [],
+          "detected_type": "Transcript"
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(CaptureType.Transcript, result.CaptureType);
+        Assert.Equal(CaptureType.Transcript, result.AiExtraction!.DetectedCaptureType);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DetectedTypeSameAsCurrent_DoesNotReclassify()
+    {
+        var capture = Capture.Create(_userId, "Test meeting notes", CaptureType.MeetingNotes);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "Meeting notes.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": [],
+          "detected_type": "MeetingNotes"
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(CaptureType.MeetingNotes, result.CaptureType);
+        Assert.Equal(CaptureType.MeetingNotes, result.AiExtraction!.DetectedCaptureType);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DetectedTypeNull_DoesNotReclassify()
+    {
+        var capture = Capture.Create(_userId, "Test content", CaptureType.QuickNote);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "A note.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": []
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(CaptureType.QuickNote, result.CaptureType);
+        Assert.Null(result.AiExtraction!.DetectedCaptureType);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DetectedTypeUnrecognized_DoesNotReclassify()
+    {
+        var capture = Capture.Create(_userId, "Test content", CaptureType.QuickNote);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "A note.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": [],
+          "detected_type": "UnknownType"
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(CaptureType.QuickNote, result.CaptureType);
+        Assert.Null(result.AiExtraction!.DetectedCaptureType);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DetectedTypeStored_OnAiExtraction()
+    {
+        var capture = Capture.Create(_userId, "Some quick note", CaptureType.QuickNote);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>())
+            .Returns(capture);
+
+        var aiJson = """
+        {
+          "summary": "A quick note.",
+          "people_mentioned": [],
+          "commitments": [],
+          "decisions": [],
+          "risks": [],
+          "initiative_tags": [],
+          "detected_type": "QuickNote"
+        }
+        """;
+
+        _aiService.CompleteAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AiCompletionResult(aiJson, 100, 200, "test-model", AiProvider.Anthropic));
+
+        var result = await _sut.HandleAsync(capture.Id, CancellationToken.None);
+
+        Assert.Equal(CaptureType.QuickNote, result.AiExtraction!.DetectedCaptureType);
+    }
+
+    [Fact]
     public async Task HandleAsync_SourceOffsetsFromAi_PropagatedToSpawnedCommitment()
     {
         var capture = CreateRawCapture();

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -294,6 +294,21 @@ public class CaptureTests
     }
 
     [Fact]
+    public void Reclassify_FromAudioRecording_Throws()
+    {
+        var capture = Capture.CreateAudio(
+            UserId, "blob-ref", "audio/webm", 10.0, DateTimeOffset.UtcNow);
+        // Transition from Pending -> InProgress -> Transcribed to populate RawContent,
+        // then Raw -> Processing to reach the status required by Reclassify
+        capture.BeginTranscription(DateTimeOffset.UtcNow);
+        capture.AttachTranscript("transcript text", [], DateTimeOffset.UtcNow);
+        capture.BeginProcessing();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            capture.Reclassify(CaptureType.Transcript));
+    }
+
+    [Fact]
     public void Reclassify_FromRawStatus_Throws()
     {
         var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -235,4 +235,92 @@ public class CaptureTests
 
         Assert.Throws<ArgumentException>(() => capture.RecordSpawnedCommitment(Guid.Empty));
     }
+
+    // --- Reclassify tests ---
+
+    [Fact]
+    public void Reclassify_QuickNoteToTranscript_ChangesTypeAndRaisesEvent()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.ClearDomainEvents();
+
+        capture.Reclassify(CaptureType.Transcript);
+
+        Assert.Equal(CaptureType.Transcript, capture.CaptureType);
+        var domainEvent = Assert.Single(capture.DomainEvents);
+        var reclassified = Assert.IsType<CaptureReclassified>(domainEvent);
+        Assert.Equal(CaptureType.QuickNote, reclassified.OldType);
+        Assert.Equal(CaptureType.Transcript, reclassified.NewType);
+    }
+
+    [Fact]
+    public void Reclassify_QuickNoteToMeetingNotes_ChangesTypeAndRaisesEvent()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.ClearDomainEvents();
+
+        capture.Reclassify(CaptureType.MeetingNotes);
+
+        Assert.Equal(CaptureType.MeetingNotes, capture.CaptureType);
+        var domainEvent = Assert.Single(capture.DomainEvents);
+        var reclassified = Assert.IsType<CaptureReclassified>(domainEvent);
+        Assert.Equal(CaptureType.QuickNote, reclassified.OldType);
+        Assert.Equal(CaptureType.MeetingNotes, reclassified.NewType);
+    }
+
+    [Fact]
+    public void Reclassify_SameType_IsNoOp()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.ClearDomainEvents();
+
+        capture.Reclassify(CaptureType.QuickNote);
+
+        Assert.Equal(CaptureType.QuickNote, capture.CaptureType);
+        Assert.Empty(capture.DomainEvents);
+    }
+
+    [Fact]
+    public void Reclassify_ToAudioRecording_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            capture.Reclassify(CaptureType.AudioRecording));
+    }
+
+    [Fact]
+    public void Reclassify_FromRawStatus_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            capture.Reclassify(CaptureType.Transcript));
+    }
+
+    [Fact]
+    public void Reclassify_FromProcessedStatus_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(CreateTestExtraction());
+
+        Assert.Throws<InvalidOperationException>(() =>
+            capture.Reclassify(CaptureType.Transcript));
+    }
+
+    [Fact]
+    public void Reclassify_FromFailedStatus_Throws()
+    {
+        var capture = Capture.Create(UserId, "content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.FailProcessing("error");
+
+        Assert.Throws<InvalidOperationException>(() =>
+            capture.Reclassify(CaptureType.Transcript));
+    }
 }


### PR DESCRIPTION
## Summary

Add content-type classification to the AI extraction pipeline. When a user pastes a meeting transcript into Quick Capture (which defaults to QuickNote), the AI now detects the actual content type and reclassifies the capture automatically. This improves type-based filtering accuracy with zero additional AI calls.

Closes #172

**Spec**: [capture-ai-extraction](openspec/specs/capture-ai-extraction/spec.md), [capture-text](openspec/specs/capture-text/spec.md)

## Changes

- **Domain**: Added `Reclassify(CaptureType)` method on `Capture` aggregate with Processing status guard, AudioRecording rejection, same-type no-op, and `CaptureReclassified` domain event
- **Domain**: Added `DetectedCaptureType` (nullable) property to `AiExtraction` value object
- **Application**: Extended `ExtractionPromptBuilder` with `detected_type` classification instructions (QuickNote, Transcript, MeetingNotes)
- **Application**: Added `detected_type` field to `ExtractionResponseDto` with `[JsonPropertyName("detected_type")]`
- **Application**: Updated `AutoExtractCaptureHandler` to parse detected type, reclassify when conditions are met, and store on `AiExtraction`
- **Application**: Extended `AiExtractionResponse` DTO with `DetectedCaptureType`
- **Infrastructure**: Added string conversion config for `DetectedCaptureType` in JSONB; empty migration (model snapshot update only)
- **Frontend**: Added `detectedCaptureType` to `AiExtraction` interface and capture detail view shows "Detected as: {type}" tag with success/warn severity

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (387 tests: 217 domain + 149 application + 21 integration)
- [x] `ng test --watch=false` passes (53 tests across 14 files)
- [x] Domain tests: Reclassify success (QuickNote->Transcript, QuickNote->MeetingNotes), no-op same type, reject AudioRecording, reject non-Processing status (Raw, Processed, Failed)
- [x] Handler tests: reclassification when detected type differs, no reclassification when same type, null detected_type, unrecognized detected_type, DetectedCaptureType stored on AiExtraction
- [x] Frontend tests: detectedCaptureType computed signal returns correct values for null, present, and absent extraction cases

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI now detects the capture type during extraction and suggests classification as Quick Note, Transcript, or Meeting Notes.
  * Captures automatically reclassify when the AI-detected type differs from the current classification.
  * Capture details display the AI-detected type with a visual indicator showing whether it matches the actual classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->