### PR TITLE
feat: surface unresolved people and spawn commitments on resolution

### DIFF
--- a/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/AutoExtractCaptureHandler.cs
@@ -160,6 +160,7 @@ public sealed class AutoExtractCaptureHandler(
                 {
                     Description = c.Description,
                     Direction = direction,
+                    PersonRawName = c.PersonRawName?.Trim(),
                     PersonId = personId,
                     DueDate = dueDate,
                     Confidence = confidence,

--- a/src/MentalMetal.Application/Captures/AutoExtract/QuickCreateAndResolveHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/QuickCreateAndResolveHandler.cs
@@ -6,9 +6,9 @@ using MentalMetal.Domain.Users;
 
 namespace MentalMetal.Application.Captures.AutoExtract;
 
-public sealed record ResolvePersonMentionRequest(string RawName, Guid PersonId);
+public sealed record QuickCreateAndResolveRequest(string RawName, string PersonName, PersonType PersonType);
 
-public sealed class ResolvePersonMentionHandler(
+public sealed class QuickCreateAndResolveHandler(
     ICaptureRepository captureRepository,
     IPersonRepository personRepository,
     ICommitmentRepository commitmentRepository,
@@ -16,7 +16,7 @@ public sealed class ResolvePersonMentionHandler(
     IUnitOfWork unitOfWork)
 {
     public async Task<CaptureResponse> HandleAsync(
-        Guid captureId, ResolvePersonMentionRequest request, CancellationToken cancellationToken)
+        Guid captureId, QuickCreateAndResolveRequest request, CancellationToken cancellationToken)
     {
         var userId = currentUserService.UserId;
 
@@ -24,44 +24,48 @@ public sealed class ResolvePersonMentionHandler(
             .EnsureOwned(userId, captureId);
 
         if (capture.AiExtraction is null)
-            throw new InvalidOperationException("Capture has no AI extraction to resolve.");
+            throw new InvalidOperationException("Capture has no AI extraction to resolve");
+
+        var trimmedRawName = request.RawName.Trim();
+        var trimmedPersonName = request.PersonName.Trim();
 
         // Validate that rawName matches an existing PeopleMentioned entry
-        var trimmedName = request.RawName.Trim();
         var mentionExists = capture.AiExtraction.PeopleMentioned
-            .Any(p => string.Equals(p.RawName, trimmedName, StringComparison.OrdinalIgnoreCase));
+            .Any(p => string.Equals(p.RawName, trimmedRawName, StringComparison.OrdinalIgnoreCase));
         if (!mentionExists)
             throw new InvalidOperationException(
-                $"No person mention with raw name '{trimmedName}' found in extraction.");
+                $"No person mention with raw name '{trimmedRawName}' found in extraction.");
 
-        var person = await personRepository.GetByIdAsync(request.PersonId, cancellationToken)
-            ?? throw new InvalidOperationException($"Person not found: {request.PersonId}");
+        // Check for duplicate person name
+        if (await personRepository.ExistsByNameAsync(userId, trimmedPersonName, excludeId: null, cancellationToken))
+            throw new DuplicatePersonNameException(trimmedPersonName);
 
-        if (person.UserId != userId)
-            throw new InvalidOperationException($"Person not found: {request.PersonId}");
+        // Create the person
+        var person = Person.Create(userId, trimmedPersonName, request.PersonType);
 
-        // Add the raw name as an alias (idempotent — skip if already this person's name/alias)
-        if (!string.Equals(person.Name, trimmedName, StringComparison.OrdinalIgnoreCase)
-            && !person.Aliases.Any(a => string.Equals(a, trimmedName, StringComparison.OrdinalIgnoreCase)))
+        // Add raw name as alias if different from person name
+        if (!string.Equals(trimmedRawName, trimmedPersonName, StringComparison.OrdinalIgnoreCase))
         {
-            // Ensure alias isn't already used by another person
-            if (await personRepository.AliasExistsForOtherPersonAsync(userId, trimmedName, person.Id, cancellationToken))
-                throw new InvalidOperationException($"Alias '{trimmedName}' is already used by another person.");
+            // Check alias uniqueness across user's people
+            if (await personRepository.AliasExistsForOtherPersonAsync(userId, trimmedRawName, person.Id, cancellationToken))
+                throw new InvalidOperationException($"Alias '{trimmedRawName}' is already used by another person.");
 
-            person.AddAlias(trimmedName);
+            person.AddAlias(trimmedRawName);
         }
+
+        await personRepository.AddAsync(person, cancellationToken);
 
         // Update the extraction with resolved PersonId on people mentions
         var updatedPeople = capture.AiExtraction.PeopleMentioned.Select(p =>
-            string.Equals(p.RawName, trimmedName, StringComparison.OrdinalIgnoreCase)
-                ? p with { PersonId = request.PersonId }
+            string.Equals(p.RawName, trimmedRawName, StringComparison.OrdinalIgnoreCase)
+                ? p with { PersonId = person.Id }
                 : p).ToList();
 
         // Spawn skipped commitments for this person and update extraction commitments
         var updatedCommitments = new List<ExtractedCommitment>();
         foreach (var c in capture.AiExtraction.Commitments)
         {
-            if (string.Equals(c.PersonRawName, trimmedName, StringComparison.OrdinalIgnoreCase)
+            if (string.Equals(c.PersonRawName, trimmedRawName, StringComparison.OrdinalIgnoreCase)
                 && c.SpawnedCommitmentId is null
                 && c.Confidence is CommitmentConfidence.High or CommitmentConfidence.Medium)
             {
@@ -73,7 +77,7 @@ public sealed class ResolvePersonMentionHandler(
                     userId,
                     c.Description,
                     c.Direction,
-                    request.PersonId,
+                    person.Id,
                     dueDateOnly,
                     initiativeId: null,
                     capture.Id,
@@ -86,14 +90,13 @@ public sealed class ResolvePersonMentionHandler(
 
                 updatedCommitments.Add(c with
                 {
-                    PersonId = request.PersonId,
+                    PersonId = person.Id,
                     SpawnedCommitmentId = commitment.Id
                 });
             }
-            else if (string.Equals(c.PersonRawName, trimmedName, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(c.PersonRawName, trimmedRawName, StringComparison.OrdinalIgnoreCase))
             {
-                // Update PersonId on already-spawned or low-confidence commitments
-                updatedCommitments.Add(c with { PersonId = request.PersonId });
+                updatedCommitments.Add(c with { PersonId = person.Id });
             }
             else
             {
@@ -107,14 +110,20 @@ public sealed class ResolvePersonMentionHandler(
             Commitments = updatedCommitments
         };
 
-        // Replace extraction via domain method
         capture.UpdateExtraction(updatedExtraction);
-
-        // Link capture to the person
-        capture.LinkToPerson(request.PersonId);
+        capture.LinkToPerson(person.Id);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
         return CaptureResponse.From(capture);
     }
+}
+
+/// <summary>
+/// Thrown when a person with the same name already exists for the user.
+/// </summary>
+public sealed class DuplicatePersonNameException(string name)
+    : Exception($"A person named '{name}' already exists. Consider linking to the existing person instead.")
+{
+    public string PersonName { get; } = name;
 }

--- a/src/MentalMetal.Application/Captures/AutoExtract/QuickCreateAndResolveHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/QuickCreateAndResolveHandler.cs
@@ -29,12 +29,16 @@ public sealed class QuickCreateAndResolveHandler(
         var trimmedRawName = request.RawName.Trim();
         var trimmedPersonName = request.PersonName.Trim();
 
-        // Validate that rawName matches an existing PeopleMentioned entry
-        var mentionExists = capture.AiExtraction.PeopleMentioned
-            .Any(p => string.Equals(p.RawName, trimmedRawName, StringComparison.OrdinalIgnoreCase));
-        if (!mentionExists)
+        // Validate that rawName matches an existing unresolved PeopleMentioned entry
+        var mention = capture.AiExtraction.PeopleMentioned
+            .FirstOrDefault(p => string.Equals(p.RawName, trimmedRawName, StringComparison.OrdinalIgnoreCase));
+        if (mention is null)
             throw new InvalidOperationException(
                 $"No person mention with raw name '{trimmedRawName}' found in extraction.");
+
+        if (mention.PersonId.HasValue)
+            throw new InvalidOperationException(
+                $"Person mention '{trimmedRawName}' is already resolved.");
 
         // Check for duplicate person name
         if (await personRepository.ExistsByNameAsync(userId, trimmedPersonName, excludeId: null, cancellationToken))
@@ -48,7 +52,7 @@ public sealed class QuickCreateAndResolveHandler(
         {
             // Check alias uniqueness across user's people
             if (await personRepository.AliasExistsForOtherPersonAsync(userId, trimmedRawName, person.Id, cancellationToken))
-                throw new InvalidOperationException($"Alias '{trimmedRawName}' is already used by another person.");
+                throw new AliasConflictException(trimmedRawName);
 
             person.AddAlias(trimmedRawName);
         }
@@ -126,4 +130,13 @@ public sealed class DuplicatePersonNameException(string name)
     : Exception($"A person named '{name}' already exists. Consider linking to the existing person instead.")
 {
     public string PersonName { get; } = name;
+}
+
+/// <summary>
+/// Thrown when the raw name is already used as an alias by another person.
+/// </summary>
+public sealed class AliasConflictException(string alias)
+    : Exception($"Alias '{alias}' is already used by another person.")
+{
+    public string Alias { get; } = alias;
 }

--- a/src/MentalMetal.Application/Captures/AutoExtract/ResolvePersonMentionHandler.cs
+++ b/src/MentalMetal.Application/Captures/AutoExtract/ResolvePersonMentionHandler.cs
@@ -26,13 +26,17 @@ public sealed class ResolvePersonMentionHandler(
         if (capture.AiExtraction is null)
             throw new InvalidOperationException("Capture has no AI extraction to resolve.");
 
-        // Validate that rawName matches an existing PeopleMentioned entry
+        // Validate that rawName matches an existing unresolved PeopleMentioned entry
         var trimmedName = request.RawName.Trim();
-        var mentionExists = capture.AiExtraction.PeopleMentioned
-            .Any(p => string.Equals(p.RawName, trimmedName, StringComparison.OrdinalIgnoreCase));
-        if (!mentionExists)
+        var mention = capture.AiExtraction.PeopleMentioned
+            .FirstOrDefault(p => string.Equals(p.RawName, trimmedName, StringComparison.OrdinalIgnoreCase));
+        if (mention is null)
             throw new InvalidOperationException(
                 $"No person mention with raw name '{trimmedName}' found in extraction.");
+
+        if (mention.PersonId.HasValue)
+            throw new InvalidOperationException(
+                $"Person mention '{trimmedName}' is already resolved.");
 
         var person = await personRepository.GetByIdAsync(request.PersonId, cancellationToken)
             ?? throw new InvalidOperationException($"Person not found: {request.PersonId}");
@@ -46,7 +50,7 @@ public sealed class ResolvePersonMentionHandler(
         {
             // Ensure alias isn't already used by another person
             if (await personRepository.AliasExistsForOtherPersonAsync(userId, trimmedName, person.Id, cancellationToken))
-                throw new InvalidOperationException($"Alias '{trimmedName}' is already used by another person.");
+                throw new AliasConflictException(trimmedName);
 
             person.AddAlias(trimmedName);
         }

--- a/src/MentalMetal.Application/Captures/CaptureDtos.cs
+++ b/src/MentalMetal.Application/Captures/CaptureDtos.cs
@@ -22,7 +22,7 @@ public sealed record AiExtractionResponse(
             extraction.Summary,
             (extraction.PeopleMentioned ?? []).Select(p => new PersonMentionResponse(p.RawName, p.PersonId, p.Context)).ToList(),
             (extraction.Commitments ?? []).Select(c => new ExtractedCommitmentResponse(
-                c.Description, c.Direction, c.PersonId, c.DueDate, c.Confidence, c.SpawnedCommitmentId)).ToList(),
+                c.Description, c.Direction, c.PersonRawName, c.PersonId, c.DueDate, c.Confidence, c.SpawnedCommitmentId)).ToList(),
             (extraction.Decisions ?? []).ToList(),
             (extraction.Risks ?? []).ToList(),
             (extraction.InitiativeTags ?? []).Select(t => new InitiativeTagResponse(t.RawName, t.InitiativeId, t.Context)).ToList(),
@@ -32,7 +32,7 @@ public sealed record AiExtractionResponse(
 
 public sealed record PersonMentionResponse(string RawName, Guid? PersonId, string? Context);
 public sealed record ExtractedCommitmentResponse(
-    string Description, CommitmentDirection Direction, Guid? PersonId,
+    string Description, CommitmentDirection Direction, string? PersonRawName, Guid? PersonId,
     DateTimeOffset? DueDate, CommitmentConfidence Confidence, Guid? SpawnedCommitmentId);
 public sealed record InitiativeTagResponse(string RawName, Guid? InitiativeId, string? Context);
 

--- a/src/MentalMetal.Domain/Captures/AiExtraction.cs
+++ b/src/MentalMetal.Domain/Captures/AiExtraction.cs
@@ -28,6 +28,7 @@ public sealed record ExtractedCommitment
 {
     public required string Description { get; init; }
     public required CommitmentDirection Direction { get; init; }
+    public string? PersonRawName { get; init; }
     public Guid? PersonId { get; init; }
     public DateTimeOffset? DueDate { get; init; }
     public required CommitmentConfidence Confidence { get; init; }

--- a/src/MentalMetal.Infrastructure/DependencyInjection.cs
+++ b/src/MentalMetal.Infrastructure/DependencyInjection.cs
@@ -176,6 +176,7 @@ public static class DependencyInjection
         services.AddScoped<NameResolutionService>();
         services.AddScoped<InitiativeTaggingService>();
         services.AddScoped<ResolvePersonMentionHandler>();
+        services.AddScoped<QuickCreateAndResolveHandler>();
         services.AddScoped<ResolveInitiativeTagHandler>();
 
         // Capture import handlers and parsers

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.spec.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { CaptureDetailComponent } from './capture-detail.component';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { PeopleService } from '../../../shared/services/people.service';
@@ -54,6 +54,7 @@ describe('CaptureDetailComponent', () => {
     updateMetadata: vi.fn(),
     resolvePersonMention: vi.fn(),
     resolveInitiativeTag: vi.fn(),
+    quickCreateAndResolve: vi.fn(),
     getTranscript: vi.fn().mockReturnValue(of(null)),
     updateSpeakers: vi.fn(),
   };
@@ -126,5 +127,137 @@ describe('CaptureDetailComponent', () => {
     );
 
     expect((component as any).detectedCaptureType()).toBe('MeetingNotes');
+  });
+
+  it('unresolvedPeople returns empty array when no extraction', () => {
+    (component as any).capture.set(
+      buildCapture({ processingStatus: 'Raw', aiExtraction: null }),
+    );
+
+    expect((component as any).unresolvedPeople()).toEqual([]);
+  });
+
+  it('unresolvedPeople returns unresolved mentions only', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        aiExtraction: buildExtraction({
+          peopleMentioned: [
+            { rawName: 'Sarah', personId: null, context: 'discussed project' },
+            { rawName: 'Alice', personId: 'person-1', context: null },
+            { rawName: 'Mike', personId: null, context: null },
+          ],
+        }),
+      }),
+    );
+
+    const unresolved = (component as any).unresolvedPeople();
+    expect(unresolved).toHaveLength(2);
+    expect(unresolved[0].rawName).toBe('Sarah');
+    expect(unresolved[1].rawName).toBe('Mike');
+  });
+
+  it('unresolvedPeople returns empty when all resolved', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        aiExtraction: buildExtraction({
+          peopleMentioned: [
+            { rawName: 'Alice', personId: 'person-1', context: null },
+          ],
+        }),
+      }),
+    );
+
+    expect((component as any).unresolvedPeople()).toHaveLength(0);
+  });
+
+  it('hasUnresolvedMentions is true when there are unresolved people', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        aiExtraction: buildExtraction({
+          peopleMentioned: [
+            { rawName: 'Sarah', personId: null, context: null },
+          ],
+        }),
+      }),
+    );
+
+    expect((component as any).hasUnresolvedMentions()).toBe(true);
+  });
+
+  it('hasUnresolvedMentions is false when all resolved', () => {
+    (component as any).capture.set(
+      buildCapture({
+        processingStatus: 'Processed',
+        aiExtraction: buildExtraction({
+          peopleMentioned: [
+            { rawName: 'Alice', personId: 'person-1', context: null },
+          ],
+        }),
+      }),
+    );
+
+    expect((component as any).hasUnresolvedMentions()).toBe(false);
+  });
+
+  it('openQuickCreate pre-fills name and sets default type', () => {
+    (component as any).capture.set(buildCapture());
+    (component as any).openQuickCreate('Sarah');
+
+    expect((component as any).quickCreateRawName()).toBe('Sarah');
+    expect((component as any).quickCreateName()).toBe('Sarah');
+    expect((component as any).quickCreateType()).toBe('Stakeholder');
+    expect((component as any).quickCreateVisible()).toBe(true);
+  });
+
+  it('submitQuickCreate calls service and updates capture on success', () => {
+    const updatedCapture = buildCapture({
+      aiExtraction: buildExtraction({
+        peopleMentioned: [{ rawName: 'Sarah', personId: 'new-person-id', context: null }],
+      }),
+    });
+    mockCapturesService.quickCreateAndResolve.mockReturnValue(of(updatedCapture));
+
+    (component as any).capture.set(
+      buildCapture({
+        aiExtraction: buildExtraction({
+          peopleMentioned: [{ rawName: 'Sarah', personId: null, context: null }],
+        }),
+      }),
+    );
+    (component as any).quickCreateRawName.set('Sarah');
+    (component as any).quickCreateName.set('Sarah Chen');
+    (component as any).quickCreateType.set('Stakeholder');
+
+    (component as any).submitQuickCreate();
+
+    expect(mockCapturesService.quickCreateAndResolve).toHaveBeenCalledWith(
+      'cap-1', 'Sarah', 'Sarah Chen', 'Stakeholder',
+    );
+  });
+
+  it('submitQuickCreate handles 409 conflict with warning message', () => {
+    mockCapturesService.quickCreateAndResolve.mockReturnValue(
+      throwError(() => ({ status: 409, error: { error: 'Duplicate name' } })),
+    );
+
+    (component as any).capture.set(
+      buildCapture({
+        aiExtraction: buildExtraction({
+          peopleMentioned: [{ rawName: 'Sarah', personId: null, context: null }],
+        }),
+      }),
+    );
+    // Open the dialog first so quickCreateVisible is true
+    (component as any).openQuickCreate('Sarah');
+    (component as any).quickCreateName.set('Sarah Chen');
+
+    (component as any).submitQuickCreate();
+
+    expect((component as any).quickCreateSubmitting()).toBe(false);
+    // Dialog should remain open on conflict
+    expect((component as any).quickCreateVisible()).toBe(true);
   });
 });

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -8,12 +8,13 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { PanelModule } from 'primeng/panel';
 import { SelectModule } from 'primeng/select';
+import { DialogModule } from 'primeng/dialog';
 import { MessageService } from 'primeng/api';
 import { CapturesService } from '../../../shared/services/captures.service';
 import { PeopleService } from '../../../shared/services/people.service';
 import { InitiativesService } from '../../../shared/services/initiatives.service';
 import { Capture, CaptureTranscript, CaptureType, ProcessingStatus } from '../../../shared/models/capture.model';
-import { Person } from '../../../shared/models/person.model';
+import { Person, PersonType } from '../../../shared/models/person.model';
 import { Initiative } from '../../../shared/models/initiative.model';
 import { TranscriptViewerComponent } from '../transcript-viewer/transcript-viewer.component';
 import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.component';
@@ -31,6 +32,7 @@ import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.compone
     ToastModule,
     PanelModule,
     SelectModule,
+    DialogModule,
     TranscriptViewerComponent,
     SpeakerPickerComponent,
   ],
@@ -54,6 +56,12 @@ import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.compone
     .error-title { color: var(--p-red-700); }
     .error-detail { color: var(--p-red-600); }
     .risk-icon { color: var(--p-yellow-500); }
+    .unresolved-banner {
+      border-color: var(--p-yellow-200);
+      background-color: var(--p-yellow-50);
+    }
+    .unresolved-icon { color: var(--p-yellow-500); }
+    .unresolved-title { color: var(--p-yellow-700); }
   `],
   providers: [MessageService],
   template: `
@@ -115,6 +123,82 @@ import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.compone
             />
           </div>
         }
+
+        <!-- Unresolved People Banner -->
+        @if (unresolvedPeople().length > 0) {
+          <div class="p-4 rounded-md border unresolved-banner flex flex-col gap-3">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-users unresolved-icon"></i>
+              <span class="font-medium unresolved-title">{{ unresolvedPeople().length }} unresolved {{ unresolvedPeople().length === 1 ? 'person' : 'people' }}</span>
+            </div>
+            @for (p of unresolvedPeople(); track p.rawName) {
+              <div class="flex items-center gap-2 text-sm">
+                <span class="font-medium">{{ p.rawName }}</span>
+                @if (p.context) {
+                  <span class="text-muted-color">— {{ p.context }}</span>
+                }
+                @if (resolvingPersonName() === p.rawName) {
+                  <p-select
+                    [options]="people()"
+                    optionLabel="name"
+                    optionValue="id"
+                    placeholder="Select person..."
+                    [filter]="true"
+                    filterBy="name"
+                    (onChange)="onPersonSelected(p.rawName, $event.value)"
+                    appendTo="body"
+                    class="ml-2"
+                    [style]="{ 'min-width': '200px' }"
+                  />
+                  <p-button icon="pi pi-times" [text]="true" size="small" (onClick)="resolvingPersonName.set(null)" />
+                } @else {
+                  <p-button label="Link to Existing" icon="pi pi-link" size="small" [text]="true" (onClick)="startResolvePerson(p.rawName)" />
+                  <p-button label="Quick Create" icon="pi pi-plus" size="small" [text]="true" (onClick)="openQuickCreate(p.rawName)" />
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Quick Create Person Dialog -->
+        <p-dialog
+          header="Quick Create Person"
+          [visible]="quickCreateVisible()"
+          (visibleChange)="quickCreateVisible.set($event)"
+          [modal]="true"
+          [style]="{ width: '400px' }"
+        >
+          <div class="flex flex-col gap-4 pt-2">
+            <div class="flex flex-col gap-2">
+              <label for="qc-name" class="text-sm font-medium">Name</label>
+              <input pInputText id="qc-name" [ngModel]="quickCreateName()" (ngModelChange)="quickCreateName.set($event)" class="w-full" />
+            </div>
+            <div class="flex flex-col gap-2">
+              <label for="qc-type" class="text-sm font-medium">Type</label>
+              <p-select
+                id="qc-type"
+                [options]="personTypeOptions"
+                optionLabel="label"
+                optionValue="value"
+                [ngModel]="quickCreateType()"
+                (ngModelChange)="quickCreateType.set($event)"
+                class="w-full"
+              />
+            </div>
+          </div>
+          <ng-template #footer>
+            <div class="flex justify-end gap-2">
+              <p-button label="Cancel" [text]="true" (onClick)="quickCreateVisible.set(false)" />
+              <p-button
+                label="Create & Resolve"
+                icon="pi pi-check"
+                (onClick)="submitQuickCreate()"
+                [loading]="quickCreateSubmitting()"
+                [disabled]="!quickCreateName().trim()"
+              />
+            </div>
+          </ng-template>
+        </p-dialog>
 
         <!-- Raw Content -->
         <section class="flex flex-col gap-4">
@@ -211,23 +295,6 @@ import { SpeakerPickerComponent } from '../speaker-picker/speaker-picker.compone
                       <p-tag value="Resolved" severity="success" />
                     } @else {
                       <p-tag value="Unresolved" severity="warn" />
-                      @if (resolvingPersonName() === p.rawName) {
-                        <p-select
-                          [options]="people()"
-                          optionLabel="name"
-                          optionValue="id"
-                          placeholder="Select person..."
-                          [filter]="true"
-                          filterBy="name"
-                          (onChange)="onPersonSelected(p.rawName, $event.value)"
-                          appendTo="body"
-                          class="ml-2"
-                          [style]="{ 'min-width': '200px' }"
-                        />
-                        <p-button icon="pi pi-times" [text]="true" size="small" (onClick)="resolvingPersonName.set(null)" />
-                      } @else {
-                        <p-button label="Resolve" icon="pi pi-link" size="small" [text]="true" (onClick)="startResolvePerson(p.rawName)" />
-                      }
                     }
                   </div>
                 }
@@ -353,6 +420,21 @@ export class CaptureDetailComponent implements OnInit {
   readonly resolvingPersonName = signal<string | null>(null);
   readonly resolvingInitiativeName = signal<string | null>(null);
 
+  // Quick Create dialog state
+  readonly quickCreateVisible = signal(false);
+  readonly quickCreateRawName = signal('');
+  readonly quickCreateName = signal('');
+  readonly quickCreateType = signal<PersonType>('Stakeholder');
+  readonly quickCreateSubmitting = signal(false);
+
+  readonly personTypeOptions = [
+    { label: 'Direct Report', value: 'DirectReport' as PersonType },
+    { label: 'Stakeholder', value: 'Stakeholder' as PersonType },
+    { label: 'Peer', value: 'Peer' as PersonType },
+    { label: 'External', value: 'External' as PersonType },
+    { label: 'Candidate', value: 'Candidate' as PersonType },
+  ];
+
   constructor() {
     effect(() => {
       const el = this.highlightMark()?.nativeElement;
@@ -367,9 +449,14 @@ export class CaptureDetailComponent implements OnInit {
     return c?.aiExtraction?.detectedCaptureType ?? null;
   });
 
-  readonly hasUnresolvedMentions = computed(() => {
+  readonly unresolvedPeople = computed(() => {
     const c = this.capture();
-    return c?.aiExtraction?.peopleMentioned.some(p => !p.personId) ?? false;
+    if (!c?.aiExtraction) return [];
+    return c.aiExtraction.peopleMentioned.filter(p => !p.personId);
+  });
+
+  readonly hasUnresolvedMentions = computed(() => {
+    return this.unresolvedPeople().length > 0;
   });
 
   readonly hasUnlinkedTags = computed(() => {
@@ -495,6 +582,43 @@ export class CaptureDetailComponent implements OnInit {
       },
       error: () => {
         this.messageService.add({ severity: 'error', summary: 'Failed to resolve person' });
+      },
+    });
+  }
+
+  protected openQuickCreate(rawName: string): void {
+    this.quickCreateRawName.set(rawName);
+    this.quickCreateName.set(rawName);
+    this.quickCreateType.set('Stakeholder');
+    this.quickCreateVisible.set(true);
+  }
+
+  protected submitQuickCreate(): void {
+    const c = this.capture();
+    const rawName = this.quickCreateRawName();
+    const name = this.quickCreateName().trim();
+    if (!c || !rawName || !name) return;
+
+    this.quickCreateSubmitting.set(true);
+    this.capturesService.quickCreateAndResolve(c.id, rawName, name, this.quickCreateType()).subscribe({
+      next: (updated) => {
+        this.capture.set(updated);
+        this.quickCreateSubmitting.set(false);
+        this.quickCreateVisible.set(false);
+        this.messageService.add({ severity: 'success', summary: 'Person created and resolved' });
+      },
+      error: (err) => {
+        this.quickCreateSubmitting.set(false);
+        const detail = err?.error?.error ?? 'Unknown error';
+        if (err.status === 409) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Duplicate name',
+            detail: 'A person with this name already exists. Try linking to the existing person instead.',
+          });
+        } else {
+          this.messageService.add({ severity: 'error', summary: 'Failed to create person', detail });
+        }
       },
     });
   }

--- a/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/pages/captures/capture-detail/capture-detail.component.ts
@@ -613,8 +613,8 @@ export class CaptureDetailComponent implements OnInit {
         if (err.status === 409) {
           this.messageService.add({
             severity: 'warn',
-            summary: 'Duplicate name',
-            detail: 'A person with this name already exists. Try linking to the existing person instead.',
+            summary: 'Conflict',
+            detail,
           });
         } else {
           this.messageService.add({ severity: 'error', summary: 'Failed to create person', detail });

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/models/capture.model.ts
@@ -47,6 +47,7 @@ export interface PersonMention {
 export interface ExtractedCommitment {
   description: string;
   direction: CommitmentDirection;
+  personRawName: string | null;
   personId: string | null;
   dueDate: string | null;
   confidence: CommitmentConfidence;

--- a/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
+++ b/src/MentalMetal.Web/ClientApp/src/app/shared/services/captures.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateCaptureMetadataRequest,
   UpdateCaptureSpeakersRequest,
 } from '../models/capture.model';
+import { PersonType } from '../models/person.model';
 
 @Injectable({ providedIn: 'root' })
 export class CapturesService {
@@ -85,5 +86,13 @@ export class CapturesService {
 
   resolveInitiativeTag(id: string, rawName: string, initiativeId: string): Observable<Capture> {
     return this.http.post<Capture>(`${this.baseUrl}/${id}/resolve-initiative-tag`, { rawName, initiativeId });
+  }
+
+  quickCreateAndResolve(id: string, rawName: string, personName: string, personType: PersonType): Observable<Capture> {
+    return this.http.post<Capture>(`${this.baseUrl}/${id}/resolve-person-mention/quick-create`, {
+      rawName,
+      personName,
+      personType,
+    });
   }
 }

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -954,7 +954,7 @@ app.MapPost("/api/captures/{id:guid}/resolve-person-mention", async (
     {
         return Results.NotFound();
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("Alias") && ex.Message.Contains("already used"))
+    catch (AliasConflictException ex)
     {
         return Results.Conflict(new { error = ex.Message });
     }
@@ -987,13 +987,9 @@ app.MapPost("/api/captures/{id:guid}/resolve-person-mention/quick-create", async
     {
         return Results.Conflict(new { error = ex.Message });
     }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("Alias") && ex.Message.Contains("already used"))
+    catch (AliasConflictException ex)
     {
         return Results.Conflict(new { error = ex.Message });
-    }
-    catch (InvalidOperationException ex) when (ex.Message.Contains("no AI extraction"))
-    {
-        return Results.BadRequest(new { error = ex.Message });
     }
     catch (InvalidOperationException ex)
     {

--- a/src/MentalMetal.Web/Program.cs
+++ b/src/MentalMetal.Web/Program.cs
@@ -954,6 +954,47 @@ app.MapPost("/api/captures/{id:guid}/resolve-person-mention", async (
     {
         return Results.NotFound();
     }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Alias") && ex.Message.Contains("already used"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/captures/{id:guid}/resolve-person-mention/quick-create", async (
+    Guid id,
+    QuickCreateAndResolveRequest request,
+    QuickCreateAndResolveHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var response = await handler.HandleAsync(id, request, cancellationToken);
+        return Results.Ok(response);
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+    {
+        return Results.NotFound();
+    }
+    catch (DuplicatePersonNameException ex)
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Alias") && ex.Message.Contains("already used"))
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("no AI extraction"))
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
     catch (InvalidOperationException ex)
     {
         return Results.BadRequest(new { error = ex.Message });

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/AutoExtractCaptureHandlerTests.cs
@@ -292,6 +292,11 @@ public class AutoExtractCaptureHandlerTests
 
         // Person is unresolved — cannot spawn commitment (PersonId is required)
         await _commitmentRepo.DidNotReceive().AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+
+        // PersonRawName should be stored for later resolution
+        Assert.Equal("Unknown Person", result.AiExtraction!.Commitments[0].PersonRawName);
+        Assert.Null(result.AiExtraction.Commitments[0].PersonId);
+        Assert.Null(result.AiExtraction.Commitments[0].SpawnedCommitmentId);
     }
 
     [Fact]

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/QuickCreateAndResolveHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/QuickCreateAndResolveHandlerTests.cs
@@ -139,4 +139,20 @@ public class QuickCreateAndResolveHandlerTests
             () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
         Assert.Contains("found in extraction", ex.Message);
     }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyResolvedMention_Throws()
+    {
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Alice", PersonId = Guid.NewGuid(), Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+
+        var request = new QuickCreateAndResolveRequest("Alice", "Alice Smith", PersonType.Peer);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
+        Assert.Contains("already resolved", ex.Message);
+    }
 }

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/QuickCreateAndResolveHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/QuickCreateAndResolveHandlerTests.cs
@@ -1,0 +1,142 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Application.Captures.AutoExtract;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.People;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Captures.AutoExtract;
+
+public class QuickCreateAndResolveHandlerTests
+{
+    private readonly ICaptureRepository _captureRepo = Substitute.For<ICaptureRepository>();
+    private readonly IPersonRepository _personRepo = Substitute.For<IPersonRepository>();
+    private readonly ICommitmentRepository _commitmentRepo = Substitute.For<ICommitmentRepository>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly QuickCreateAndResolveHandler _sut;
+
+    public QuickCreateAndResolveHandlerTests()
+    {
+        _currentUser.UserId.Returns(_userId);
+        _sut = new QuickCreateAndResolveHandler(
+            _captureRepo, _personRepo, _commitmentRepo, _currentUser, _unitOfWork);
+    }
+
+    private Capture CreateProcessedCaptureWithExtraction(
+        IReadOnlyList<PersonMention> people,
+        IReadOnlyList<ExtractedCommitment> commitments)
+    {
+        var capture = Capture.Create(_userId, "Test content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(new AiExtraction
+        {
+            Summary = "Test",
+            PeopleMentioned = people,
+            Commitments = commitments,
+            Decisions = [],
+            Risks = [],
+            InitiativeTags = [],
+            ExtractedAt = DateTimeOffset.UtcNow
+        });
+        return capture;
+    }
+
+    [Fact]
+    public async Task HandleAsync_CreatesPersonAndSpawnsCommitments()
+    {
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Sarah", Context = "discussed project" }],
+            [new ExtractedCommitment
+            {
+                Description = "Send the API spec",
+                Direction = CommitmentDirection.TheirsToMe,
+                PersonRawName = "Sarah",
+                PersonId = null,
+                Confidence = CommitmentConfidence.High,
+                SpawnedCommitmentId = null
+            }]);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.ExistsByNameAsync(_userId, "Sarah Chen", null, Arg.Any<CancellationToken>()).Returns(false);
+        _personRepo.AliasExistsForOtherPersonAsync(_userId, "Sarah", Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var request = new QuickCreateAndResolveRequest("Sarah", "Sarah Chen", PersonType.Stakeholder);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _personRepo.Received(1).AddAsync(Arg.Is<Person>(p => p.Name == "Sarah Chen" && p.Type == PersonType.Stakeholder), Arg.Any<CancellationToken>());
+        await _commitmentRepo.Received(1).AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.NotEmpty(result.SpawnedCommitmentIds);
+        Assert.NotNull(result.AiExtraction!.Commitments[0].SpawnedCommitmentId);
+        Assert.NotNull(result.AiExtraction.PeopleMentioned[0].PersonId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DuplicatePersonName_ThrowsDuplicatePersonNameException()
+    {
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Alice", Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.ExistsByNameAsync(_userId, "Alice Smith", null, Arg.Any<CancellationToken>()).Returns(true);
+
+        var request = new QuickCreateAndResolveRequest("Alice", "Alice Smith", PersonType.Peer);
+
+        await Assert.ThrowsAsync<DuplicatePersonNameException>(
+            () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_SameNameAsRawName_SkipsAlias()
+    {
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Sarah Chen", Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.ExistsByNameAsync(_userId, "Sarah Chen", null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var request = new QuickCreateAndResolveRequest("Sarah Chen", "Sarah Chen", PersonType.Stakeholder);
+        await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        // Person should be added but alias should NOT be checked/added (name matches raw name)
+        await _personRepo.Received(1).AddAsync(
+            Arg.Is<Person>(p => p.Aliases.Count == 0),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoExtraction_Throws()
+    {
+        var capture = Capture.Create(_userId, "Test", CaptureType.QuickNote);
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+
+        var request = new QuickCreateAndResolveRequest("Sarah", "Sarah Chen", PersonType.Stakeholder);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
+        Assert.Contains("no AI extraction", ex.Message);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UnknownRawName_Throws()
+    {
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Alice", Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.ExistsByNameAsync(_userId, "Bob", null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var request = new QuickCreateAndResolveRequest("Bob", "Bob", PersonType.Peer);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
+        Assert.Contains("found in extraction", ex.Message);
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/ResolvePersonMentionHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/ResolvePersonMentionHandlerTests.cs
@@ -1,0 +1,176 @@
+using MentalMetal.Application.Captures;
+using MentalMetal.Application.Captures.AutoExtract;
+using MentalMetal.Application.Common;
+using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
+using MentalMetal.Domain.People;
+using MentalMetal.Domain.Users;
+using NSubstitute;
+
+namespace MentalMetal.Application.Tests.Captures.AutoExtract;
+
+public class ResolvePersonMentionHandlerTests
+{
+    private readonly ICaptureRepository _captureRepo = Substitute.For<ICaptureRepository>();
+    private readonly IPersonRepository _personRepo = Substitute.For<IPersonRepository>();
+    private readonly ICommitmentRepository _commitmentRepo = Substitute.For<ICommitmentRepository>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly ResolvePersonMentionHandler _sut;
+
+    public ResolvePersonMentionHandlerTests()
+    {
+        _currentUser.UserId.Returns(_userId);
+        _sut = new ResolvePersonMentionHandler(
+            _captureRepo, _personRepo, _commitmentRepo, _currentUser, _unitOfWork);
+    }
+
+    private Capture CreateProcessedCaptureWithExtraction(
+        IReadOnlyList<PersonMention> people,
+        IReadOnlyList<ExtractedCommitment> commitments)
+    {
+        var capture = Capture.Create(_userId, "Test content", CaptureType.QuickNote);
+        capture.BeginProcessing();
+        capture.CompleteProcessing(new AiExtraction
+        {
+            Summary = "Test",
+            PeopleMentioned = people,
+            Commitments = commitments,
+            Decisions = [],
+            Risks = [],
+            InitiativeTags = [],
+            ExtractedAt = DateTimeOffset.UtcNow
+        });
+        return capture;
+    }
+
+    [Fact]
+    public async Task HandleAsync_SpawnsSkippedHighConfidenceCommitments()
+    {
+        var person = Person.Create(_userId, "Sarah Chen", PersonType.Stakeholder);
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Sarah", Context = "mentioned" }],
+            [new ExtractedCommitment
+            {
+                Description = "Send the report",
+                Direction = CommitmentDirection.MineToThem,
+                PersonRawName = "Sarah",
+                PersonId = null,
+                Confidence = CommitmentConfidence.High,
+                SpawnedCommitmentId = null
+            }]);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Sarah", person.Id);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _commitmentRepo.Received(1).AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.NotEmpty(result.SpawnedCommitmentIds);
+        Assert.NotNull(result.AiExtraction!.Commitments[0].SpawnedCommitmentId);
+        Assert.Equal(person.Id, result.AiExtraction.Commitments[0].PersonId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DoesNotSpawnLowConfidenceCommitments()
+    {
+        var person = Person.Create(_userId, "Mike Jones", PersonType.Peer);
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Mike", Context = null }],
+            [new ExtractedCommitment
+            {
+                Description = "Maybe look into this",
+                Direction = CommitmentDirection.TheirsToMe,
+                PersonRawName = "Mike",
+                PersonId = null,
+                Confidence = CommitmentConfidence.Low,
+                SpawnedCommitmentId = null
+            }]);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Mike", person.Id);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _commitmentRepo.DidNotReceive().AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.Empty(result.SpawnedCommitmentIds);
+        Assert.Null(result.AiExtraction!.Commitments[0].SpawnedCommitmentId);
+        // PersonId should still be updated
+        Assert.Equal(person.Id, result.AiExtraction.Commitments[0].PersonId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DoesNotDuplicateAlreadySpawnedCommitments()
+    {
+        var person = Person.Create(_userId, "Alice", PersonType.DirectReport);
+        var existingCommitmentId = Guid.NewGuid();
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Alice", Context = null }],
+            [new ExtractedCommitment
+            {
+                Description = "Already spawned commitment",
+                Direction = CommitmentDirection.MineToThem,
+                PersonRawName = "Alice",
+                PersonId = null,
+                Confidence = CommitmentConfidence.High,
+                SpawnedCommitmentId = existingCommitmentId
+            }]);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Alice", person.Id);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _commitmentRepo.DidNotReceive().AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.Equal(existingCommitmentId, result.AiExtraction!.Commitments[0].SpawnedCommitmentId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ResolvedWithNoCommitments_NoSpawning()
+    {
+        var person = Person.Create(_userId, "Dave", PersonType.Peer);
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Dave", Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Dave", person.Id);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _commitmentRepo.DidNotReceive().AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.Equal(person.Id, result.AiExtraction!.PeopleMentioned[0].PersonId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SpawnsMediumConfidenceCommitments()
+    {
+        var person = Person.Create(_userId, "Eve", PersonType.Stakeholder);
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Eve", Context = null }],
+            [new ExtractedCommitment
+            {
+                Description = "Follow up on proposal",
+                Direction = CommitmentDirection.TheirsToMe,
+                PersonRawName = "Eve",
+                PersonId = null,
+                Confidence = CommitmentConfidence.Medium,
+                SpawnedCommitmentId = null
+            }]);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Eve", person.Id);
+        var result = await _sut.HandleAsync(capture.Id, request, CancellationToken.None);
+
+        await _commitmentRepo.Received(1).AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
+        Assert.NotEmpty(result.SpawnedCommitmentIds);
+    }
+}

--- a/tests/MentalMetal.Application.Tests/Captures/AutoExtract/ResolvePersonMentionHandlerTests.cs
+++ b/tests/MentalMetal.Application.Tests/Captures/AutoExtract/ResolvePersonMentionHandlerTests.cs
@@ -173,4 +173,22 @@ public class ResolvePersonMentionHandlerTests
         await _commitmentRepo.Received(1).AddAsync(Arg.Any<Commitment>(), Arg.Any<CancellationToken>());
         Assert.NotEmpty(result.SpawnedCommitmentIds);
     }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyResolvedMention_Throws()
+    {
+        var person = Person.Create(_userId, "Alice", PersonType.DirectReport);
+        var capture = CreateProcessedCaptureWithExtraction(
+            [new PersonMention { RawName = "Alice", PersonId = Guid.NewGuid(), Context = null }],
+            []);
+
+        _captureRepo.GetByIdAsync(capture.Id, Arg.Any<CancellationToken>()).Returns(capture);
+        _personRepo.GetByIdAsync(person.Id, Arg.Any<CancellationToken>()).Returns(person);
+
+        var request = new ResolvePersonMentionRequest("Alice", person.Id);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.HandleAsync(capture.Id, request, CancellationToken.None));
+        Assert.Contains("already resolved", ex.Message);
+    }
 }

--- a/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
+++ b/tests/MentalMetal.Domain.Tests/Captures/CaptureTests.cs
@@ -1,4 +1,5 @@
 using MentalMetal.Domain.Captures;
+using MentalMetal.Domain.Commitments;
 
 namespace MentalMetal.Domain.Tests.Captures;
 
@@ -337,5 +338,35 @@ public class CaptureTests
 
         Assert.Throws<InvalidOperationException>(() =>
             capture.Reclassify(CaptureType.Transcript));
+    }
+
+    [Fact]
+    public void ExtractedCommitment_StoresPersonRawName()
+    {
+        var commitment = new ExtractedCommitment
+        {
+            Description = "Send report",
+            Direction = CommitmentDirection.MineToThem,
+            PersonRawName = "Sarah",
+            PersonId = null,
+            Confidence = CommitmentConfidence.High
+        };
+
+        Assert.Equal("Sarah", commitment.PersonRawName);
+    }
+
+    [Fact]
+    public void ExtractedCommitment_PersonRawName_NullWhenNoPerson()
+    {
+        var commitment = new ExtractedCommitment
+        {
+            Description = "General task",
+            Direction = CommitmentDirection.MineToThem,
+            PersonRawName = null,
+            PersonId = null,
+            Confidence = CommitmentConfidence.Medium
+        };
+
+        Assert.Null(commitment.PersonRawName);
     }
 }


### PR DESCRIPTION
## Summary

When AI extraction finds people not yet in the system, their commitments are silently dropped. This PR surfaces unresolved person mentions on the capture detail view and lets users quick-create a new person or link to an existing one, then automatically spawns the skipped commitments.

**Spec**: [capture-ai-extraction](openspec/specs/capture-ai-extraction/spec.md), [unresolved-people-review](openspec/specs/unresolved-people-review/spec.md)

Closes #173

## Changes

- **Domain**: Add `PersonRawName` to `ExtractedCommitment` for correlating unresolved names with their commitments
- **Application**: Extend `ResolvePersonMentionHandler` to spawn High/Medium confidence commitments when a person is resolved post-extraction
- **Application**: Add `QuickCreateAndResolveHandler` — creates a Person, adds alias, resolves the mention, and spawns commitments in one atomic operation
- **Application**: Add `DuplicatePersonNameException` for 409 conflict handling
- **API**: Add `POST /api/captures/{id}/resolve-person-mention/quick-create` endpoint; add alias-conflict 409 response to existing resolve endpoint
- **Frontend**: Add unresolved people banner on capture detail with "Link to Existing" and "Quick Create" action buttons
- **Frontend**: Add quick-create person dialog (pre-filled name, person type dropdown, defaults to Stakeholder)
- **Frontend**: Add `PersonRawName` to `ExtractedCommitment` model and DTO
- **No migration needed** — `AiExtraction` is stored as a JSON column; `PersonRawName` is an additive field

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (400 tests: 220 domain + 159 application + 21 integration)
- [x] `ng test --watch=false` passes (61 tests)
- [x] New tests for `ResolvePersonMentionHandler`: spawns High/Medium commitments, skips Low, skips already-spawned, handles no-commitments case
- [x] New tests for `QuickCreateAndResolveHandler`: happy path, duplicate name conflict, same-name-as-raw skips alias, no extraction, unknown raw name
- [x] New frontend tests: unresolved people computed signals, quick-create dialog pre-fill, submit success, 409 conflict handling
- [x] Existing `AutoExtractCaptureHandler` test updated to verify `PersonRawName` stored on unresolved commitments

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)