### PR TITLE
fix: update archived spec scenario to match actual fields

### DIFF
--- a/openspec/changes/archive/2026-04-21-auto-detect-capture-type/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/archive/2026-04-21-auto-detect-capture-type/specs/capture-ai-extraction/spec.md
@@ -15,7 +15,7 @@ The `AutoExtractCaptureHandler` SHALL orchestrate the extraction pipeline: (1) l
 #### Scenario: Successful extraction from a transcript
 
 - **WHEN** the processing pipeline runs on a Transcript capture containing a multi-topic meeting transcript
-- **THEN** the AI extracts a summary, commitments, delegations, decisions, risks, observations, and suggested person/initiative links
+- **THEN** the AI extracts a summary, commitments, decisions, risks, initiative tags, and suggested person/initiative links
 - **AND** each extracted commitment includes `source_start_offset` and `source_end_offset`
 - **AND** the AI returns `detected_type` of "Transcript"
 
@@ -69,9 +69,10 @@ The system SHALL define an `AiExtraction` value object embedded on the Capture a
 
 #### Scenario: AiExtraction with all fields populated
 
-- **WHEN** a transcript yields commitments, decisions, risks, and initiative tags
-- **THEN** the AiExtraction value object contains all extracted items with their respective properties
+- **WHEN** a transcript yields a summary, people mentioned, commitments, decisions, risks, and initiative tags
+- **THEN** the AiExtraction value object contains Summary, PeopleMentioned, Commitments, Decisions, Risks, and InitiativeTags with their respective properties populated
 - **AND** each commitment includes SourceStartOffset and SourceEndOffset
+- **AND** ExtractedAt is populated
 - **AND** DetectedCaptureType is set to the type the AI classified the content as
 
 #### Scenario: AiExtraction with minimal content

--- a/openspec/changes/archive/2026-04-21-auto-detect-capture-type/specs/capture-ai-extraction/spec.md
+++ b/openspec/changes/archive/2026-04-21-auto-detect-capture-type/specs/capture-ai-extraction/spec.md
@@ -69,7 +69,7 @@ The system SHALL define an `AiExtraction` value object embedded on the Capture a
 
 #### Scenario: AiExtraction with all fields populated
 
-- **WHEN** a transcript yields commitments, delegations, observations, decisions, and risks
+- **WHEN** a transcript yields commitments, decisions, risks, and initiative tags
 - **THEN** the AiExtraction value object contains all extracted items with their respective properties
 - **AND** each commitment includes SourceStartOffset and SourceEndOffset
 - **AND** DetectedCaptureType is set to the type the AI classified the content as


### PR DESCRIPTION
## Summary

Addresses remaining review feedback from #184. The "all fields populated" scenario in the auto-detect-capture-type archived spec still referenced removed fields (`delegations`, `observations`) that no longer exist on the `AiExtraction` value object. Updated to match actual fields: `commitments`, `decisions`, `risks`, and `initiative tags`.

## Changes

- Updated scenario wording in `openspec/changes/archive/2026-04-21-auto-detect-capture-type/specs/capture-ai-extraction/spec.md` to list the correct AiExtraction fields

## Test Plan

- [x] `dotnet test src/MentalMetal.slnx` passes (402 tests)
- [x] `ng test --watch=false` passes (61 tests)
- [x] Verified the parallel spec in `openspec/changes/archive/2026-04-21-surface-unresolved-people/` already has the correct field list

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI extraction specification to reflect the extraction of commitments, decisions, risks, and initiative tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->